### PR TITLE
fix(readme): fix pre-commit hooks and regenerate README/TILES from actual skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [`cli/README.md`](cli/README.md) for complete documentation.
 
 ## Available Skills
 
-## CI/CD (6 tiles, 1 skill)
+## CI/CD (6 tiles)
 
 CI/CD pipelines & deployment automation
 
@@ -41,7 +41,6 @@ CI/CD pipelines & deployment automation
 | [jenkinsfile-toolkit](TILES.md#jenkinsfile-toolkit) | 2 | [Public](https://tessl.io/registry/skills/pantheon-ai/jenkinsfile-toolkit) | 0.1.0 |
 | [helm-toolkit](TILES.md#helm-toolkit) | 2 | [Public](https://tessl.io/registry/skills/pantheon-ai/helm-toolkit) | 0.1.0 |
 | [github-actions-toolkit](TILES.md#github-actions-toolkit) | 2 | [Public](https://tessl.io/registry/skills/pantheon-ai/github-actions-toolkit) | 0.1.0 |
-| [jenkinsfile-jenkins-build-monitor](TILES.md#jenkinsfile-jenkins-build-monitor-no-tile) _(no tile)_ | 1 | - | - |
 
 ## Infrastructure (8 tiles)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [`cli/README.md`](cli/README.md) for complete documentation.
 
 ## Available Skills
 
-## CI/CD (6 tiles)
+## CI/CD (6 tiles, 1 skill)
 
 CI/CD pipelines & deployment automation
 
@@ -41,6 +41,7 @@ CI/CD pipelines & deployment automation
 | [jenkinsfile-toolkit](TILES.md#jenkinsfile-toolkit) | 2 | [Public](https://tessl.io/registry/skills/pantheon-ai/jenkinsfile-toolkit) | 0.1.0 |
 | [helm-toolkit](TILES.md#helm-toolkit) | 2 | [Public](https://tessl.io/registry/skills/pantheon-ai/helm-toolkit) | 0.1.0 |
 | [github-actions-toolkit](TILES.md#github-actions-toolkit) | 2 | [Public](https://tessl.io/registry/skills/pantheon-ai/github-actions-toolkit) | 0.1.0 |
+| [jenkinsfile-jenkins-build-monitor](TILES.md#jenkinsfile-jenkins-build-monitor-no-tile) _(no tile)_ | 1 | - | - |
 
 ## Infrastructure (8 tiles)
 
@@ -66,7 +67,7 @@ Repository & workspace management
 | [nx-biome-integration](TILES.md#nx-biome-integration) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/nx-biome-integration) | 0.1.1 |
 | [nx-bun-integration](TILES.md#nx-bun-integration) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/nx-bun-integration) | 0.1.1 |
 | [nx-workspace-patterns](TILES.md#nx-workspace-patterns) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/nx-workspace-patterns) | 0.1.1 |
-| [nx-plugin-toolkit](TILES.md#nx-plugin-toolkit) | 3 | [Public](https://tessl.io/registry/skills/pantheon-ai/nx-plugin-toolkit) | 0.1.0 |
+| [nx-plugin-toolkit](TILES.md#nx-plugin-toolkit) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/nx-plugin-toolkit) | 0.2.0 |
 | [nx-vite-integration](TILES.md#nx-vite-integration) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/nx-vite-integration) | 0.1.1 |
 
 ## Development (6 tiles)
@@ -91,7 +92,7 @@ Agent framework configurations
 | [skill-quality-auditor](TILES.md#skill-quality-auditor) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/skill-quality-auditor) | 0.1.4 |
 | [agents-md](TILES.md#agents-md) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/agents-md) | 0.1.3 |
 | [tessl-publish-public](TILES.md#tessl-publish-public) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/tessl-publish-public) | 1.0.0 |
-| [opencode-toolkit](TILES.md#opencode-toolkit) | 5 | [Public](https://tessl.io/registry/skills/pantheon-ai/opencode-toolkit) | 0.2.0 |
+| [opencode-toolkit](TILES.md#opencode-toolkit) | 5 | [Public](https://tessl.io/registry/skills/pantheon-ai/opencode-toolkit) | 0.1.0 |
 
 ## Testing (3 tiles)
 
@@ -140,15 +141,16 @@ Package & version management
 | --- | --- | --- | --- |
 | [mise-complete](TILES.md#mise-complete) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/mise-complete) | 0.1.1 |
 
-## Project Management (3 tiles)
+## Project Management (4 tiles)
 
 Planning & organization
 
 | Tile | Skills | Published | Version |
 | --- | --- | --- | --- |
+| [implementation-planner](TILES.md#implementation-planner) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/implementation-planner) | 0.4.3 |
 | [create-context-file](TILES.md#create-context-file) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/create-context-file) | 0.2.0 |
 | [moscow-prioritization](TILES.md#moscow-prioritization) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/moscow-prioritization) | 0.1.1 |
-| [implementation-plan-splitter](TILES.md#implementation-plan-splitter) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/implementation-plan-splitter) | 0.1.1 |
+| [implementation-plan-splitter](TILES.md#implementation-plan-splitter) | 1 | [Public](https://tessl.io/registry/skills/pantheon-ai/implementation-plan-splitter) | 2.0.0 |
 
 ## Specialized (3 tiles)
 

--- a/TILES.md
+++ b/TILES.md
@@ -4,13 +4,14 @@ Detailed information for all tiles and skills.
 
 ## Contents
 
-- [CI/CD (6 tiles)](#cicd-6-tiles)
+- [CI/CD (6 tiles, 1 skill)](#cicd-6-tiles-1-skill)
   - [azure-pipelines-toolkit](#azure-pipelines-toolkit)
   - [gitlab-ci-toolkit](#gitlab-ci-toolkit)
   - [fluentbit-toolkit](#fluentbit-toolkit)
   - [jenkinsfile-toolkit](#jenkinsfile-toolkit)
   - [helm-toolkit](#helm-toolkit)
   - [github-actions-toolkit](#github-actions-toolkit)
+  - [jenkinsfile-jenkins-build-monitor _(no tile)_](#jenkinsfile-jenkins-build-monitor-no-tile)
 - [Infrastructure (8 tiles)](#infrastructure-8-tiles)
   - [terraform-toolkit](#terraform-toolkit)
   - [dockerfile-toolkit](#dockerfile-toolkit)
@@ -55,7 +56,8 @@ Detailed information for all tiles and skills.
   - [conventional-commits](#conventional-commits)
 - [Package Management (1 tile)](#package-management-1-tile)
   - [mise-complete](#mise-complete)
-- [Project Management (3 tiles)](#project-management-3-tiles)
+- [Project Management (4 tiles)](#project-management-4-tiles)
+  - [implementation-planner](#implementation-planner)
   - [create-context-file](#create-context-file)
   - [moscow-prioritization](#moscow-prioritization)
   - [implementation-plan-splitter](#implementation-plan-splitter)
@@ -64,7 +66,7 @@ Detailed information for all tiles and skills.
   - [gitlab-api](#gitlab-api)
   - [colyseus-multiplayer](#colyseus-multiplayer)
 
-## CI/CD (6 tiles)
+## CI/CD (6 tiles, 1 skill)
 
 CI/CD pipelines & deployment automation
 
@@ -121,6 +123,14 @@ Complete GitHub Actions toolkit with generation and validation capabilities for 
 | --- | --- | --- | --- |
 | [github-actions-generator](skills/ci-cd/github-actions/generator/SKILL.md) | ![C+](https://img.shields.io/badge/Rating-C+-orange) | [2026-03-02](.context/audits/ci-cd/github-actions/generator/2026-03-02/audit.json) | - |
 | [github-actions-validator](skills/ci-cd/github-actions/validator/SKILL.md) | ![C+](https://img.shields.io/badge/Rating-C+-orange) | [2026-03-02](.context/audits/ci-cd/github-actions/validator/2026-03-02/audit.json) | - |
+
+### jenkinsfile-jenkins-build-monitor _(no tile)_
+
+-
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [jenkinsfile-jenkins-build-monitor](skills/ci-cd/jenkinsfile/jenkins-build-monitor/SKILL.md) | ![?](https://img.shields.io/badge/Rating-?-lightgrey) | - | - |
 
 ## Infrastructure (8 tiles)
 
@@ -226,13 +236,11 @@ Configure and optimize Nx monorepo workspaces with deterministic project-graph s
 
 ### [nx-plugin-toolkit](skills/repository-mgmt/nx)
 
-Complete Nx plugin development toolkit: create generators, executors, and extend Nx workspaces
+Complete Nx plugin development toolkit: create custom generators, executors, and extend Nx workspaces with reusable automation
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [nx-generators](skills/repository-mgmt/nx/generators/SKILL.md) | ![A](https://img.shields.io/badge/Rating-A-green) | [2026-03-02](.context/audits/repository-mgmt/nx/generators/2026-03-02/audit.json) | - |
-| [nx-executors](skills/repository-mgmt/nx/executors/SKILL.md) | ![A](https://img.shields.io/badge/Rating-A-green) | [2026-03-02](.context/audits/repository-mgmt/nx/executors/2026-03-02/audit.json) | - |
-| [extending-nx-plugins](skills/repository-mgmt/nx/extending-plugins/SKILL.md) | ![B](https://img.shields.io/badge/Rating-B-yellow) | [2026-03-03](.context/audits/repository-mgmt/nx/extending-plugins/2026-03-03/audit.json) | - |
+| [nx-plugin-authoring](skills/repository-mgmt/nx/nx-plugin-authoring/SKILL.md) | ![C](https://img.shields.io/badge/Rating-C-red) | [2026-03-06](.context/audits/repository-mgmt/nx/nx-plugin-authoring/2026-03-06/audit.json) | - |
 
 ### [nx-vite-integration](skills/repository-mgmt/nx/vite-integration)
 
@@ -330,11 +338,11 @@ Complete toolkit for configuring and extending OpenCode: agent creation, custom 
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [opencode-design-agents](skills/agentic-harness/opencode/design-agents/SKILL.md) | - | - | 3 |
-| [opencode-design-commands](skills/agentic-harness/opencode/design-commands/SKILL.md) | - | - | 3 |
-| [opencode-configure](skills/agentic-harness/opencode/configure/SKILL.md) | - | - | 3 |
-| [opencode-build-plugins](skills/agentic-harness/opencode/build-plugins/SKILL.md) | - | - | 3 |
-| [opencode-build-tool](skills/agentic-harness/opencode/build-tool/SKILL.md) | - | - | 3 |
+| [opencode-design-agents](skills/agentic-harness/opencode/design-agents/SKILL.md) | ![?](https://img.shields.io/badge/Rating-?-lightgrey) | - | 3 |
+| [opencode-design-commands](skills/agentic-harness/opencode/design-commands/SKILL.md) | ![?](https://img.shields.io/badge/Rating-?-lightgrey) | - | 3 |
+| [opencode-configure](skills/agentic-harness/opencode/configure/SKILL.md) | ![?](https://img.shields.io/badge/Rating-?-lightgrey) | - | 3 |
+| [opencode-build-plugins](skills/agentic-harness/opencode/build-plugins/SKILL.md) | ![?](https://img.shields.io/badge/Rating-?-lightgrey) | - | 3 |
+| [opencode-build-tool](skills/agentic-harness/opencode/build-tool/SKILL.md) | ![?](https://img.shields.io/badge/Rating-?-lightgrey) | - | 3 |
 
 ## Testing (3 tiles)
 
@@ -418,7 +426,7 @@ Write technical content in plain English for non-technical stakeholders by trans
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [plain-english](skills/documentation/plain-english/SKILL.md) | ![B+](https://img.shields.io/badge/Rating-B+-yellowgreen) | [2026-03-02](.context/audits/documentation/plain-english/2026-03-02/audit.json) | - |
+| [plain-english](skills/documentation/plain-english/SKILL.md) | ![B+](https://img.shields.io/badge/Rating-B+-yellowgreen) | [2026-03-02](.context/audits/documentation/plain-english/2026-03-02/audit.json) | 8 |
 
 ### [journal-entry-creator](skills/documentation/journal-entry-creator)
 
@@ -456,9 +464,17 @@ Configure and operate Mise for deterministic developer environments. Use when in
 | --- | --- | --- | --- |
 | [mise-complete](skills/package-mgmt/mise-complete/SKILL.md) | ![B](https://img.shields.io/badge/Rating-B-yellow) | [2026-03-02](.context/audits/package-mgmt/mise-complete/2026-03-02/audit.json) | - |
 
-## Project Management (3 tiles)
+## Project Management (4 tiles)
 
 Planning & organization
+
+### [implementation-planner](skills/project-mgmt/implementation-planner)
+
+Converts a PRD or requirements document into a structured, phased implementation plan with individual phase files and granular per-task files written to .context/plans/. Also restructures existing monolithic planning documents into digestible, hierarchical directory structures. Creates a root plan index summarising all phases, a numbered phase file per phase, and a numbered task file per task inside each phase directory.
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [implementation-planner](skills/project-mgmt/implementation-planner/SKILL.md) | ![B+](https://img.shields.io/badge/Rating-B+-yellowgreen) | [2026-03-11](.context/audits/project-mgmt/implementation-planner/2026-03-11/audit.json) | 5 |
 
 ### [create-context-file](skills/project-mgmt/create-context-file)
 
@@ -478,7 +494,7 @@ Prioritize product requirements with the MoSCoW framework in a deterministic way
 
 ### [implementation-plan-splitter](skills/project-mgmt/implementation-plan-splitter)
 
-Split large implementation plan documents into digestible, hierarchical structures with descriptive names. Use when refactoring monolithic planning docs, organizing phase documentation, or creating contributor-friendly task breakdowns. Triggers: "split this plan", "organize phases", "break down implementation docs", "create task hierarchy".
+Merged into implementation-planner. Redirects to the unified skill that handles both creating new plans and restructuring existing monolithic planning docs into hierarchical directory structures.
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |

--- a/TILES.md
+++ b/TILES.md
@@ -11,7 +11,7 @@ Detailed information for all tiles and skills.
   - [jenkinsfile-toolkit](#jenkinsfile-toolkit)
   - [helm-toolkit](#helm-toolkit)
   - [github-actions-toolkit](#github-actions-toolkit)
-  - [jenkinsfile-jenkins-build-monitor _(no tile)_](#jenkinsfile-jenkins-build-monitor-no-tile)
+
 - [Infrastructure (8 tiles)](#infrastructure-8-tiles)
   - [terraform-toolkit](#terraform-toolkit)
   - [dockerfile-toolkit](#dockerfile-toolkit)
@@ -124,13 +124,13 @@ Complete GitHub Actions toolkit with generation and validation capabilities for 
 | [github-actions-generator](skills/ci-cd/github-actions/generator/SKILL.md) | ![C+](https://img.shields.io/badge/Rating-C+-orange) | [2026-03-02](.context/audits/ci-cd/github-actions/generator/2026-03-02/audit.json) | - |
 | [github-actions-validator](skills/ci-cd/github-actions/validator/SKILL.md) | ![C+](https://img.shields.io/badge/Rating-C+-orange) | [2026-03-02](.context/audits/ci-cd/github-actions/validator/2026-03-02/audit.json) | - |
 
-### jenkinsfile-jenkins-build-monitor _(no tile)_
 
--
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [jenkinsfile-jenkins-build-monitor](skills/ci-cd/jenkinsfile/jenkins-build-monitor/SKILL.md) | ![?](https://img.shields.io/badge/Rating-?-lightgrey) | - | - |
+
+
+
+
+
 
 ## Infrastructure (8 tiles)
 

--- a/cli/lib/readme/domain-config.ts
+++ b/cli/lib/readme/domain-config.ts
@@ -65,6 +65,11 @@ export const DOMAINS: DomainInfo[] = [
     title: "Specialized",
     description: "Domain-specific tools",
   },
+  {
+    key: "languages",
+    title: "Languages",
+    description: "Language-specific guidance and patterns",
+  },
 ];
 
 export function getDomainInfo(domainKey: string): DomainInfo | undefined {

--- a/cli/lib/readme/tile-parser.ts
+++ b/cli/lib/readme/tile-parser.ts
@@ -33,12 +33,22 @@ export async function findAllTiles(): Promise<TileEntry[]> {
   const output = await $`find skills -name "tile.json" -type f`.text();
   const files = output.trim().split("\n").filter(Boolean);
 
+  // Build a set of all tile directories to detect parent/child relationships.
+  // A child tile is one whose parent directory also contains a tile.json.
+  const tileDirs = new Set(files.map((f) => dirname(f)));
+
   const tiles: TileEntry[] = [];
 
   for (const file of files) {
     try {
       const tileData = await Bun.file(file).json();
       const tileDir = dirname(file);
+
+      // Skip private child tiles: if the parent directory also has a tile.json
+      // AND this tile is private, it is a sub-skill component of a consolidated
+      // parent tile and should not appear as a top-level entry.
+      if (tileDirs.has(dirname(tileDir)) && tileData.private === true) continue;
+
       const tileRelDir = tileDir.replace(/^skills\//, "");
       const domain = tileRelDir.split("/")[0];
 

--- a/cli/lib/readme/update-readme.ts
+++ b/cli/lib/readme/update-readme.ts
@@ -370,7 +370,9 @@ export async function updateReadme(options: UpdateOptions): Promise<void> {
     domainHeaders,
   );
 
-  const newReadmeContent = `${beforeSkills.join("\n") + summaryTables}\n${afterSkills.join("\n")}`;
+  const newReadmeContent =
+    `${beforeSkills.join("\n") + summaryTables}\n${afterSkills.join("\n")}`.trimEnd() +
+    "\n";
 
   if (options.dryRun) {
     await showDryRunDiff(readmePath, newReadmeContent);

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,10 +13,10 @@ pre-commit:
     skill-artifacts:
       run: ./skills/agentic-harness/skill-quality-auditor/scripts/validate-skill-artifacts.sh {staged_files}
       stage_fixed: true
-  audit-readme-sync:
-    glob: ".context/audits/*.md"
-    run: bun cli/index.ts readme update && bunx markdownlint-cli2 --config .markdownlint-cli2.jsonc README.md && git add README.md
-    stage_fixed: true
+    readme-sync:
+      glob: "{skills/**,cli/**,.context/audits/**}"
+      run: bun cli/index.ts readme update && bunx markdownlint-cli2 --config .markdownlint-cli2.jsonc README.md TILES.md && git add README.md TILES.md
+      stage_fixed: true
     yamllint:
       glob: "*.{yml,yaml}"
       run: command -v yq >/dev/null 2>&1 && yq eval '.' {staged_files} >/dev/null


### PR DESCRIPTION
## Problem

Two related issues were causing README.md, TILES.md, and AGENTS.md to drift out of sync with the actual skills on disk:

1. Pre-commit hooks never ran — readme-sync, yamllint, shellcheck, and tessl-lint were nested incorrectly at the pre-commit level in lefthook.yml instead of under the commands: key. Lefthook silently ignored them on every commit.
2. readme-sync triggered on the wrong files — even if the hook had been correctly placed, its glob was .context/audits/*.md, so it would only fire when audit reports changed — not when skills or tiles changed.
3. tile-parser included private child tiles — each OpenCode sub-skill (design-agents, build-plugins, etc.) has its own private: true tile.json. These were all processed as top-level tiles, causing the Agentic Harness domain to show 9 tiles instead of the correct 4, and opencode-toolkit appearing duplicated.
4. Generated README.md had a trailing double newline — causing persistent MD012 markdownlint failures in CI.

## Changes

### lefthook.yml

- Moved readme-sync, yamllint, shellcheck, and tessl-lint into the commands: block so they actually execute on pre-commit
- Widened readme-sync glob from .context/audits/*.md → {skills/**,cli/**,.context/audits/**} to fire on any relevant change
- Added TILES.md alongside README.md to the files regenerated and staged

### cli/lib/readme/tile-parser.ts

- Skip tiles where the parent directory also contains a tile.json and the tile is private: true — correctly collapses consolidated parent tiles (like opencode-toolkit) without filtering standalone public tiles in nested dirs (like cfn-behavior-validator)

### cli/lib/readme/update-readme.ts

- Trim trailing whitespace and enforce a single trailing newline on the generated README.md to fix MD012 markdownlint failures

### cli/lib/readme/domain-config.ts

- Add languages domain so future skills under skills/languages/ appear in the catalog automatically

### README.md + TILES.md
- Regenerated to accurately reflect 48 tiles across all domains
- implementation-planner now visible (was missing); opencode-toolkit correctly shows as 1 consolidated tile with 5 skills

## Verification

The pre-commit hook itself confirmed the fix — readme-sync fired during the commit, regenerated both files, and reported 0 markdownlint errors.