### PR TITLE
feat(cli): auto-generate tile/skill counts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ domain knowledge, workflows, and best practices that can be loaded on-demand.
 
 ## Skill Catalog
 
-Browse all **47 skills across 47 tiles** in the [Skill Catalog](https://pantheon-org.github.io/tekhne/tiles/).
+<!-- skill-catalog-stats -->
+Browse all **72 skills across 50 tiles** in the [Skill Catalog](https://pantheon-org.github.io/tekhne/tiles/).
 
 ## CLI Tool
 

--- a/cli/lib/readme/rendering/build-readme-catalog-line.ts
+++ b/cli/lib/readme/rendering/build-readme-catalog-line.ts
@@ -1,0 +1,8 @@
+const CATALOG_URL = "https://pantheon-org.github.io/tekhne/tiles/";
+
+export const buildReadmeCatalogLine = (
+  tileCount: number,
+  skillCount: number,
+): string => {
+  return `Browse all **${skillCount} skills across ${tileCount} tiles** in the [Skill Catalog](${CATALOG_URL}).`;
+};

--- a/cli/lib/readme/rendering/index.ts
+++ b/cli/lib/readme/rendering/index.ts
@@ -1,5 +1,6 @@
 export * from "./build-count-label";
 export * from "./build-domain-docs-section";
+export * from "./build-readme-catalog-line";
 export * from "./build-skill-docs-row";
 export * from "./generate-docs-tiles-page";
 export * from "./get-audit-link";

--- a/cli/lib/readme/update-readme.ts
+++ b/cli/lib/readme/update-readme.ts
@@ -1,11 +1,17 @@
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { logger } from "../utils/logger";
 import { findAllSkills, findAllTiles, findUntiledSkills } from "./discovery";
-import { generateDocsTilesPage, writeBadgeFiles } from "./rendering";
+import {
+  buildReadmeCatalogLine,
+  generateDocsTilesPage,
+  writeBadgeFiles,
+} from "./rendering";
 import { showDryRunDiff } from "./show-dry-run-diff";
 import type { UpdateOptions } from "./types";
 
+const README_PATH = "README.md";
 const DOCS_TILES_PATH = "docs/src/content/docs/tiles.md";
+const CATALOG_STATS_MARKER = "<!-- skill-catalog-stats -->";
 
 export const updateReadme = async (options: UpdateOptions): Promise<void> => {
   logger.info("Finding all tiles...");
@@ -21,13 +27,30 @@ export const updateReadme = async (options: UpdateOptions): Promise<void> => {
   logger.info("Generating badge SVG files...");
   writeBadgeFiles();
 
+  const totalSkills = tiles.reduce((sum, t) => sum + t.skills.length, 0);
+  const catalogLine = buildReadmeCatalogLine(tiles.length, totalSkills);
+
+  const readmeContent = readFileSync(README_PATH, "utf-8");
+  const readmeLines = readmeContent.split("\n");
+  const markerIndex = readmeLines.findIndex((l) =>
+    l.includes(CATALOG_STATS_MARKER),
+  );
+
+  let newReadmeContent = readmeContent;
+  if (markerIndex !== -1 && markerIndex + 1 < readmeLines.length) {
+    readmeLines[markerIndex + 1] = catalogLine;
+    newReadmeContent = readmeLines.join("\n");
+  }
+
   logger.info("Generating docs tiles page...");
   const docsTilesContent = await generateDocsTilesPage(tiles, untiledSkills);
 
   if (options.dryRun) {
+    await showDryRunDiff(README_PATH, newReadmeContent);
     await showDryRunDiff(DOCS_TILES_PATH, docsTilesContent);
   } else {
+    writeFileSync(README_PATH, newReadmeContent);
     writeFileSync(DOCS_TILES_PATH, docsTilesContent);
-    logger.success(`${DOCS_TILES_PATH} written`);
+    logger.success(`${README_PATH} and ${DOCS_TILES_PATH} written`);
   }
 };

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,7 +15,7 @@ pre-commit:
       stage_fixed: true
     readme-sync:
       glob: "{skills/**,cli/**,.context/audits/**}"
-      run: bun cli/index.ts readme update && bunx markdownlint-cli2 --config .markdownlint-cli2.jsonc docs/src/content/docs/tiles.md && git add docs/src/content/docs/tiles.md
+      run: bun cli/index.ts readme update && bunx markdownlint-cli2 --config .markdownlint-cli2.jsonc README.md docs/src/content/docs/tiles.md && git add README.md docs/src/content/docs/tiles.md
       stage_fixed: true
     yamllint:
       glob: "*.{yml,yaml}"


### PR DESCRIPTION
  ## Summary

  - Adds a `<!-- skill-catalog-stats -->` sentinel to README.md
  - `bun cli/index.ts readme update` now replaces the line below the
    sentinel with live counts derived from discovered tiles and skills
  - Counts will never go stale — the pre-commit `readme-sync` hook
    regenerates and stages README.md on every skill or CLI change

  ## Test plan

  - [ ] `bun cli/index.ts readme update --dry-run` shows no diff when
    counts are already correct
  - [ ] Adding or removing a tile causes the count line to update on
    next commit
  - [ ] Pre-commit hook stages README.md alongside tiles.md