### PR TITLE
fix(ci): pin Node.js 22 in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,10 @@ jobs:
           # Full history not needed; a shallow clone is fine for the build.
           fetch-depth: 1
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
       - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
         with:
           bun-version: "1.3.10"


### PR DESCRIPTION
## Summary
The GitHub Pages deployment was failing because Astro requires Node.js
>=22.12.0 but the Actions runner defaulted to Node.js 20.
Adds `actions/setup-node@v4` with `node-version: "22"` before the Bun
setup step in `.github/workflows/deploy-docs.yml`.