### PR TITLE
fix(ci): fix secrets in if-conditions and add Tessl publish-on-merge workflow

### DIFF
--- a/.github/workflows/pr-skill-checks.yml
+++ b/.github/workflows/pr-skill-checks.yml
@@ -22,18 +22,29 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Check for TESSL_TOKEN
+        id: token-check
+        env:
+          TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
+        run: |
+          if [ -n "$TESSL_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
-        if: secrets.TESSL_TOKEN != ''
+        if: steps.token-check.outputs.present == 'true'
         with:
           bun-version: "1.3.10"
 
       - name: Install dependencies
-        if: secrets.TESSL_TOKEN != ''
+        if: steps.token-check.outputs.present == 'true'
         run: bun install
 
       - name: Run tessl skill lint
         id: lint
-        if: secrets.TESSL_TOKEN != ''
+        if: steps.token-check.outputs.present == 'true'
         env:
           TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
         run: |
@@ -92,18 +103,29 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Check for TESSL_TOKEN
+        id: token-check
+        env:
+          TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
+        run: |
+          if [ -n "$TESSL_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
-        if: secrets.TESSL_TOKEN != ''
+        if: steps.token-check.outputs.present == 'true'
         with:
           bun-version: "1.3.10"
 
       - name: Install dependencies
-        if: secrets.TESSL_TOKEN != ''
+        if: steps.token-check.outputs.present == 'true'
         run: bun install
 
       - name: Run tessl skill review
         id: review
-        if: secrets.TESSL_TOKEN != ''
+        if: steps.token-check.outputs.present == 'true'
         env:
           TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
         run: |

--- a/.github/workflows/pr-skill-checks.yml
+++ b/.github/workflows/pr-skill-checks.yml
@@ -3,6 +3,7 @@ name: PR Skill Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [main]
     paths:
       - "skills/**"
 
@@ -15,7 +16,8 @@ jobs:
   tessl-lint:
     name: Tessl Skill Lint
     # Fork PRs run with a read-only GITHUB_TOKEN; skip entirely to avoid permission errors on comment steps
-    if: github.event.pull_request.head.repo.fork == false
+    # Also skip if the PR is no longer open (e.g. a queued run completing after merge)
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -84,7 +86,8 @@ jobs:
   tessl-review:
     name: Tessl Skill Review
     # Fork PRs run with a read-only GITHUB_TOKEN; skip entirely to avoid permission errors on comment steps
-    if: github.event.pull_request.head.repo.fork == false
+    # Also skip if the PR is no longer open (e.g. a queued run completing after merge)
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -152,7 +155,7 @@ jobs:
 
   request-eval-scenarios:
     name: Request Eval Scenarios from Copilot
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -1,0 +1,76 @@
+name: Publish Skills to Tessl
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+
+permissions:
+  contents: read
+  id-token: write # Required for OIDC token
+
+jobs:
+  detect-tiles:
+    name: Detect Changed Tiles
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.tiles.outputs.matrix }}
+      has-tiles: ${{ steps.tiles.outputs.has-tiles }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 2
+
+      - name: Find changed tile directories
+        id: tiles
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'skills/**' 2>/dev/null || true)
+
+          if [ -z "$CHANGED" ]; then
+            echo "has-tiles=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"tile":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # For each changed file, walk up the directory tree to find the nearest tile.json
+          TILE_DIRS=""
+          while IFS= read -r file; do
+            dir="$(dirname "$file")"
+            while [ "$dir" != "." ] && [ "$dir" != "skills" ]; do
+              if [ -f "$dir/tile.json" ]; then
+                TILE_DIRS="${TILE_DIRS}${dir}\n"
+                break
+              fi
+              dir="$(dirname "$dir")"
+            done
+          done <<< "$CHANGED"
+
+          UNIQUE_DIRS=$(printf '%b' "$TILE_DIRS" | sort -u | grep -v '^$' || true)
+
+          if [ -z "$UNIQUE_DIRS" ]; then
+            echo "has-tiles=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"tile":[]}' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' "$UNIQUE_DIRS" | jq -R . | jq -sc '{tile: .}')
+            echo "has-tiles=true" >> "$GITHUB_OUTPUT"
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    name: Publish ${{ matrix.tile }}
+    needs: detect-tiles
+    if: needs.detect-tiles.outputs.has-tiles == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.detect-tiles.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: tesslio/publish@main
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+          path: ${{ matrix.tile }}
+          review: "true"
+          review-threshold: "50"


### PR DESCRIPTION
Problem

  The existing pr-skill-checks.yml used secrets.TESSL_TOKEN != '' directly in step if: conditions, which is invalid in GitHub Actions — the secrets context is not accessible in expression
  conditionals. This caused the workflow to fail with "Unrecognized named-value: 'secrets'" errors.

  Changes

  Fix: pr-skill-checks.yml

  Replaced the invalid if: secrets.TESSL_TOKEN != '' step conditions with a dedicated Check for TESSL_TOKEN step that reads the secret via env: and exports present=true/false to step
  outputs. Subsequent steps gate on steps.token-check.outputs.present == 'true', which is valid.

  New: publish-skills.yml

  Adds a publish workflow that integrates [tesslio/publish@main ](https://docs.tessl.io/distribute/review-and-publish-with-github-actions)and triggers on push to main when skills/** changes (i.e. after a PR is merged).

  - detect-tiles job: walks up the directory tree of each changed file to find the nearest tile.json, deduplicates, and builds a JSON matrix of affected tile directories
  - publish job: runs tesslio/publish@main once per changed tile via matrix strategy, with review: true as a quality gate before publishing
  - Uses the org-level TESSL_TOKEN secret
  - fail-fast: false so one failing tile doesn't block others