### PR TITLE
fix(ci): prevent PR skill checks from running after merge

### DIFF
--- a/.github/workflows/pr-skill-checks.yml
+++ b/.github/workflows/pr-skill-checks.yml
@@ -3,6 +3,7 @@ name: PR Skill Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [main]
     paths:
       - "skills/**"
 
@@ -15,7 +16,8 @@ jobs:
   tessl-lint:
     name: Tessl Skill Lint
     # Fork PRs run with a read-only GITHUB_TOKEN; skip entirely to avoid permission errors on comment steps
-    if: github.event.pull_request.head.repo.fork == false
+    # Also skip if the PR is no longer open (e.g. a queued run completing after merge)
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -84,7 +86,8 @@ jobs:
   tessl-review:
     name: Tessl Skill Review
     # Fork PRs run with a read-only GITHUB_TOKEN; skip entirely to avoid permission errors on comment steps
-    if: github.event.pull_request.head.repo.fork == false
+    # Also skip if the PR is no longer open (e.g. a queued run completing after merge)
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -152,7 +155,7 @@ jobs:
 
   request-eval-scenarios:
     name: Request Eval Scenarios from Copilot
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Problem
The `pr-skill-checks` workflow was executing on `main` after a PR was
merged. This happened because runs queued by a `synchronize` event
(last commit push) would complete after the PR closed, and GitHub
displays those runs under the base branch (`main`).
## Changes
- Added `branches: [main]` filter to the workflow trigger to be explicit
  about which PRs this workflow targets
- Added `github.event.pull_request.state == 'open'` guard to all three
  jobs (`tessl-lint`, `tessl-review`, `request-eval-scenarios`) so any
  in-flight run will skip all work if the PR is no longer open at
  execution time