### PR TITLE
feat(cli): improve install command robustness and filtering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "tekhne",
       "dependencies": {
+        "@inquirer/checkbox": "^5.1.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -35,6 +36,16 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A=="],
+
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.3", "", {}, "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@5.1.0", "", { "dependencies": { "@inquirer/ansi": "^2.0.3", "@inquirer/core": "^11.1.5", "@inquirer/figures": "^2.0.3", "@inquirer/type": "^4.0.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-/HjF1LN0a1h4/OFsbGKHNDtWICFU/dqXCdym719HFTyJo9IG7Otr+ziGWc9S0iQuohRZllh+WprSgd5UW5Fw0g=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.5", "", { "dependencies": { "@inquirer/ansi": "^2.0.3", "@inquirer/figures": "^2.0.3", "@inquirer/type": "^4.0.3", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-QQPAX+lka8GyLcZ7u7Nb1h6q72iZ/oy0blilC3IB2nSt1Qqxp7akt94Jqhi/DzARuN3Eo9QwJRvtl4tmVe4T5A=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.3", "", {}, "sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.3", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -70,6 +81,8 @@
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
     "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -83,6 +96,12 @@
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -208,6 +227,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -219,6 +240,8 @@
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 

--- a/cli/commands/install.ts
+++ b/cli/commands/install.ts
@@ -7,17 +7,30 @@ export const installCommand = new Command("install")
   .description("Install skills to local agent directories")
   .option(
     "-a, --agent <agents...>",
-    "Specific agents to install for (opencode, cursor, gemini, claude, codex)",
+    "Specific agents to install for (opencode, cursor, gemini, claude, codex). Note: only opencode supports local installs; all other agents always install to ~/.config/",
     ["opencode"],
   )
   .option(
     "-g, --global",
-    "Install to global agent directories (~/.config/)",
+    "Install to global agent directories (~/.config/). Only applies to opencode; other agents are always global.",
     false,
   )
   .option(
     "--dry-run",
     "Show what would be installed without making changes",
+    false,
+  )
+  .option(
+    "--skill-domain <domains...>",
+    "Only install skills from these top-level domains (e.g. ci-cd infrastructure)",
+  )
+  .option(
+    "--skill-subdomain <subdomains...>",
+    "Only install skills from these subdomains (e.g. github-actions terraform)",
+  )
+  .option(
+    "-i, --interactive",
+    "Interactively select which skills to install (ignored when stdin is not a TTY)",
     false,
   )
   .action(async (options) => {

--- a/cli/lib/install/install-skills.test.ts
+++ b/cli/lib/install/install-skills.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -137,16 +138,12 @@ describe(
     });
 
     test("throws CLIError when skills/ directory does not exist", async () => {
-      await expect(findSkills(tmpDir)).rejects.toBeInstanceOf(CLIError);
-
-      try {
-        await findSkills(tmpDir);
-      } catch (err) {
-        expect((err as CLIError).message).toContain(
-          "skills/ directory not found",
-        );
-        expect((err as CLIError).exitCode).toBe(1);
-      }
+      const err = await findSkills(tmpDir).catch((e) => e);
+      expect(err).toBeInstanceOf(CLIError);
+      expect((err as CLIError).message).toContain(
+        "skills/ directory not found",
+      );
+      expect((err as CLIError).exitCode).toBe(1);
     });
 
     test("returns skill paths when SKILL.md files exist", async () => {
@@ -198,6 +195,8 @@ describe("ensureDirectory", () => {
     const dir = join(tmpDir, "new", "nested");
     ensureDirectory(dir, false);
     expect(require("node:fs").existsSync(dir)).toBe(true);
+    // Intermediate parent must also be created (mkdir -p behaviour)
+    expect(require("node:fs").existsSync(join(tmpDir, "new"))).toBe(true);
   });
 
   test("does not create directory in dry-run mode", () => {
@@ -241,9 +240,15 @@ describe("createSymlink", () => {
     const linkDest = require("node:fs").readlinkSync(target);
     // Should be relative, not absolute
     expect(linkDest).not.toMatch(/^\//);
+    // And must resolve to the correct source directory
+    expect(
+      realpathSync.native(
+        resolve(require("node:path").dirname(target), linkDest),
+      ),
+    ).toBe(realpathSync.native(resolve(sourceDir)));
   });
 
-  test("returns false without creating symlink in dry-run mode", () => {
+  test("returns true but does not create symlink in dry-run mode", () => {
     const target = join(tmpDir, "link");
     const result = createSymlink(sourceDir, target, true);
 
@@ -272,10 +277,13 @@ describe("createSymlink", () => {
     expect(result).toBe(true);
 
     const linkDest = require("node:fs").readlinkSync(target);
-    // Resolved destination should point to sourceDir
-    expect(resolve(require("node:path").dirname(target), linkDest)).toBe(
-      resolve(sourceDir),
-    );
+    // Resolved destination should point to sourceDir (use realpathSync to
+    // handle platform-level symlinks such as macOS /tmp → /private/tmp)
+    expect(
+      realpathSync.native(
+        resolve(require("node:path").dirname(target), linkDest),
+      ),
+    ).toBe(realpathSync.native(resolve(sourceDir)));
   });
 
   test("returns false and does not throw when target is a real directory", () => {
@@ -293,39 +301,26 @@ describe("createSymlink", () => {
 
 describe("installSkills", () => {
   test("throws CLIError for unknown agent", async () => {
-    await expect(
-      installSkills({
-        agent: ["unknown-agent"],
-        global: false,
-        dryRun: true,
-        interactive: false,
-      }),
-    ).rejects.toBeInstanceOf(CLIError);
-
-    try {
-      await installSkills({
-        agent: ["unknown-agent"],
-        global: false,
-        dryRun: true,
-        interactive: false,
-      });
-    } catch (err) {
-      expect((err as CLIError).message).toContain("Unknown agent(s)");
-      expect((err as CLIError).exitCode).toBe(1);
-    }
+    const err = await installSkills({
+      agent: ["unknown-agent"],
+      global: false,
+      dryRun: true,
+      interactive: false,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(CLIError);
+    expect((err as CLIError).message).toContain("Unknown agent(s)");
+    expect((err as CLIError).exitCode).toBe(1);
   });
 
   test("throws CLIError listing all unknown agents", async () => {
-    try {
-      await installSkills({
-        agent: ["bad1", "bad2"],
-        global: false,
-        dryRun: true,
-        interactive: false,
-      });
-    } catch (err) {
-      expect((err as CLIError).message).toContain("bad1");
-      expect((err as CLIError).message).toContain("bad2");
-    }
+    const err = await installSkills({
+      agent: ["bad1", "bad2"],
+      global: false,
+      dryRun: true,
+      interactive: false,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(CLIError);
+    expect((err as CLIError).message).toContain("bad1");
+    expect((err as CLIError).message).toContain("bad2");
   });
 });

--- a/cli/lib/install/install-skills.test.ts
+++ b/cli/lib/install/install-skills.test.ts
@@ -1,155 +1,331 @@
-import { describe, expect, test } from "bun:test";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { CLIError } from "../utils/errors";
+import {
+  createSymlink,
+  ensureDirectory,
+  filterSkills,
+  findSkills,
+  getSkillName,
+  installSkills,
+} from "./install-skills";
 
-describe("installSkills helper functions", () => {
-  describe("getSkillName formatting", () => {
-    test("should convert domain/skill to domain--skill", () => {
-      const skillPath = "skills/domain/skill-name";
-      const parts = skillPath.split("/").slice(1);
-      const skillName = parts.join("--");
-      expect(skillName).toBe("domain--skill-name");
-    });
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-    test("should handle nested paths", () => {
-      const skillPath = "skills/domain/category/skill-name";
-      const parts = skillPath.split("/").slice(1);
-      const skillName = parts.join("--");
-      expect(skillName).toBe("domain--category--skill-name");
-    });
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "tekhne-install-test-"));
+}
 
-    test("should handle skill names with hyphens", () => {
-      const skillPath = "skills/my-domain/my-skill-name";
-      const parts = skillPath.split("/").slice(1);
-      const skillName = parts.join("--");
-      expect(skillName).toBe("my-domain--my-skill-name");
-    });
+function scaffold(base: string, paths: string[]): void {
+  for (const p of paths) {
+    const full = join(base, p);
+    mkdirSync(full.replace(/\/[^/]+$/, ""), { recursive: true });
+    writeFileSync(full, "");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getSkillName
+// ---------------------------------------------------------------------------
+
+describe("getSkillName", () => {
+  test("converts domain/skill to domain--skill", () => {
+    expect(getSkillName("skills/domain/skill-name")).toBe("domain--skill-name");
   });
 
-  describe("agent path resolution", () => {
-    test("should resolve opencode global path", () => {
-      const isGlobal = true;
-      const path = isGlobal
-        ? join(homedir(), ".config", "opencode", "skills")
-        : join("/cwd", ".agents", "skills");
-
-      expect(path).toContain(".config/opencode/skills");
-    });
-
-    test("should resolve opencode local path", () => {
-      const isGlobal = false;
-      const cwd = "/project";
-      const path = isGlobal
-        ? join(homedir(), ".config", "opencode", "skills")
-        : join(cwd, ".agents", "skills");
-
-      expect(path).toBe("/project/.agents/skills");
-    });
-
-    test("should resolve cursor path (always global)", () => {
-      const path = join(homedir(), ".config", "cursor", "skills");
-      expect(path).toContain(".config/cursor/skills");
-    });
-
-    test("should resolve gemini path (always global)", () => {
-      const path = join(homedir(), ".config", "gemini", "skills");
-      expect(path).toContain(".config/gemini/skills");
-    });
+  test("handles nested paths", () => {
+    expect(getSkillName("skills/domain/category/skill-name")).toBe(
+      "domain--category--skill-name",
+    );
   });
 
-  describe("installation stats tracking", () => {
-    test("should initialize stats with zeros", () => {
-      const stats = { installed: 0, skipped: 0, failed: 0 };
+  test("preserves hyphens", () => {
+    expect(getSkillName("skills/my-domain/my-skill-name")).toBe(
+      "my-domain--my-skill-name",
+    );
+  });
+});
 
-      expect(stats.installed).toBe(0);
-      expect(stats.skipped).toBe(0);
-      expect(stats.failed).toBe(0);
-    });
+// ---------------------------------------------------------------------------
+// filterSkills
+// ---------------------------------------------------------------------------
 
-    test("should increment installed count", () => {
-      const stats = { installed: 0, skipped: 0, failed: 0 };
-      stats.installed++;
+describe("filterSkills", () => {
+  const skills = [
+    "skills/ci-cd/github-actions/generator",
+    "skills/ci-cd/gitlab-ci/validator",
+    "skills/infrastructure/terraform/generator",
+    "skills/infrastructure/k8s",
+    "skills/documentation/markdown-authoring",
+  ];
 
-      expect(stats.installed).toBe(1);
-    });
-
-    test("should increment skipped count", () => {
-      const stats = { installed: 0, skipped: 0, failed: 0 };
-      stats.skipped++;
-
-      expect(stats.skipped).toBe(1);
-    });
-
-    test("should increment failed count", () => {
-      const stats = { installed: 0, skipped: 0, failed: 0 };
-      stats.failed++;
-
-      expect(stats.failed).toBe(1);
-    });
+  test("returns all skills when no filters are set", () => {
+    expect(filterSkills(skills, {})).toEqual(skills);
   });
 
-  describe("skill discovery pattern", () => {
-    test("should extract directory from SKILL.md path", () => {
-      const skillPath = "skills/domain/skill-name/SKILL.md";
-      const directory = skillPath.replace("/SKILL.md", "");
-
-      expect(directory).toBe("skills/domain/skill-name");
-    });
-
-    test("should handle multiple SKILL.md results", () => {
-      const output = `skills/domain1/skill1/SKILL.md
-skills/domain2/skill2/SKILL.md
-skills/domain3/skill3/SKILL.md`;
-
-      const skills = output
-        .trim()
-        .split("\n")
-        .filter(Boolean)
-        .map((path) => path.replace("/SKILL.md", ""));
-
-      expect(skills.length).toBe(3);
-      expect(skills[0]).toBe("skills/domain1/skill1");
-      expect(skills[1]).toBe("skills/domain2/skill2");
-      expect(skills[2]).toBe("skills/domain3/skill3");
-    });
+  test("filters by domain", () => {
+    const result = filterSkills(skills, { skillDomain: ["ci-cd"] });
+    expect(result).toEqual([
+      "skills/ci-cd/github-actions/generator",
+      "skills/ci-cd/gitlab-ci/validator",
+    ]);
   });
 
-  describe("summary display logic", () => {
-    test("should display stats for multiple agents", () => {
-      const agents = ["opencode", "cursor"];
-      const stats: Record<
-        string,
-        { installed: number; skipped: number; failed: number }
-      > = {
-        opencode: { installed: 10, skipped: 2, failed: 0 },
-        cursor: { installed: 8, skipped: 4, failed: 1 },
-      };
+  test("filters by multiple domains (union)", () => {
+    const result = filterSkills(skills, {
+      skillDomain: ["ci-cd", "documentation"],
+    });
+    expect(result).toHaveLength(3);
+  });
 
-      for (const agent of agents) {
-        const agentStats = stats[agent];
-        expect(agentStats).toBeDefined();
-        expect(agentStats.installed).toBeGreaterThanOrEqual(0);
+  test("filters by subdomain", () => {
+    const result = filterSkills(skills, {
+      skillSubdomain: ["terraform"],
+    });
+    expect(result).toEqual(["skills/infrastructure/terraform/generator"]);
+  });
+
+  test("intersection when both domain and subdomain are set", () => {
+    // domain=ci-cd AND subdomain=github-actions → only the github-actions skill
+    const result = filterSkills(skills, {
+      skillDomain: ["ci-cd"],
+      skillSubdomain: ["github-actions"],
+    });
+    expect(result).toEqual(["skills/ci-cd/github-actions/generator"]);
+  });
+
+  test("intersection excludes skills matching only one filter", () => {
+    // domain=infrastructure AND subdomain=github-actions → no intersection
+    const result = filterSkills(skills, {
+      skillDomain: ["infrastructure"],
+      skillSubdomain: ["github-actions"],
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("empty domain array treated as no domain filter", () => {
+    const result = filterSkills(skills, { skillDomain: [] });
+    expect(result).toEqual(skills);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSkills
+// ---------------------------------------------------------------------------
+
+describe(
+  "findSkills",
+  () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = makeTempDir();
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test("throws CLIError when skills/ directory does not exist", async () => {
+      await expect(findSkills(tmpDir)).rejects.toBeInstanceOf(CLIError);
+
+      try {
+        await findSkills(tmpDir);
+      } catch (err) {
+        expect((err as CLIError).message).toContain(
+          "skills/ directory not found",
+        );
+        expect((err as CLIError).exitCode).toBe(1);
       }
     });
 
-    test("should skip agents with no stats", () => {
-      const agents = ["opencode", "cursor", "unknown"];
-      const stats: Record<
-        string,
-        { installed: number; skipped: number; failed: number }
-      > = {
-        opencode: { installed: 10, skipped: 0, failed: 0 },
-        cursor: { installed: 5, skipped: 0, failed: 0 },
-      };
+    test("returns skill paths when SKILL.md files exist", async () => {
+      scaffold(tmpDir, [
+        "skills/ci-cd/github-actions/SKILL.md",
+        "skills/infrastructure/terraform/SKILL.md",
+      ]);
 
-      let displayedCount = 0;
-      for (const agent of agents) {
-        if (stats[agent]) {
-          displayedCount++;
-        }
-      }
-
-      expect(displayedCount).toBe(2);
+      const skills = await findSkills(tmpDir);
+      expect(skills).toContain("skills/ci-cd/github-actions");
+      expect(skills).toContain("skills/infrastructure/terraform");
+      expect(skills).toHaveLength(2);
     });
+
+    test("strips /SKILL.md suffix from each path", async () => {
+      scaffold(tmpDir, ["skills/domain/skill/SKILL.md"]);
+
+      const skills = await findSkills(tmpDir);
+      expect(skills).toHaveLength(1);
+      expect(skills[0]).not.toContain("SKILL.md");
+      expect(skills[0]).toBe("skills/domain/skill");
+    });
+
+    test("returns empty array when skills/ exists but has no SKILL.md files", async () => {
+      mkdirSync(join(tmpDir, "skills"));
+      const skills = await findSkills(tmpDir);
+      expect(skills).toEqual([]);
+    });
+  },
+  { timeout: 10000 },
+);
+
+// ---------------------------------------------------------------------------
+// ensureDirectory
+// ---------------------------------------------------------------------------
+
+describe("ensureDirectory", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("creates directory in live mode", () => {
+    const dir = join(tmpDir, "new", "nested");
+    ensureDirectory(dir, false);
+    expect(require("node:fs").existsSync(dir)).toBe(true);
+  });
+
+  test("does not create directory in dry-run mode", () => {
+    const dir = join(tmpDir, "should-not-exist");
+    ensureDirectory(dir, true);
+    expect(require("node:fs").existsSync(dir)).toBe(false);
+  });
+
+  test("does not throw if directory already exists", () => {
+    const dir = join(tmpDir, "existing");
+    mkdirSync(dir);
+    expect(() => ensureDirectory(dir, false)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSymlink
+// ---------------------------------------------------------------------------
+
+describe("createSymlink", () => {
+  let tmpDir: string;
+  let sourceDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    sourceDir = join(tmpDir, "source");
+    mkdirSync(sourceDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("creates a relative symlink in live mode", () => {
+    const target = join(tmpDir, "link");
+    const result = createSymlink(sourceDir, target, false);
+
+    expect(result).toBe(true);
+    expect(require("node:fs").existsSync(target)).toBe(true);
+
+    const linkDest = require("node:fs").readlinkSync(target);
+    // Should be relative, not absolute
+    expect(linkDest).not.toMatch(/^\//);
+  });
+
+  test("returns false without creating symlink in dry-run mode", () => {
+    const target = join(tmpDir, "link");
+    const result = createSymlink(sourceDir, target, true);
+
+    expect(result).toBe(true); // dry-run still signals "would install"
+    expect(require("node:fs").existsSync(target)).toBe(false);
+  });
+
+  test("returns false when target is already linked to same source", () => {
+    const target = join(tmpDir, "link");
+    createSymlink(sourceDir, target, false);
+
+    const result = createSymlink(sourceDir, target, false);
+    expect(result).toBe(false);
+  });
+
+  test("replaces stale symlink pointing to a different source", () => {
+    const otherSource = join(tmpDir, "other");
+    mkdirSync(otherSource);
+    const target = join(tmpDir, "link");
+
+    // Create initial symlink pointing to otherSource
+    symlinkSync(otherSource, target, "dir");
+
+    // Now replace with sourceDir
+    const result = createSymlink(sourceDir, target, false);
+    expect(result).toBe(true);
+
+    const linkDest = require("node:fs").readlinkSync(target);
+    // Resolved destination should point to sourceDir
+    expect(resolve(require("node:path").dirname(target), linkDest)).toBe(
+      resolve(sourceDir),
+    );
+  });
+
+  test("returns false and does not throw when target is a real directory", () => {
+    const target = join(tmpDir, "realdir");
+    mkdirSync(target);
+
+    const result = createSymlink(sourceDir, target, false);
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// installSkills — unknown agent validation
+// ---------------------------------------------------------------------------
+
+describe("installSkills", () => {
+  test("throws CLIError for unknown agent", async () => {
+    await expect(
+      installSkills({
+        agent: ["unknown-agent"],
+        global: false,
+        dryRun: true,
+        interactive: false,
+      }),
+    ).rejects.toBeInstanceOf(CLIError);
+
+    try {
+      await installSkills({
+        agent: ["unknown-agent"],
+        global: false,
+        dryRun: true,
+        interactive: false,
+      });
+    } catch (err) {
+      expect((err as CLIError).message).toContain("Unknown agent(s)");
+      expect((err as CLIError).exitCode).toBe(1);
+    }
+  });
+
+  test("throws CLIError listing all unknown agents", async () => {
+    try {
+      await installSkills({
+        agent: ["bad1", "bad2"],
+        global: false,
+        dryRun: true,
+        interactive: false,
+      });
+    } catch (err) {
+      expect((err as CLIError).message).toContain("bad1");
+      expect((err as CLIError).message).toContain("bad2");
+    }
   });
 });

--- a/cli/lib/install/install-skills.ts
+++ b/cli/lib/install/install-skills.ts
@@ -6,14 +6,19 @@ import {
   unlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
+import checkbox from "@inquirer/checkbox";
 import { $ } from "bun";
+import { CLIError } from "../utils/errors";
 import { logger } from "../utils/logger";
 
-interface InstallOptions {
+export interface InstallOptions {
   agent: string[];
   global: boolean;
   dryRun: boolean;
+  skillDomain?: string[];
+  skillSubdomain?: string[];
+  interactive?: boolean;
 }
 
 const AGENT_PATHS: Record<string, (isGlobal: boolean, cwd: string) => string> =
@@ -32,8 +37,18 @@ const AGENT_PATHS: Record<string, (isGlobal: boolean, cwd: string) => string> =
       join(homedir(), ".config", "codex", "skills"),
   };
 
-async function findSkills(): Promise<string[]> {
-  const output = await $`find skills -name "SKILL.md" -type f`.text();
+// Agents that are always global (--global flag has no effect)
+const ALWAYS_GLOBAL_AGENTS = new Set(["cursor", "gemini", "claude", "codex"]);
+
+export async function findSkills(cwd: string): Promise<string[]> {
+  if (!existsSync(join(cwd, "skills"))) {
+    throw new CLIError(
+      "skills/ directory not found. Run this command from the repository root.",
+      1,
+    );
+  }
+
+  const output = await $`find skills -name "SKILL.md" -type f`.cwd(cwd).text();
   return output
     .trim()
     .split("\n")
@@ -41,12 +56,68 @@ async function findSkills(): Promise<string[]> {
     .map((path) => path.replace("/SKILL.md", ""));
 }
 
-function getSkillName(skillPath: string): string {
+export function getSkillName(skillPath: string): string {
   const parts = skillPath.split("/").slice(1);
   return parts.join("--");
 }
 
-function ensureDirectory(dir: string, dryRun: boolean): void {
+export function filterSkills(
+  skills: string[],
+  options: Pick<InstallOptions, "skillDomain" | "skillSubdomain">,
+): string[] {
+  const { skillDomain, skillSubdomain } = options;
+  const hasDomainFilter = skillDomain && skillDomain.length > 0;
+  const hasSubdomainFilter = skillSubdomain && skillSubdomain.length > 0;
+
+  if (!hasDomainFilter && !hasSubdomainFilter) {
+    return skills;
+  }
+
+  return skills.filter((skillPath) => {
+    // skillPath format: "skills/<domain>/<subdomain>[/leaf]"
+    const parts = skillPath.split("/");
+    const domain = parts[1];
+    const subdomain = parts[2];
+
+    const domainMatch = hasDomainFilter ? skillDomain?.includes(domain) : true;
+    const subdomainMatch = hasSubdomainFilter
+      ? skillSubdomain?.includes(subdomain)
+      : true;
+
+    return domainMatch && subdomainMatch;
+  });
+}
+
+export async function selectSkillsInteractively(
+  skills: string[],
+): Promise<string[]> {
+  if (!process.stdin.isTTY) {
+    logger.warning(
+      "--interactive ignored: stdin is not a TTY. Installing all skills.",
+    );
+    return skills;
+  }
+
+  const choices = skills.map((skillPath) => ({
+    name: getSkillName(skillPath),
+    value: skillPath,
+    checked: true,
+  }));
+
+  const selected = await checkbox({
+    message: "Select skills to install (space to toggle, enter to confirm):",
+    choices,
+  });
+
+  if (selected.length === 0) {
+    logger.info("No skills selected. Aborting.");
+    process.exit(0);
+  }
+
+  return selected;
+}
+
+export function ensureDirectory(dir: string, dryRun: boolean): void {
   if (dryRun) {
     if (!existsSync(dir)) {
       logger.info(`Would create directory: ${dir}`);
@@ -60,23 +131,27 @@ function ensureDirectory(dir: string, dryRun: boolean): void {
   }
 }
 
-function createSymlink(
+export function createSymlink(
   source: string,
   target: string,
   dryRun: boolean,
 ): boolean {
+  const resolvedSource = resolve(source);
+  const relativeSource = relative(dirname(target), resolvedSource);
+
   if (existsSync(target)) {
     try {
       const existing = readlinkSync(target);
-      const resolvedSource = resolve(source);
+      // Resolve existing (may be relative or absolute) to compare
+      const resolvedExisting = resolve(dirname(target), existing);
 
-      if (existing === resolvedSource) {
+      if (resolvedExisting === resolvedSource) {
         logger.debug(`Already linked: ${target}`);
         return false;
       }
 
       if (dryRun) {
-        logger.warning(`Would replace symlink: ${target} -> ${source}`);
+        logger.warning(`Would replace symlink: ${target} -> ${relativeSource}`);
         return true;
       }
 
@@ -89,12 +164,12 @@ function createSymlink(
   }
 
   if (dryRun) {
-    logger.info(`Would symlink: ${target} -> ${source}`);
+    logger.info(`Would symlink: ${target} -> ${relativeSource}`);
     return true;
   }
 
   try {
-    symlinkSync(resolve(source), target, "dir");
+    symlinkSync(relativeSource, target, "dir");
     logger.success(`Linked: ${target.split("/").pop()}`);
     return true;
   } catch (error: unknown) {
@@ -117,12 +192,13 @@ function installSkillsForAgent(
 ): AgentStats {
   const stats: AgentStats = { installed: 0, skipped: 0, failed: 0 };
 
-  if (!AGENT_PATHS[agent]) {
-    logger.error(`Unknown agent: ${agent}`);
-    return stats;
-  }
-
   logger.header(`\nInstalling for ${agent}`);
+
+  if (options.global && ALWAYS_GLOBAL_AGENTS.has(agent)) {
+    logger.warning(
+      `--global has no effect for ${agent}: it always installs to ~/.config/${agent}/skills`,
+    );
+  }
 
   const targetDir = AGENT_PATHS[agent](options.global, cwd);
   logger.info(`Target directory: ${targetDir}`);
@@ -173,13 +249,37 @@ function displaySummary(
 export async function installSkills(options: InstallOptions): Promise<void> {
   const cwd = process.cwd();
 
+  // Validate agents upfront before doing any work
+  const unknownAgents = options.agent.filter((a) => !AGENT_PATHS[a]);
+  if (unknownAgents.length > 0) {
+    throw new CLIError(
+      `Unknown agent(s): ${unknownAgents.join(", ")}. Valid agents: ${Object.keys(AGENT_PATHS).join(", ")}`,
+      1,
+    );
+  }
+
   if (options.dryRun) {
     logger.header("Dry Run: Install Skills");
   } else {
     logger.header("Installing Skills");
   }
 
-  const skills = await findSkills();
+  let skills = await findSkills(cwd);
+
+  // Apply domain/subdomain filters
+  const filtered = filterSkills(skills, options);
+  if (filtered.length < skills.length) {
+    logger.info(
+      `Excluded ${skills.length - filtered.length} skill(s) via domain/subdomain filters`,
+    );
+  }
+  skills = filtered;
+
+  // Apply interactive selection (ignored if not TTY)
+  if (options.interactive) {
+    skills = await selectSkillsInteractively(skills);
+  }
+
   logger.info(`Found ${skills.length} skills`);
 
   const agents = options.agent;

--- a/cli/lib/install/install-skills.ts
+++ b/cli/lib/install/install-skills.ts
@@ -2,6 +2,7 @@ import {
   existsSync,
   mkdirSync,
   readlinkSync,
+  realpathSync,
   symlinkSync,
   unlinkSync,
 } from "node:fs";
@@ -111,7 +112,7 @@ export async function selectSkillsInteractively(
 
   if (selected.length === 0) {
     logger.info("No skills selected. Aborting.");
-    process.exit(0);
+    return [];
   }
 
   return selected;
@@ -136,14 +137,17 @@ export function createSymlink(
   target: string,
   dryRun: boolean,
 ): boolean {
-  const resolvedSource = resolve(source);
+  const resolvedSource = realpathSync.native(resolve(source));
   const relativeSource = relative(dirname(target), resolvedSource);
 
   if (existsSync(target)) {
     try {
       const existing = readlinkSync(target);
-      // Resolve existing (may be relative or absolute) to compare
-      const resolvedExisting = resolve(dirname(target), existing);
+      // Resolve existing (may be relative or absolute) and canonicalize
+      // with realpathSync to handle platform symlinks (e.g. macOS /tmp → /private/tmp)
+      const resolvedExisting = realpathSync.native(
+        resolve(dirname(target), existing),
+      );
 
       if (resolvedExisting === resolvedSource) {
         logger.debug(`Already linked: ${target}`);
@@ -278,6 +282,9 @@ export async function installSkills(options: InstallOptions): Promise<void> {
   // Apply interactive selection (ignored if not TTY)
   if (options.interactive) {
     skills = await selectSkillsInteractively(skills);
+    if (skills.length === 0) {
+      return;
+    }
   }
 
   logger.info(`Found ${skills.length} skills`);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "tessl": "^0.68.0"
   },
   "dependencies": {
+    "@inquirer/checkbox": "^5.1.0",
     "zod": "^4.3.6"
   }
 }


### PR DESCRIPTION
This PR fixes six issues identified during a review of the install CLI command, covering correctness, usability, and test coverage.
## Changes
### Correctness
- Unknown agent exits non-zero — previously -a unknown logged an error but exited 0, making failures invisible in CI. The command now validates all agents upfront and throws a CLIError (exit 1) before doing any work.
- Relative symlinks — symlinks were created with absolute source paths, breaking silently if the repository was moved or re-cloned. They are now relative.
- CWD guard in findSkills() — running the command outside the repository root silently returned "0 skills found". It now checks for skills/ existence first and throws a clear error message.
### Usability
- --global warning for always-global agents — cursor, gemini, claude, and codex always install to ~/.config/ regardless of the flag. Passing --global for these agents now emits a warning. Flag descriptions updated accordingly.
- Structured filtering flags — two new flags allow installing a subset of skills without an interactive prompt:
  - --skill-domain <domains...> — filter by top-level domain (e.g. ci-cd, infrastructure)
  - --skill-subdomain <subdomains...> — filter by subdomain (e.g. github-actions, terraform)
- -i / --interactive flag — presents a checkbox prompt (via @inquirer/checkbox) for per-skill selection after any domain/subdomain pre-filtering. Gracefully ignored when stdin is not a TTY.
### Tests
- Internal functions (findSkills, filterSkills, createSymlink, ensureDirectory) are now exported and covered by 24 filesystem-level tests using Bun's tmp utilities.