### PR TITLE
feat(cli): add Cucumber/Gherkin integration tests + wire install to agents registry

### DIFF
--- a/.github/workflows/pr-cli-tests.yml
+++ b/.github/workflows/pr-cli-tests.yml
@@ -1,0 +1,46 @@
+name: PR CLI Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - "cli/**"
+      - "cucumber.js"
+      - "package.json"
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run unit tests
+        run: bun test cli/
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run integration tests
+        run: bunx cucumber-js

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,18 @@
       "type": "stdio",
       "command": "tessl",
       "args": ["mcp", "start"]
+    },
+    "jdocmunch": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["jdocmunch-mcp"],
+      "env": {}
+    },
+    "jcodemunch": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["jcodemunch-mcp"],
+      "env": {}
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -14,15 +14,21 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
+        "@cucumber/cucumber": "^11.0.0",
         "@types/bun": "latest",
         "@types/js-yaml": "^4.0.9",
         "lefthook": "^2.1.1",
         "markdownlint-cli2": "^0.21.0",
         "tessl": "^0.68.0",
+        "tsx": "^4.0.0",
       },
     },
   },
   "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.4", "https://npm.jsr.io/@biomejs/biome/-/biome-2.4.4.tgz", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.4", "@biomejs/cli-darwin-x64": "2.4.4", "@biomejs/cli-linux-arm64": "2.4.4", "@biomejs/cli-linux-arm64-musl": "2.4.4", "@biomejs/cli-linux-x64": "2.4.4", "@biomejs/cli-linux-x64-musl": "2.4.4", "@biomejs/cli-win32-arm64": "2.4.4", "@biomejs/cli-win32-x64": "2.4.4" }, "bin": { "biome": "bin/biome" } }, "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.4", "https://npm.jsr.io/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.4.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A=="],
@@ -44,6 +50,86 @@
     "@cliffy/command": ["@jsr/cliffy__command@1.0.0", "https://npm.jsr.io/~/11/@jsr/cliffy__command/1.0.0.tgz", { "dependencies": { "@jsr/cliffy__flags": "1.0.0", "@jsr/cliffy__internal": "1.0.0", "@jsr/cliffy__table": "1.0.0", "@jsr/std__fmt": "^1.0.9", "@jsr/std__semver": "^1.0.8", "@jsr/std__text": "^1.0.17" } }, "sha512-oObplVtu1tvpkhgpuPDHZidx9g3axVOfRMQGmw7ZSGxp0+vZIJGiEtpcSvlN0XfuEhOG8neqfVBSSE9txrKanw=="],
 
     "@cliffy/prompt": ["@jsr/cliffy__prompt@1.0.0", "https://npm.jsr.io/~/11/@jsr/cliffy__prompt/1.0.0.tgz", { "dependencies": { "@jsr/cliffy__ansi": "1.0.0", "@jsr/cliffy__internal": "1.0.0", "@jsr/cliffy__keycode": "1.0.0", "@jsr/std__assert": "^1.0.18", "@jsr/std__fmt": "^1.0.9", "@jsr/std__io": "~0.225.3", "@jsr/std__path": "^1.1.4", "@jsr/std__text": "^1.0.17" } }, "sha512-JDuHcCAjScV0IUj389brneF6AzJyyP0pK8mymsrGN5/PGQfqK8zr96QpFlo1wmo8BY/3JQAdNfy6NZkPCJ6VWA=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@cucumber/ci-environment": ["@cucumber/ci-environment@10.0.1", "", {}, "sha512-/+ooDMPtKSmvcPMDYnMZt4LuoipfFfHaYspStI4shqw8FyKcfQAmekz6G+QKWjQQrvM+7Hkljwx58MEwPCwwzg=="],
+
+    "@cucumber/cucumber": ["@cucumber/cucumber@11.3.0", "", { "dependencies": { "@cucumber/ci-environment": "10.0.1", "@cucumber/cucumber-expressions": "18.0.1", "@cucumber/gherkin": "30.0.4", "@cucumber/gherkin-streams": "5.0.1", "@cucumber/gherkin-utils": "9.2.0", "@cucumber/html-formatter": "21.10.1", "@cucumber/junit-xml-formatter": "0.7.1", "@cucumber/message-streams": "4.0.1", "@cucumber/messages": "27.2.0", "@cucumber/tag-expressions": "6.1.2", "assertion-error-formatter": "^3.0.0", "capital-case": "^1.0.4", "chalk": "^4.1.2", "cli-table3": "0.6.5", "commander": "^10.0.0", "debug": "^4.3.4", "error-stack-parser": "^2.1.4", "figures": "^3.2.0", "glob": "^10.3.10", "has-ansi": "^4.0.1", "indent-string": "^4.0.0", "is-installed-globally": "^0.4.0", "is-stream": "^2.0.0", "knuth-shuffle-seeded": "^1.0.6", "lodash.merge": "^4.6.2", "lodash.mergewith": "^4.6.2", "luxon": "3.6.1", "mime": "^3.0.0", "mkdirp": "^2.1.5", "mz": "^2.7.0", "progress": "^2.0.3", "read-package-up": "^11.0.0", "semver": "7.7.1", "string-argv": "0.3.1", "supports-color": "^8.1.1", "type-fest": "^4.41.0", "util-arity": "^1.1.0", "yaml": "^2.2.2", "yup": "1.6.1" }, "bin": { "cucumber-js": "bin/cucumber.js" } }, "sha512-1YGsoAzRfDyVOnRMTSZP/EcFsOBElOKa2r+5nin0DJAeK+Mp0mzjcmSllMgApGtck7Ji87wwy3kFONfHUHMn4g=="],
+
+    "@cucumber/cucumber-expressions": ["@cucumber/cucumber-expressions@18.0.1", "", { "dependencies": { "regexp-match-indices": "1.0.2" } }, "sha512-NSid6bI+7UlgMywl5octojY5NXnxR9uq+JisjOrO52VbFsQM6gTWuQFE8syI10KnIBEdPzuEUSVEeZ0VFzRnZA=="],
+
+    "@cucumber/gherkin": ["@cucumber/gherkin@30.0.4", "", { "dependencies": { "@cucumber/messages": ">=19.1.4 <=26" } }, "sha512-pb7lmAJqweZRADTTsgnC3F5zbTh3nwOB1M83Q9ZPbUKMb3P76PzK6cTcPTJBHWy3l7isbigIv+BkDjaca6C8/g=="],
+
+    "@cucumber/gherkin-streams": ["@cucumber/gherkin-streams@5.0.1", "", { "dependencies": { "commander": "9.1.0", "source-map-support": "0.5.21" }, "peerDependencies": { "@cucumber/gherkin": ">=22.0.0", "@cucumber/message-streams": ">=4.0.0", "@cucumber/messages": ">=17.1.1" }, "bin": { "gherkin-javascript": "bin/gherkin" } }, "sha512-/7VkIE/ASxIP/jd4Crlp4JHXqdNFxPGQokqWqsaCCiqBiu5qHoKMxcWNlp9njVL/n9yN4S08OmY3ZR8uC5x74Q=="],
+
+    "@cucumber/gherkin-utils": ["@cucumber/gherkin-utils@9.2.0", "", { "dependencies": { "@cucumber/gherkin": "^31.0.0", "@cucumber/messages": "^27.0.0", "@teppeis/multimaps": "3.0.0", "commander": "13.1.0", "source-map-support": "^0.5.21" }, "bin": { "gherkin-utils": "bin/gherkin-utils" } }, "sha512-3nmRbG1bUAZP3fAaUBNmqWO0z0OSkykZZotfLjyhc8KWwDSOrOmMJlBTd474lpA8EWh4JFLAX3iXgynBqBvKzw=="],
+
+    "@cucumber/html-formatter": ["@cucumber/html-formatter@21.10.1", "", { "peerDependencies": { "@cucumber/messages": ">=18" } }, "sha512-isaaNMNnBYThsvaHy7i+9kkk9V3+rhgdkt0pd6TCY6zY1CSRZQ7tG6ST9pYyRaECyfbCeF7UGH0KpNEnh6UNvQ=="],
+
+    "@cucumber/junit-xml-formatter": ["@cucumber/junit-xml-formatter@0.7.1", "", { "dependencies": { "@cucumber/query": "^13.0.2", "@teppeis/multimaps": "^3.0.0", "luxon": "^3.5.0", "xmlbuilder": "^15.1.1" }, "peerDependencies": { "@cucumber/messages": "*" } }, "sha512-AzhX+xFE/3zfoYeqkT7DNq68wAQfBcx4Dk9qS/ocXM2v5tBv6eFQ+w8zaSfsktCjYzu4oYRH/jh4USD1CYHfaQ=="],
+
+    "@cucumber/message-streams": ["@cucumber/message-streams@4.0.1", "", { "peerDependencies": { "@cucumber/messages": ">=17.1.1" } }, "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA=="],
+
+    "@cucumber/messages": ["@cucumber/messages@27.2.0", "", { "dependencies": { "@types/uuid": "10.0.0", "class-transformer": "0.5.1", "reflect-metadata": "0.2.2", "uuid": "11.0.5" } }, "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA=="],
+
+    "@cucumber/query": ["@cucumber/query@13.6.0", "", { "dependencies": { "@teppeis/multimaps": "3.0.0", "lodash.sortby": "^4.7.0" }, "peerDependencies": { "@cucumber/messages": "*" } }, "sha512-tiDneuD5MoWsJ9VKPBmQok31mSX9Ybl+U4wqDoXeZgsXHDURqzM3rnpWVV3bC34y9W6vuFxrlwF/m7HdOxwqRw=="],
+
+    "@cucumber/tag-expressions": ["@cucumber/tag-expressions@6.1.2", "", {}, "sha512-xa3pER+ntZhGCxRXSguDTKEHTZpUUsp+RzTRNnit+vi5cqnk6abLdSLg5i3HZXU3c74nQ8afQC6IT507EN74oQ=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@jsr/cliffy__ansi": ["@jsr/cliffy__ansi@1.0.0", "https://npm.jsr.io/~/11/@jsr/cliffy__ansi/1.0.0.tgz", { "dependencies": { "@jsr/cliffy__internal": "1.0.0", "@jsr/std__encoding": "^1.0.10", "@jsr/std__fmt": "^1.0.9", "@jsr/std__io": "~0.225.3" } }, "sha512-JesgTdgR0aW1mZv96VqvRHr2efzr4MgDFMnoT+hkhaiCpmyBz33sHM5peAoMJUbGVfEfQAsysIXvvgoFYoveYg=="],
 
@@ -81,7 +167,11 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "https://npm.jsr.io/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "https://npm.jsr.io/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@teppeis/multimaps": ["@teppeis/multimaps@3.0.0", "", {}, "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q=="],
 
     "@types/bun": ["@types/bun@1.3.10", "https://npm.jsr.io/@types/bun/-/bun-1.3.10.tgz", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
@@ -95,21 +185,41 @@
 
     "@types/node": ["@types/node@25.3.3", "https://npm.jsr.io/@types/node/-/node-25.3.3.tgz", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
+    "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
     "@types/unist": ["@types/unist@2.0.11", "https://npm.jsr.io/@types/unist/-/unist-2.0.11.tgz", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
     "anafanafo": ["anafanafo@2.0.0", "", { "dependencies": { "char-width-table-consumer": "^1.0.0" } }, "sha512-Nlfq7NC4AOkTJerWRIZcOAiMNtIDVIGWGvQ98O7Jl6Kr2Dk0dX5u4MqN778kSRTy5KRqchpLdF2RtLFEz9FVkQ=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "https://npm.jsr.io/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@4.1.1", "", {}, "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "argparse": ["argparse@2.0.1", "https://npm.jsr.io/argparse/-/argparse-2.0.1.tgz", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "assertion-error-formatter": ["assertion-error-formatter@3.0.0", "", { "dependencies": { "diff": "^4.0.1", "pad-right": "^0.2.2", "repeat-string": "^1.6.1" } }, "sha512-6YyAVLrEze0kQ7CmJfUgrLHb+Y7XghmL2Ie7ijVa2Y9ynP3LV+VDiwFk62Dn0qtqbmY0BT0ss6p1xxpiF2PYbQ=="],
+
     "badge-maker": ["badge-maker@5.0.2", "", { "dependencies": { "anafanafo": "2.0.0", "css-color-converter": "^2.0.0" }, "bin": { "badge": "lib/badge-cli.js" } }, "sha512-Xd3YUmKPEShQcn6PFB03Wxq0RNJRFwVVroyRz0qIjSXwniYUGsGWNHqtNsQYi/Sbs8Ni7qAEf7LKgDOtcAoCDg=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "binary-search": ["binary-search@1.3.6", "", {}, "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="],
 
+    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
     "braces": ["braces@3.0.3", "https://npm.jsr.io/braces/-/braces-3.0.3.tgz", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "bun-types": ["bun-types@1.3.10", "https://npm.jsr.io/bun-types/-/bun-types-1.3.10.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "capital-case": ["capital-case@1.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3", "upper-case-first": "^2.0.2" } }, "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "char-width-table-consumer": ["char-width-table-consumer@1.0.0", "", { "dependencies": { "binary-search": "^1.3.5" } }, "sha512-Fz4UD0LBpxPgL9i29CJ5O4KANwaMnX/OhhbxzvNa332h+9+nRKyeuLw4wA51lt/ex67+/AdsoBQJF3kgX2feYQ=="],
 
@@ -119,11 +229,17 @@
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "https://npm.jsr.io/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
+    "class-transformer": ["class-transformer@0.5.1", "", {}, "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
+
     "color-convert": ["color-convert@0.5.3", "", {}, "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "commander": ["commander@8.3.0", "https://npm.jsr.io/commander/-/commander-8.3.0.tgz", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+    "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-color-converter": ["css-color-converter@2.0.0", "", { "dependencies": { "color-convert": "^0.5.2", "color-name": "^1.1.4", "css-unit-converter": "^1.1.2" } }, "sha512-oLIG2soZz3wcC3aAl/7Us5RS8Hvvc6I8G8LniF/qfMmrm7fIKQ8RIDDRZeKyGL2SrWfNqYspuLShbnjBMVWm8g=="],
 
@@ -137,21 +253,59 @@
 
     "devlop": ["devlop@1.1.0", "https://npm.jsr.io/devlop/-/devlop-1.1.0.tgz", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "diff": ["diff@4.0.4", "", {}, "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "entities": ["entities@4.5.0", "https://npm.jsr.io/entities/-/entities-4.5.0.tgz", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "error-stack-parser": ["error-stack-parser@2.1.4", "", { "dependencies": { "stackframe": "^1.3.4" } }, "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ=="],
+
+    "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "fast-glob": ["fast-glob@3.3.3", "https://npm.jsr.io/fast-glob/-/fast-glob-3.3.3.tgz", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fastq": ["fastq@1.20.1", "https://npm.jsr.io/fastq/-/fastq-1.20.1.tgz", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
+    "figures": ["figures@3.2.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg=="],
+
     "fill-range": ["fill-range@7.1.1", "https://npm.jsr.io/fill-range/-/fill-range-7.1.1.tgz", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "https://npm.jsr.io/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
+    "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "glob-parent": ["glob-parent@5.1.2", "https://npm.jsr.io/glob-parent/-/glob-parent-5.1.2.tgz", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "global-dirs": ["global-dirs@3.0.1", "", { "dependencies": { "ini": "2.0.0" } }, "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA=="],
 
     "globby": ["globby@16.1.0", "https://npm.jsr.io/globby/-/globby-16.1.0.tgz", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "fast-glob": "^3.3.3", "ignore": "^7.0.5", "is-path-inside": "^4.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.4.0" } }, "sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ=="],
 
+    "has-ansi": ["has-ansi@4.0.1", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-Qr4RtTm30xvEdqUXbSBVWDu+PrTokJOwe/FU+VdfJPk+MXAPoeOzKpRyrDTnZIJwAkQ4oBLTU53nu0HrkF/Z2A=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
     "ignore": ["ignore@7.0.5", "https://npm.jsr.io/ignore/-/ignore-7.0.5.tgz", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
+
+    "ini": ["ini@2.0.0", "", {}, "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "https://npm.jsr.io/is-alphabetical/-/is-alphabetical-2.0.1.tgz", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -161,19 +315,33 @@
 
     "is-extglob": ["is-extglob@2.1.1", "https://npm.jsr.io/is-extglob/-/is-extglob-2.1.1.tgz", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-glob": ["is-glob@4.0.3", "https://npm.jsr.io/is-glob/-/is-glob-4.0.3.tgz", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "https://npm.jsr.io/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
+    "is-installed-globally": ["is-installed-globally@0.4.0", "", { "dependencies": { "global-dirs": "^3.0.0", "is-path-inside": "^3.0.2" } }, "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ=="],
+
     "is-number": ["is-number@7.0.0", "https://npm.jsr.io/is-number/-/is-number-7.0.0.tgz", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "is-path-inside": ["is-path-inside@4.0.0", "https://npm.jsr.io/is-path-inside/-/is-path-inside-4.0.0.tgz", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
+    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "https://npm.jsr.io/js-yaml/-/js-yaml-4.1.1.tgz", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "https://npm.jsr.io/jsonc-parser/-/jsonc-parser-3.3.1.tgz", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "katex": ["katex@0.16.28", "https://npm.jsr.io/katex/-/katex-0.16.28.tgz", { "dependencies": { "commander": "^8.3.0" }, "bin": "cli.js" }, "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg=="],
+
+    "knuth-shuffle-seeded": ["knuth-shuffle-seeded@1.0.6", "", { "dependencies": { "seed-random": "~2.2.0" } }, "sha512-9pFH0SplrfyKyojCLxZfMcvkhf5hH0d+UwR9nTVJ/DDQJGuzcXjTwB7TP7sDfehSudlGGaOLblmEWqv04ERVWg=="],
 
     "lefthook": ["lefthook@2.1.1", "https://npm.jsr.io/lefthook/-/lefthook-2.1.1.tgz", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.1", "lefthook-darwin-x64": "2.1.1", "lefthook-freebsd-arm64": "2.1.1", "lefthook-freebsd-x64": "2.1.1", "lefthook-linux-arm64": "2.1.1", "lefthook-linux-x64": "2.1.1", "lefthook-openbsd-arm64": "2.1.1", "lefthook-openbsd-x64": "2.1.1", "lefthook-windows-arm64": "2.1.1", "lefthook-windows-x64": "2.1.1" }, "bin": "bin/index.js" }, "sha512-Tl9h9c+sG3ShzTHKuR3LAIblnnh+Mgxnm2Ul7yu9cu260Z27LEbO3V6Zw4YZFP59/2rlD42pt/llYsQCkkCFzw=="],
 
@@ -198,6 +366,18 @@
     "lefthook-windows-x64": ["lefthook-windows-x64@2.1.1", "https://npm.jsr.io/lefthook-windows-x64/-/lefthook-windows-x64-2.1.1.tgz", { "os": "win32", "cpu": "x64" }, "sha512-1L2oGIzmhfOTxfwbe5mpSQ+m3ilpvGNymwIhn4UHq6hwHsUL6HEhODqx02GfBn6OXpVIr56bvdBAusjL/SVYGQ=="],
 
     "linkify-it": ["linkify-it@5.0.0", "https://npm.jsr.io/linkify-it/-/linkify-it-5.0.0.tgz", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lodash.mergewith": ["lodash.mergewith@4.6.2", "", {}, "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="],
+
+    "lodash.sortby": ["lodash.sortby@4.7.0", "", {}, "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="],
+
+    "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "luxon": ["luxon@3.6.1", "", {}, "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ=="],
 
     "markdown-it": ["markdown-it@14.1.1", "https://npm.jsr.io/markdown-it/-/markdown-it-14.1.1.tgz", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": "bin/markdown-it.mjs" }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
 
@@ -263,29 +443,121 @@
 
     "micromatch": ["micromatch@4.0.8", "https://npm.jsr.io/micromatch/-/micromatch-4.0.8.tgz", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mkdirp": ["mkdirp@2.1.6", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A=="],
+
     "ms": ["ms@2.1.3", "https://npm.jsr.io/ms/-/ms-2.1.3.tgz", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "no-case": ["no-case@3.0.4", "", { "dependencies": { "lower-case": "^2.0.2", "tslib": "^2.0.3" } }, "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg=="],
+
+    "normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "pad-right": ["pad-right@0.2.2", "", { "dependencies": { "repeat-string": "^1.5.2" } }, "sha512-4cy8M95ioIGolCoMmm2cMntGR1lPLEbOMzOKu8bzjuJP6JpzEMQcDHmh7hHLYGgob+nKe1YHFMaG4V59HQa89g=="],
 
     "parse-entities": ["parse-entities@4.0.2", "https://npm.jsr.io/parse-entities/-/parse-entities-4.0.2.tgz", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
+    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "picomatch": ["picomatch@2.3.1", "https://npm.jsr.io/picomatch/-/picomatch-2.3.1.tgz", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "property-expr": ["property-expr@2.0.6", "", {}, "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="],
 
     "punycode.js": ["punycode.js@2.3.1", "https://npm.jsr.io/punycode.js/-/punycode.js-2.3.1.tgz", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "https://npm.jsr.io/queue-microtask/-/queue-microtask-1.2.3.tgz", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
+
+    "read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
+    "regexp-match-indices": ["regexp-match-indices@1.0.2", "", { "dependencies": { "regexp-tree": "^0.1.11" } }, "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ=="],
+
+    "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
+
+    "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "reusify": ["reusify@1.1.0", "https://npm.jsr.io/reusify/-/reusify-1.1.0.tgz", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "https://npm.jsr.io/run-parallel/-/run-parallel-1.2.0.tgz", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "seed-random": ["seed-random@2.2.0", "", {}, "sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ=="],
+
+    "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "slash": ["slash@5.1.0", "https://npm.jsr.io/slash/-/slash-5.1.0.tgz", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
-    "string-width": ["string-width@8.1.0", "https://npm.jsr.io/string-width/-/string-width-8.1.0.tgz", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
-    "strip-ansi": ["strip-ansi@7.1.2", "https://npm.jsr.io/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "spdx-correct": ["spdx-correct@3.2.0", "", { "dependencies": { "spdx-expression-parse": "^3.0.0", "spdx-license-ids": "^3.0.0" } }, "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA=="],
+
+    "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
+
+    "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+
+    "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
+
+    "stackframe": ["stackframe@1.3.4", "", {}, "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="],
+
+    "string-argv": ["string-argv@0.3.1", "", {}, "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "tessl": ["tessl@0.68.0", "https://npm.jsr.io/tessl/-/tessl-0.68.0.tgz", { "bin": { "tessl": "bin/tessl.js" } }, "sha512-gFrxgSMD0TOzzwDuDDlPM3IpAnUUmLgrqUyGJTbNVhGOVyXMrzxOz+nOevC9uJJnMI1O3CaHssy5PeCQuGuatQ=="],
 
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tiny-case": ["tiny-case@1.0.3", "", {}, "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "https://npm.jsr.io/to-regex-range/-/to-regex-range-5.0.1.tgz", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toposort": ["toposort@2.0.2", "", {}, "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "uc.micro": ["uc.micro@2.1.0", "https://npm.jsr.io/uc.micro/-/uc.micro-2.1.0.tgz", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -293,8 +565,82 @@
 
     "unicorn-magic": ["unicorn-magic@0.4.0", "https://npm.jsr.io/unicorn-magic/-/unicorn-magic-0.4.0.tgz", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
+    "upper-case-first": ["upper-case-first@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg=="],
+
+    "util-arity": ["util-arity@1.1.0", "", {}, "sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA=="],
+
+    "uuid": ["uuid@11.0.5", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="],
+
+    "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
+    "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "yup": ["yup@1.6.1", "", { "dependencies": { "property-expr": "^2.0.5", "tiny-case": "^1.0.3", "toposort": "^2.0.2", "type-fest": "^2.19.0" } }, "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA=="],
+
     "zod": ["zod@4.3.6", "https://npm.jsr.io/zod/-/zod-4.3.6.tgz", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@cucumber/gherkin/@cucumber/messages": ["@cucumber/messages@26.0.1", "", { "dependencies": { "@types/uuid": "10.0.0", "class-transformer": "0.5.1", "reflect-metadata": "0.2.2", "uuid": "10.0.0" } }, "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg=="],
+
+    "@cucumber/gherkin-streams/commander": ["commander@9.1.0", "", {}, "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w=="],
+
+    "@cucumber/gherkin-utils/@cucumber/gherkin": ["@cucumber/gherkin@31.0.0", "", { "dependencies": { "@cucumber/messages": ">=19.1.4 <=26" } }, "sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw=="],
+
+    "@cucumber/gherkin-utils/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "https://npm.jsr.io/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "globby/is-path-inside": ["is-path-inside@4.0.0", "https://npm.jsr.io/is-path-inside/-/is-path-inside-4.0.0.tgz", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
+
+    "katex/commander": ["commander@8.3.0", "https://npm.jsr.io/commander/-/commander-8.3.0.tgz", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "markdownlint/string-width": ["string-width@8.1.0", "https://npm.jsr.io/string-width/-/string-width-8.1.0.tgz", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
+
+    "read-pkg/unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "https://npm.jsr.io/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "yup/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
+
+    "@cucumber/gherkin-utils/@cucumber/gherkin/@cucumber/messages": ["@cucumber/messages@26.0.1", "", { "dependencies": { "@types/uuid": "10.0.0", "class-transformer": "0.5.1", "reflect-metadata": "0.2.2", "uuid": "10.0.0" } }, "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg=="],
+
+    "@cucumber/gherkin/@cucumber/messages/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://npm.jsr.io/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "markdownlint/string-width/strip-ansi": ["strip-ansi@7.1.2", "https://npm.jsr.io/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://npm.jsr.io/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@cucumber/gherkin-utils/@cucumber/gherkin/@cucumber/messages/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "markdownlint/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://npm.jsr.io/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
   }
 }

--- a/cli/commands/install.ts
+++ b/cli/commands/install.ts
@@ -1,11 +1,10 @@
 import { Command, EnumType } from "@cliffy/command";
 import { installSkills } from "../lib/install";
+import type { AgentType } from "../lib/types";
+import { agents } from "../lib/types";
 import { CLIError, logger } from "../lib/utils";
 
-const AGENTS = ["opencode", "cursor", "gemini", "claude", "codex"] as const;
-type Agent = (typeof AGENTS)[number];
-
-const agentType = new EnumType(AGENTS);
+const agentType = new EnumType(Object.keys(agents) as AgentType[]);
 
 export const installCommand = new Command()
   .description("Install skills to local agent directories")
@@ -13,7 +12,7 @@ export const installCommand = new Command()
   .option(
     "-a, --agent <agents...:agent>",
     "Specific agents to install for. Note: only opencode supports local installs; all other agents always install to ~/.config/",
-    { default: ["opencode"] as Agent[] },
+    { default: ["opencode"] as AgentType[] },
   )
   .option(
     "-g, --global",

--- a/cli/features/audit.feature
+++ b/cli/features/audit.feature
@@ -1,0 +1,33 @@
+Feature: Audit command
+  The audit command evaluates skill quality. The status and summary subcommands
+  read existing audit data from .context/audits/ without calling any external AI.
+
+  Scenario: Top-level help shows available subcommands
+    Given I am at the repository root
+    When I run the CLI command "audit --help"
+    Then the exit code should be 0
+    And the output should contain "Skill quality audit"
+
+  Scenario: skill subcommand help shows usage
+    Given I am at the repository root
+    When I run the CLI command "audit skill --help"
+    Then the exit code should be 0
+    And the output should contain "Audit a single skill"
+
+  Scenario: all subcommand help shows usage
+    Given I am at the repository root
+    When I run the CLI command "audit all --help"
+    Then the exit code should be 0
+    And the output should contain "Audit all skills"
+
+  Scenario: status subcommand runs and reports compliance
+    Given I am at the repository root
+    When I run the CLI command "audit status"
+    Then the exit code should be 0
+    And the output should contain "Audit Status"
+
+  Scenario: summary subcommand generates a report when audit data exists
+    Given I am at the repository root
+    When I run the CLI command "audit summary"
+    Then the exit code should be 0
+    And the output should contain "Audit Summary"

--- a/cli/features/install.feature
+++ b/cli/features/install.feature
@@ -1,0 +1,25 @@
+Feature: Install command
+  The install command places skill symlinks in agent config directories.
+  The --dry-run flag shows what would be installed without making changes.
+
+  Scenario: Dry run exits successfully without installing anything
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run"
+    Then the exit code should be 0
+
+  Scenario: Dry run output mentions dry run mode
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run"
+    Then the exit code should be 0
+    And the output should contain "dry run"
+
+  Scenario: Help flag shows the command description
+    Given I am at the repository root
+    When I run the CLI command "install --help"
+    Then the exit code should be 0
+    And the output should contain "Install skills"
+
+  Scenario: Filtering by domain in dry run shows only matching skills
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run --skill-domain ci-cd"
+    Then the exit code should be 0

--- a/cli/features/install.feature
+++ b/cli/features/install.feature
@@ -1,17 +1,7 @@
 Feature: Install command
-  The install command places skill symlinks in agent config directories.
-  The --dry-run flag shows what would be installed without making changes.
-
-  Scenario: Dry run exits successfully without installing anything
-    Given I am at the repository root
-    When I run the CLI command "install --dry-run"
-    Then the exit code should be 0
-
-  Scenario: Dry run output mentions dry run mode
-    Given I am at the repository root
-    When I run the CLI command "install --dry-run"
-    Then the exit code should be 0
-    And the output should contain "dry run"
+  The install command places namespaced skill symlinks (domain--subdomain--skill)
+  in agent config directories. The --dry-run flag previews all changes without
+  writing anything to disk.
 
   Scenario: Help flag shows the command description
     Given I am at the repository root
@@ -19,7 +9,63 @@ Feature: Install command
     Then the exit code should be 0
     And the output should contain "Install skills"
 
-  Scenario: Filtering by domain in dry run shows only matching skills
+  Scenario: Dry run exits successfully and confirms no changes were made
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run"
+    Then the exit code should be 0
+    And the output should contain "Dry run completed"
+
+  Scenario: Dry run reports how many skills were discovered
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run"
+    Then the exit code should be 0
+    And the output should contain "Found"
+
+  Scenario: Dry run always shows an installation summary
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run"
+    Then the exit code should be 0
+    And the output should contain "Installation Summary"
+
+  Scenario: Filtering by domain excludes skills from other domains
     Given I am at the repository root
     When I run the CLI command "install --dry-run --skill-domain ci-cd"
     Then the exit code should be 0
+    And the output should contain "Excluded"
+
+  Scenario: Filtering by subdomain excludes skills from other subdomains
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run --skill-subdomain github-actions"
+    Then the exit code should be 0
+    And the output should contain "Excluded"
+
+  Scenario: Installing for multiple agents in dry run reports each agent
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run --agent opencode cursor"
+    Then the exit code should be 0
+    And the output should contain "opencode"
+    And the output should contain "cursor"
+
+  Scenario Outline: Install mode is reflected in target directory
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run <flags>"
+    Then the exit code should be 0
+    And the output should contain "Mode: <mode>"
+    And the output should contain "<path_fragment>"
+
+    Examples:
+      | flags    | mode   | path_fragment       |
+      |          | local  | .agents/skills      |
+      | --global | global | .config/opencode/skills |
+
+  Scenario: Global flag has no effect for agents that are always global
+    Given I am at the repository root
+    When I run the CLI command "install --dry-run --global --agent cursor"
+    Then the exit code should be 0
+    And the output should contain "--global has no effect for cursor"
+
+  Scenario: An unknown agent name is rejected by the CLI parser
+    Given I am at the repository root
+    When I run the CLI command "install --agent not-a-real-agent"
+    Then the exit code should be 2
+    And the output should contain "not-a-real-agent"

--- a/cli/features/install.feature
+++ b/cli/features/install.feature
@@ -58,11 +58,11 @@ Feature: Install command
       |          | local  | .agents/skills      |
       | --global | global | .config/opencode/skills |
 
-  Scenario: Global flag has no effect for agents that are always global
+  Scenario: Global flag for cursor targets the cursor-specific config directory
     Given I am at the repository root
     When I run the CLI command "install --dry-run --global --agent cursor"
     Then the exit code should be 0
-    And the output should contain "--global has no effect for cursor"
+    And the output should contain ".cursor/skills"
 
   Scenario: An unknown agent name is rejected by the CLI parser
     Given I am at the repository root

--- a/cli/features/readme.feature
+++ b/cli/features/readme.feature
@@ -1,0 +1,20 @@
+Feature: Readme command
+  The readme update command regenerates the skill catalog in docs and README.md.
+  The --dry-run flag shows the diff without writing any files.
+
+  Scenario: Help shows the command description
+    Given I am at the repository root
+    When I run the CLI command "readme update --help"
+    Then the exit code should be 0
+    And the output should contain "Update skill catalog"
+
+  Scenario: Dry run exits successfully
+    Given I am at the repository root
+    When I run the CLI command "readme update --dry-run"
+    Then the exit code should be 0
+
+  Scenario: Dry run output reports discovered tiles
+    Given I am at the repository root
+    When I run the CLI command "readme update --dry-run"
+    Then the exit code should be 0
+    And the output should contain "tiles"

--- a/cli/features/step-definitions/common.steps.ts
+++ b/cli/features/step-definitions/common.steps.ts
@@ -11,7 +11,7 @@ Given("I am at the repository root", function (this: CliWorld) {
 When(
   "I run the CLI command {string}",
   function (this: CliWorld, command: string) {
-    const args = command.split(/\s+/);
+    const args = command.split(/\s+/).filter(Boolean);
     this.lastResult = runCli(args, this.repoRoot);
   },
 );

--- a/cli/features/step-definitions/common.steps.ts
+++ b/cli/features/step-definitions/common.steps.ts
@@ -1,0 +1,45 @@
+// Step definition files use `function` syntax for Cucumber's `this` binding.
+// These files live outside cli/lib/ and are exempt from CLI TypeScript conventions.
+import { Given, Then, When } from "@cucumber/cucumber";
+import { runCli } from "./run-cli";
+import type { CliWorld } from "./world";
+
+Given("I am at the repository root", function (this: CliWorld) {
+  // No-op: cucumber.js is at the repo root so process.cwd() is already correct.
+});
+
+When(
+  "I run the CLI command {string}",
+  function (this: CliWorld, command: string) {
+    const args = command.split(/\s+/);
+    this.lastResult = runCli(args, this.repoRoot);
+  },
+);
+
+Then(
+  "the exit code should be {int}",
+  function (this: CliWorld, expectedCode: number) {
+    if (!this.lastResult) throw new Error("No CLI command has been run yet");
+    const actual = this.lastResult.exitCode;
+    if (actual !== expectedCode) {
+      throw new Error(
+        `Expected exit code ${expectedCode} but got ${actual}\n` +
+          `stdout: ${this.lastResult.stdout}\n` +
+          `stderr: ${this.lastResult.stderr}`,
+      );
+    }
+  },
+);
+
+Then(
+  "the output should contain {string}",
+  function (this: CliWorld, expected: string) {
+    if (!this.lastResult) throw new Error("No CLI command has been run yet");
+    const combined = this.lastResult.stdout + this.lastResult.stderr;
+    if (!combined.toLowerCase().includes(expected.toLowerCase())) {
+      throw new Error(
+        `Expected output to contain "${expected}"\nActual output:\n${combined}`,
+      );
+    }
+  },
+);

--- a/cli/features/step-definitions/run-cli.ts
+++ b/cli/features/step-definitions/run-cli.ts
@@ -1,0 +1,19 @@
+import { spawnSync } from "node:child_process";
+
+export interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export const runCli = (args: string[], cwd: string): CliResult => {
+  const result = spawnSync("bun", ["cli/index.ts", ...args], {
+    cwd,
+    encoding: "utf-8",
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    exitCode: result.status ?? 1,
+  };
+};

--- a/cli/features/step-definitions/world.ts
+++ b/cli/features/step-definitions/world.ts
@@ -1,0 +1,19 @@
+import {
+  type IWorldOptions,
+  setWorldConstructor,
+  World,
+} from "@cucumber/cucumber";
+import type { CliResult } from "./run-cli";
+
+export class CliWorld extends World {
+  lastResult: CliResult | null = null;
+  repoRoot: string;
+
+  constructor(options: IWorldOptions) {
+    super(options);
+    this.lastResult = null;
+    this.repoRoot = process.cwd();
+  }
+}
+
+setWorldConstructor(CliWorld);

--- a/cli/features/sync.feature
+++ b/cli/features/sync.feature
@@ -1,0 +1,20 @@
+Feature: Sync command
+  The sync opencode command cleans broken symlinks, syncs MCP config, and links
+  Tessl tiles. The --dry-run flag shows what would change without writing anything.
+
+  Scenario: Help shows the command description
+    Given I am at the repository root
+    When I run the CLI command "sync opencode --help"
+    Then the exit code should be 0
+    And the output should contain "Sync OpenCode"
+
+  Scenario: Dry run exits successfully
+    Given I am at the repository root
+    When I run the CLI command "sync opencode --dry-run"
+    Then the exit code should be 0
+
+  Scenario: Dry run output confirms no changes were made
+    Given I am at the repository root
+    When I run the CLI command "sync opencode --dry-run"
+    Then the exit code should be 0
+    And the output should contain "Dry run"

--- a/cli/features/tessl.feature
+++ b/cli/features/tessl.feature
@@ -1,0 +1,22 @@
+Feature: Tessl command
+  The tessl command manages the Tessl registry lifecycle. The manage subcommand
+  handles import/lint/review/publish. The publish-check subcommand validates
+  tiles before publishing by running tessl skill lint locally.
+
+  Scenario: manage subcommand help shows usage
+    Given I am at the repository root
+    When I run the CLI command "tessl manage --help"
+    Then the exit code should be 0
+    And the output should contain "Manage skill lifecycle"
+
+  Scenario: publish-check subcommand help shows usage
+    Given I am at the repository root
+    When I run the CLI command "tessl publish-check --help"
+    Then the exit code should be 0
+    And the output should contain "Validate tiles"
+
+  Scenario: publish-check validates a well-formed tile
+    Given I am at the repository root
+    When I run the CLI command "tessl publish-check skills/ci-cd/github-actions"
+    Then the exit code should be 0
+    And the output should contain "All checks passed"

--- a/cli/features/validate.feature
+++ b/cli/features/validate.feature
@@ -1,0 +1,19 @@
+Feature: Validate frontmatter command
+  The validate frontmatter command checks SKILL.md files for required fields
+  and valid YAML. It exits 0 when all files pass and non-zero when any fail.
+
+  Scenario: Validating all skills exits successfully
+    Given I am at the repository root
+    When I run the CLI command "validate frontmatter"
+    Then the exit code should be 0
+
+  Scenario: Validating a specific known-good skill file succeeds
+    Given I am at the repository root
+    When I run the CLI command "validate frontmatter skills/ci-cd/github-actions/generator/SKILL.md"
+    Then the exit code should be 0
+
+  Scenario: Help flag shows the command description
+    Given I am at the repository root
+    When I run the CLI command "validate frontmatter --help"
+    Then the exit code should be 0
+    And the output should contain "Validate YAML frontmatter"

--- a/cli/lib/audit/collect-audit-data.ts
+++ b/cli/lib/audit/collect-audit-data.ts
@@ -11,7 +11,7 @@ export interface SkillAudit {
 
 export const collectAuditData = async (): Promise<SkillAudit[]> => {
   const auditJsonFiles =
-    await $`find .context/audits -name "audit.json" -path "*/latest/*"`.text();
+    await $`find -L .context/audits -name "audit.json" -path "*/latest/*"`.text();
   const files = auditJsonFiles.trim().split("\n").filter(Boolean);
 
   if (files.length === 0) {

--- a/cli/lib/install/index.ts
+++ b/cli/lib/install/index.ts
@@ -6,4 +6,5 @@ export * from "./find-skills";
 export * from "./get-skill-name";
 export * from "./install-skills";
 export * from "./install-skills-for-agent";
+export * from "./resolve-target-dir";
 export * from "./select-skills-interactively";

--- a/cli/lib/install/install-skills-for-agent.test.ts
+++ b/cli/lib/install/install-skills-for-agent.test.ts
@@ -1,42 +1,44 @@
 import { describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { AGENT_PATHS, ALWAYS_GLOBAL_AGENTS } from "./install-skills-for-agent";
+import { configHome } from "../types/agents";
+import { resolveTargetDir } from "./resolve-target-dir";
 
-describe("AGENT_PATHS", () => {
-  test("opencode with isGlobal=false uses cwd/.agents/skills", () => {
-    expect(AGENT_PATHS.opencode(false, "/project")).toBe(
+describe("resolveTargetDir", () => {
+  test("opencode local uses cwd/.agents/skills", () => {
+    expect(resolveTargetDir("opencode", false, "/project")).toBe(
       "/project/.agents/skills",
     );
   });
 
-  test("opencode with isGlobal=true uses ~/.config/opencode/skills", () => {
-    expect(AGENT_PATHS.opencode(true, "/project")).toBe(
-      join(homedir(), ".config", "opencode", "skills"),
+  test("opencode global uses xdg config opencode/skills", () => {
+    const expected = join(configHome, "opencode/skills");
+    expect(resolveTargetDir("opencode", true, "/project")).toBe(expected);
+  });
+
+  test("cursor local uses cwd/.agents/skills", () => {
+    expect(resolveTargetDir("cursor", false, "/project")).toBe(
+      "/project/.agents/skills",
     );
   });
 
-  test("cursor always uses global path regardless of isGlobal flag", () => {
-    const globalPath = join(homedir(), ".config", "cursor", "skills");
-    expect(AGENT_PATHS.cursor(false, "/project")).toBe(globalPath);
-    expect(AGENT_PATHS.cursor(true, "/project")).toBe(globalPath);
+  test("cursor global uses home/.cursor/skills", () => {
+    expect(resolveTargetDir("cursor", true, "/project")).toBe(
+      join(homedir(), ".cursor/skills"),
+    );
   });
 
-  test("claude always uses global path", () => {
-    const expected = join(homedir(), ".config", "claude", "skills");
-    expect(AGENT_PATHS.claude(false, "/project")).toBe(expected);
-    expect(AGENT_PATHS.claude(true, "/project")).toBe(expected);
+  test("claude-code local uses cwd/.claude/skills", () => {
+    expect(resolveTargetDir("claude-code", false, "/project")).toBe(
+      "/project/.claude/skills",
+    );
   });
 
-  test("gemini always uses global path", () => {
-    const expected = join(homedir(), ".config", "gemini", "skills");
-    expect(AGENT_PATHS.gemini(false, "/project")).toBe(expected);
-    expect(AGENT_PATHS.gemini(true, "/project")).toBe(expected);
-  });
-
-  test("all always-global agents are in ALWAYS_GLOBAL_AGENTS set", () => {
-    for (const agent of ALWAYS_GLOBAL_AGENTS) {
-      expect(AGENT_PATHS[agent]).toBeDefined();
-    }
+  test("codex global uses codexHome/skills", () => {
+    const codexHome =
+      process.env.CODEX_HOME?.trim() ?? join(homedir(), ".codex");
+    expect(resolveTargetDir("codex", true, "/project")).toBe(
+      join(codexHome, "skills"),
+    );
   });
 });

--- a/cli/lib/install/install-skills-for-agent.ts
+++ b/cli/lib/install/install-skills-for-agent.ts
@@ -1,36 +1,12 @@
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import type { AgentType } from "../types";
 import { logger } from "../utils/logger";
 import { createSymlink } from "./create-symlink";
 import { ensureDirectory } from "./ensure-directory";
 import { getSkillName } from "./get-skill-name";
 import type { InstallOptions } from "./install-skills";
-
-export const AGENT_PATHS: Record<
-  string,
-  (isGlobal: boolean, cwd: string) => string
-> = {
-  opencode: (isGlobal: boolean, cwd: string) =>
-    isGlobal
-      ? join(homedir(), ".config", "opencode", "skills")
-      : join(cwd, ".agents", "skills"),
-  cursor: (_isGlobal: boolean) =>
-    join(homedir(), ".config", "cursor", "skills"),
-  gemini: (_isGlobal: boolean) =>
-    join(homedir(), ".config", "gemini", "skills"),
-  claude: (_isGlobal: boolean) =>
-    join(homedir(), ".config", "claude", "skills"),
-  codex: (_isGlobal: boolean) => join(homedir(), ".config", "codex", "skills"),
-};
-
-// Agents that are always global (--global flag has no effect)
-export const ALWAYS_GLOBAL_AGENTS = new Set([
-  "cursor",
-  "gemini",
-  "claude",
-  "codex",
-]);
+import { resolveTargetDir } from "./resolve-target-dir";
 
 interface AgentStats {
   installed: number;
@@ -48,13 +24,7 @@ export const installSkillsForAgent = (
 
   logger.header(`\nInstalling for ${agent}`);
 
-  if (options.global && ALWAYS_GLOBAL_AGENTS.has(agent)) {
-    logger.warning(
-      `--global has no effect for ${agent}: it always installs to ~/.config/${agent}/skills`,
-    );
-  }
-
-  const targetDir = AGENT_PATHS[agent](options.global, cwd);
+  const targetDir = resolveTargetDir(agent as AgentType, options.global, cwd);
   logger.info(`Target directory: ${targetDir}`);
 
   ensureDirectory(targetDir, options.dryRun);

--- a/cli/lib/install/install-skills.test.ts
+++ b/cli/lib/install/install-skills.test.ts
@@ -18,10 +18,7 @@ import { filterSkills } from "./filter-skills";
 import { findSkills } from "./find-skills";
 import { getSkillName } from "./get-skill-name";
 import { installSkills } from "./install-skills";
-import {
-  ALWAYS_GLOBAL_AGENTS,
-  installSkillsForAgent,
-} from "./install-skills-for-agent";
+import { installSkillsForAgent } from "./install-skills-for-agent";
 import { selectSkillsInteractively } from "./select-skills-interactively";
 
 // ---------------------------------------------------------------------------
@@ -431,10 +428,10 @@ describe(
       ).resolves.toBeUndefined();
     });
 
-    test("dry-run with gemini agent completes without error", async () => {
+    test("dry-run with gemini-cli agent completes without error", async () => {
       await expect(
         installSkills({
-          agent: ["gemini"],
+          agent: ["gemini-cli"],
           global: false,
           dryRun: true,
           interactive: false,
@@ -477,8 +474,7 @@ describe(
       expect(require("node:fs").existsSync(linkPath)).toBe(true);
     });
 
-    test("global flag with always-global agent (cursor) completes without error", async () => {
-      // cursor is in ALWAYS_GLOBAL_AGENTS; --global has no effect but should not throw
+    test("global flag with cursor agent completes without error", async () => {
       await expect(
         installSkills({
           agent: ["cursor"],
@@ -507,22 +503,13 @@ describe("installSkillsForAgent", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test("ALWAYS_GLOBAL_AGENTS contains cursor, gemini, claude, codex", () => {
-    expect(ALWAYS_GLOBAL_AGENTS.has("cursor")).toBe(true);
-    expect(ALWAYS_GLOBAL_AGENTS.has("gemini")).toBe(true);
-    expect(ALWAYS_GLOBAL_AGENTS.has("claude")).toBe(true);
-    expect(ALWAYS_GLOBAL_AGENTS.has("codex")).toBe(true);
-    expect(ALWAYS_GLOBAL_AGENTS.has("opencode")).toBe(false);
-  });
-
-  test("logs warning when --global is passed for an always-global agent", () => {
-    // Calling with global: true for cursor triggers the warning branch (line 52-54)
+  test("installSkillsForAgent with cursor and no skills returns zero stats", () => {
     const stats = installSkillsForAgent("cursor", [], tmpDir, {
+      agent: ["cursor"],
       global: true,
       dryRun: true,
       interactive: false,
     });
-    // No skills to process, stats should be zeros
     expect(stats.installed).toBe(0);
     expect(stats.skipped).toBe(0);
     expect(stats.failed).toBe(0);
@@ -548,7 +535,7 @@ describe("installSkillsForAgent", () => {
       "opencode",
       ["skills/nonexistent/skill"],
       tmpDir,
-      { global: false, dryRun: false, interactive: false },
+      { agent: ["opencode"], global: false, dryRun: false, interactive: false },
     );
     // Restore permissions before assertions
     require("node:fs").chmodSync(readonlyTarget, 0o755);
@@ -572,7 +559,7 @@ describe("installSkillsForAgent", () => {
       "opencode",
       ["skills/ci-cd/github-actions"],
       tmpDir,
-      { global: false, dryRun: false, interactive: false },
+      { agent: ["opencode"], global: false, dryRun: false, interactive: false },
     );
     expect(stats.skipped).toBe(1);
     expect(stats.failed).toBe(0);
@@ -588,7 +575,7 @@ describe("installSkillsForAgent", () => {
       "opencode",
       ["skills/ci-cd/github-actions"],
       tmpDir,
-      { global: false, dryRun: true, interactive: false },
+      { agent: ["opencode"], global: false, dryRun: true, interactive: false },
     );
     // dry-run createSymlink returns true → installed++
     expect(stats.installed).toBe(1);

--- a/cli/lib/install/install-skills.test.ts
+++ b/cli/lib/install/install-skills.test.ts
@@ -361,8 +361,25 @@ describe("installSkills", () => {
 // ---------------------------------------------------------------------------
 
 describe("selectSkillsInteractively", () => {
+  const originalIsTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+      writable: true,
+    });
+  });
+
   test("returns all skills as-is when stdin is not a TTY", async () => {
-    // In bun:test, process.stdin.isTTY is falsy so the function bypasses prompting
     const skills = [
       "skills/ci-cd/github-actions",
       "skills/infrastructure/terraform",

--- a/cli/lib/install/install-skills.ts
+++ b/cli/lib/install/install-skills.ts
@@ -1,9 +1,11 @@
+import type { AgentType } from "../types";
+import { agents } from "../types";
 import { CLIError } from "../utils/errors";
 import { logger } from "../utils/logger";
 import { displaySummary } from "./display-summary";
 import { filterSkills } from "./filter-skills";
 import { findSkills } from "./find-skills";
-import { AGENT_PATHS, installSkillsForAgent } from "./install-skills-for-agent";
+import { installSkillsForAgent } from "./install-skills-for-agent";
 import { selectSkillsInteractively } from "./select-skills-interactively";
 
 export interface InstallOptions {
@@ -19,10 +21,10 @@ export const installSkills = async (options: InstallOptions): Promise<void> => {
   const cwd = process.cwd();
 
   // Validate agents upfront before doing any work
-  const unknownAgents = options.agent.filter((a) => !AGENT_PATHS[a]);
+  const unknownAgents = options.agent.filter((a) => !agents[a as AgentType]);
   if (unknownAgents.length > 0) {
     throw new CLIError(
-      `Unknown agent(s): ${unknownAgents.join(", ")}. Valid agents: ${Object.keys(AGENT_PATHS).join(", ")}`,
+      `Unknown agent(s): ${unknownAgents.join(", ")}. Valid agents: ${Object.keys(agents).join(", ")}`,
       1,
     );
   }
@@ -54,8 +56,8 @@ export const installSkills = async (options: InstallOptions): Promise<void> => {
 
   logger.info(`Found ${skills.length} skills`);
 
-  const agents = options.agent;
-  logger.info(`Target agents: ${agents.join(", ")}`);
+  const selectedAgents = options.agent;
+  logger.info(`Target agents: ${selectedAgents.join(", ")}`);
   logger.info(`Mode: ${options.global ? "global" : "local"}`);
 
   const stats: Record<
@@ -63,9 +65,9 @@ export const installSkills = async (options: InstallOptions): Promise<void> => {
     { installed: number; skipped: number; failed: number }
   > = {};
 
-  for (const agent of agents) {
+  for (const agent of selectedAgents) {
     stats[agent] = installSkillsForAgent(agent, skills, cwd, options);
   }
 
-  displaySummary(agents, stats, options.dryRun);
+  displaySummary(selectedAgents, stats, options.dryRun);
 };

--- a/cli/lib/install/resolve-target-dir.ts
+++ b/cli/lib/install/resolve-target-dir.ts
@@ -1,0 +1,14 @@
+import { join } from "node:path";
+import type { AgentType } from "../types";
+import { agents } from "../types";
+
+export const resolveTargetDir = (
+  agent: AgentType,
+  isGlobal: boolean,
+  cwd: string,
+): string => {
+  const config = agents[agent];
+  return isGlobal
+    ? (config.globalSkillsDir ?? join(cwd, config.skillsDir))
+    : join(cwd, config.skillsDir);
+};

--- a/cli/lib/schemas/tile.schema.test.ts
+++ b/cli/lib/schemas/tile.schema.test.ts
@@ -4,14 +4,12 @@ import { TileSchema, TileSkillSchema } from "./tile.schema";
 describe("TileSkillSchema", () => {
   test("parses valid skill", () => {
     expect(() =>
-      TileSkillSchema.parse({ name: "my-skill", description: "Does things" }),
+      TileSkillSchema.parse({ path: "my-skill/SKILL.md" }),
     ).not.toThrow();
   });
 
-  test("rejects empty name", () => {
-    expect(() =>
-      TileSkillSchema.parse({ name: "", description: "x" }),
-    ).toThrow();
+  test("rejects missing path", () => {
+    expect(() => TileSkillSchema.parse({ path: "" })).toThrow();
   });
 });
 

--- a/cli/lib/schemas/tile.schema.ts
+++ b/cli/lib/schemas/tile.schema.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 
 export const TileSkillSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().min(1),
+  path: z.string().min(1),
 });
 
 export const TileSchema = z.object({
@@ -13,7 +12,7 @@ export const TileSchema = z.object({
   version: z.string().regex(/^\d+\.\d+\.\d+$/, "Version must be semver"),
   private: z.boolean().optional(),
   summary: z.string().min(1),
-  skills: z.array(TileSkillSchema).optional(),
+  skills: z.record(z.string(), TileSkillSchema).optional(),
 });
 
 export type TileData = z.infer<typeof TileSchema>;

--- a/cli/lib/tessl/review-skill.ts
+++ b/cli/lib/tessl/review-skill.ts
@@ -14,18 +14,21 @@ export const reviewSkill = async (
   if (existsSync(tileJsonPath)) {
     const rawData = await Bun.file(tileJsonPath).json();
     const tileData = TileSchema.parse(rawData);
-    const skills = tileData.skills || [];
+    const skillEntries = Object.entries(tileData.skills ?? {});
 
-    if (skills.length > 1) {
-      logger.info(`Multi-skill tile detected (${skills.length} skills)`);
-      for (const skill of skills) {
-        const skillDir = join(skillPath, skill.name);
-        logger.info(`Reviewing skill: ${skill.name}`);
+    if (skillEntries.length > 1) {
+      logger.info(`Multi-skill tile detected (${skillEntries.length} skills)`);
+      for (const [skillName, skillInfo] of skillEntries) {
+        const skillDir = join(
+          skillPath,
+          skillInfo.path.replace(/\/SKILL\.md$/, ""),
+        );
+        logger.info(`Reviewing skill: ${skillName}`);
         const { exitCode, stderr } = await exec(
           `tessl skill review ${skillDir}`,
         );
         if (exitCode !== 0) {
-          logger.error(`Review failed for ${skill.name}: ${stderr}`);
+          logger.error(`Review failed for ${skillName}: ${stderr}`);
           return false;
         }
       }

--- a/cli/lib/tessl/validate-skill-files.test.ts
+++ b/cli/lib/tessl/validate-skill-files.test.ts
@@ -14,10 +14,7 @@ afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-const writeTile = (
-  dir: string,
-  skills: { name: string; description: string }[],
-) => {
+const writeTile = (dir: string, skills: Record<string, { path: string }>) => {
   writeFileSync(
     join(dir, "tile.json"),
     JSON.stringify({
@@ -31,7 +28,7 @@ const writeTile = (
 
 describe("validateSkillFiles", () => {
   test("returns true when no skills listed", async () => {
-    writeTile(tmp, []);
+    writeTile(tmp, {});
     expect(await validateSkillFiles(tmp)).toBe(true);
   });
 
@@ -39,12 +36,12 @@ describe("validateSkillFiles", () => {
     const skillDir = join(tmp, "my-skill");
     mkdirSync(skillDir);
     writeFileSync(join(skillDir, "SKILL.md"), "---\nname: x\n---\n");
-    writeTile(tmp, [{ name: "my-skill", description: "desc" }]);
+    writeTile(tmp, { "my-skill": { path: "my-skill/SKILL.md" } });
     expect(await validateSkillFiles(tmp)).toBe(true);
   });
 
   test("returns false when a skill SKILL.md is missing", async () => {
-    writeTile(tmp, [{ name: "missing-skill", description: "desc" }]);
+    writeTile(tmp, { "missing-skill": { path: "missing-skill/SKILL.md" } });
     expect(await validateSkillFiles(tmp)).toBe(false);
   });
 });

--- a/cli/lib/tessl/validate-skill-files.ts
+++ b/cli/lib/tessl/validate-skill-files.ts
@@ -9,14 +9,16 @@ export const validateSkillFiles = async (
   const tileJsonPath = join(tilePath, "tile.json");
   const rawData = await Bun.file(tileJsonPath).json();
   const tileData = TileSchema.parse(rawData);
-  const skillsList = tileData.skills || [];
+  const skillsMap = tileData.skills ?? {};
 
   let allValid = true;
 
-  for (const skill of skillsList) {
-    const skillMdPath = join(tilePath, skill.name, "SKILL.md");
+  for (const [skillName, skillInfo] of Object.entries(skillsMap)) {
+    const skillMdPath = join(tilePath, skillInfo.path);
     if (!existsSync(skillMdPath)) {
-      logger.error(`Missing SKILL.md for skill: ${skill.name}`);
+      logger.error(
+        `Missing SKILL.md for skill "${skillName}": ${skillInfo.path}`,
+      );
       allValid = false;
     }
   }

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,0 +1,8 @@
+module.exports = {
+  default: {
+    paths: ["cli/features/**/*.feature"],
+    require: ["cli/features/step-definitions/**/*.ts"],
+    requireModule: ["tsx"],
+    format: ["progress"],
+  },
+};

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -41,6 +41,6 @@ pre-commit:
 pre-push:
   commands:
     unit-tests:
-      run: bun test
+      run: bun test cli/
     integration-tests:
       run: bunx cucumber-js

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -37,3 +37,10 @@ pre-commit:
       glob: "cli/**/*.ts"
       run: bun cli/scripts/validate-ts-conventions.ts {staged_files}
       stage_fixed: false
+
+pre-push:
+  commands:
+    unit-tests:
+      run: bun test
+    integration-tests:
+      run: bunx cucumber-js

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "tessl:lint": "tessl skill lint",
     "tessl:publish": "tessl skill publish",
     "tessl:review": "tessl skill review",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "bun test",
+    "test:integration": "cucumber-js"
   },
   "keywords": [],
   "author": "",
@@ -36,11 +37,13 @@
   "type": "commonjs",
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
+    "@cucumber/cucumber": "^11.0.0",
     "@types/bun": "latest",
     "@types/js-yaml": "^4.0.9",
     "lefthook": "^2.1.1",
     "markdownlint-cli2": "^0.21.0",
-    "tessl": "^0.68.0"
+    "tessl": "^0.68.0",
+    "tsx": "^4.0.0"
   },
   "dependencies": {
     "@cliffy/command": "npm:@jsr/cliffy__command",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tessl:lint": "tessl skill lint",
     "tessl:publish": "tessl skill publish",
     "tessl:review": "tessl skill review",
-    "test": "bun test",
+    "test": "bun test cli/",
     "test:integration": "cucumber-js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary

  - Adds Cucumber/Gherkin integration tests covering all 6 CLI commands (`validate`,
    `install`, `audit`, `readme`, `sync`, `tessl`) with 28 scenarios / 111 steps
  - Expands `install` scenarios to include domain/subdomain filtering, multi-agent
    installs, and a local vs global install matrix
  - Wires the `install` command's agent validation and enum to the canonical
    `cli/lib/types/agents.ts` registry (42 agents), removing the old hardcoded map
  - Fixes `tile.schema.ts` to use `z.record(z.string(), TileSkillSchema)` so the
    skills field matches the actual tile.json format
  - Adds a `pre-push` lefthook running unit tests and integration tests before any push
  - Adds a `pr-cli-tests.yml` GitHub Actions workflow with parallel unit + integration
    test jobs triggered on PRs that touch `cli/**`

  ## Test plan

  - [ ] Unit tests pass: `bun test cli/` → 289 pass, 0 fail
  - [ ] Integration tests pass: `bunx cucumber-js` → 28 scenarios, 111 steps, all green
  - [ ] Pre-push hook blocks on test failure (verified locally)
  - [ ] GitHub Actions workflow triggers on this PR