### PR TITLE
feat(planning-toolkit): add wave-executor skill and extend wave format with Model column

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ domain knowledge, workflows, and best practices that can be loaded on-demand.
 ## Skill Catalog
 
 <!-- skill-catalog-stats -->
-Browse all **96 skills across 55 tiles** in the [Skill Catalog](https://pantheon-org.github.io/tekhne/tiles/).
+Browse all **97 skills across 55 tiles** in the [Skill Catalog](https://pantheon-org.github.io/tekhne/tiles/).
 
 ## CLI Tool
 

--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -603,14 +603,15 @@ Planning & organization
 
 ### planning-toolkit
 
-End-to-end project planning toolkit: converts requirements into structured phased implementation plans, groups phases into dependency-ordered waves for parallel subagent execution, and decomposes large branches into focused pull requests.
+End-to-end project planning toolkit: converts requirements into structured phased implementation plans, groups phases into dependency-ordered waves for parallel subagent execution, executes wave plans by spawning parallel agents with correct model tiers, and decomposes large branches into focused pull requests.
 
 **Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/planning-toolkit) | **Version:** 1.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [implementation-planner](/tekhne/skills/project-mgmt/planning-toolkit/implementation-planner/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-06 | 5 |
-| [wave-execution-planner](/tekhne/skills/project-mgmt/planning-toolkit/wave-execution-planner/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 6 |
+| [wave-execution-planner](/tekhne/skills/project-mgmt/planning-toolkit/wave-execution-planner/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 7 |
+| [wave-executor](/tekhne/skills/project-mgmt/planning-toolkit/wave-executor/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
 | [pr-stacker](/tekhne/skills/project-mgmt/planning-toolkit/pr-stacker/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 5 |
 
 ### create-context-file

--- a/skills/project-mgmt/planning-toolkit/tile.json
+++ b/skills/project-mgmt/planning-toolkit/tile.json
@@ -2,13 +2,16 @@
   "name": "pantheon-ai/planning-toolkit",
   "version": "1.0.0",
   "private": false,
-  "summary": "End-to-end project planning toolkit: converts requirements into structured phased implementation plans, groups phases into dependency-ordered waves for parallel subagent execution, and decomposes large branches into focused pull requests.",
+  "summary": "End-to-end project planning toolkit: converts requirements into structured phased implementation plans, groups phases into dependency-ordered waves for parallel subagent execution, executes wave plans by spawning parallel agents with correct model tiers, and decomposes large branches into focused pull requests.",
   "skills": {
     "implementation-planner": {
       "path": "implementation-planner/SKILL.md"
     },
     "wave-execution-planner": {
       "path": "wave-execution-planner/SKILL.md"
+    },
+    "wave-executor": {
+      "path": "wave-executor/SKILL.md"
     },
     "pr-stacker": {
       "path": "pr-stacker/SKILL.md"

--- a/skills/project-mgmt/planning-toolkit/wave-execution-planner/evals/scenario-7/capability.txt
+++ b/skills/project-mgmt/planning-toolkit/wave-execution-planner/evals/scenario-7/capability.txt
@@ -1,0 +1,1 @@
+include-model-column-in-wave-document

--- a/skills/project-mgmt/planning-toolkit/wave-execution-planner/evals/scenario-7/criteria.json
+++ b/skills/project-mgmt/planning-toolkit/wave-execution-planner/evals/scenario-7/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Agent was asked to create a wave document for a research consolidation with tasks of clearly different complexity. Evaluate whether the Model column is present and whether tier assignments are appropriate.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "model-column-present-in-all-wave-tables",
+      "description": "Every wave table in the document includes a Model column",
+      "max_score": 15
+    },
+    {
+      "name": "triage-phases-assigned-sonnet",
+      "description": "All 6 triage phases (skill-driven, template output) are assigned 'sonnet' in the Model column",
+      "max_score": 20
+    },
+    {
+      "name": "synthesis-phase-assigned-opus",
+      "description": "The synthesis phase (cross-document analysis, high judgment) is assigned 'opus' in the Model column",
+      "max_score": 20
+    },
+    {
+      "name": "consolidation-phase-assigned-haiku",
+      "description": "The consolidation pass (PUNCHLIST flip, script run) is assigned 'haiku' in the Model column",
+      "max_score": 20
+    },
+    {
+      "name": "cleanup-phase-assigned-haiku",
+      "description": "The cleanup audit phase (lint, consistency check) is assigned 'haiku' in the Model column",
+      "max_score": 15
+    },
+    {
+      "name": "document-written-to-correct-path",
+      "description": "The wave document is written to .context/plans/research-consolidation.md",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/project-mgmt/planning-toolkit/wave-execution-planner/evals/scenario-7/task.md
+++ b/skills/project-mgmt/planning-toolkit/wave-execution-planner/evals/scenario-7/task.md
@@ -1,0 +1,29 @@
+# Task: Create a wave plan for a research consolidation
+
+Create a wave execution plan for the following research project.
+Write the wave document to `.context/plans/research-consolidation.md`.
+
+## Requirements
+
+The team needs to:
+
+1. **Triage 6 new tools** — each tool gets its own branch and uses the `triage-tool` skill
+   to produce a structured `references/{slug}.md`. These are independent of each other.
+
+2. **Write a cross-cutting synthesis** — after triage is done, one agent reads all 6
+   `references/{slug}.md` files and extracts common patterns into an `ANALYSIS.md`
+   Key Themes section. This is high-judgment work requiring deep comparison.
+
+3. **Run a consolidation pass** — flip PUNCHLIST markers from `[ ]` to `[x]`,
+   add REVIEWED.md rows for all new tools, run `python scripts/build_reference_index.py`.
+   Mechanical; script-driven.
+
+4. **Cleanup audit** — run lint, check consistency (no orphaned files, no stale markers),
+   commit the result. Entirely mechanical.
+
+## Constraints
+
+- Steps 1 (triage) can all run in parallel.
+- Steps 2 (synthesis) and 3 (consolidation) both depend on step 1 but are independent of each other.
+- Step 4 (cleanup) depends on steps 2 and 3.
+- Use one branch per parallel workstream.

--- a/skills/project-mgmt/planning-toolkit/wave-execution-planner/references/wave-document.yaml
+++ b/skills/project-mgmt/planning-toolkit/wave-execution-planner/references/wave-document.yaml
@@ -49,9 +49,9 @@ sections:
 
     > Gate: None — start immediately.
 
-    | Phase | Focus | Tasks | Status |
-    |-------|-------|-------|--------|
-    | [<N>](<phase-N-slug>.md) | <3–6 word description> | <count> | Pending |
+    | Phase | Focus | Tasks | Status | Model |
+    |-------|-------|-------|--------|-------|
+    | [<N>](<phase-N-slug>.md) | <3–6 word description> | <count> | Pending | sonnet |
 
     Verification:
     - [ ] <command or observable check>
@@ -63,9 +63,9 @@ sections:
 
     > Gate: Wave 1 verified ✓
 
-    | Phase | Focus | Tasks | Status |
-    |-------|-------|-------|--------|
-    | [<N>](<phase-N-slug>.md) | <3–6 word description> | <count> | Pending |
+    | Phase | Focus | Tasks | Status | Model |
+    |-------|-------|-------|--------|-------|
+    | [<N>](<phase-N-slug>.md) | <3–6 word description> | <count> | Pending | sonnet |
 
     Verification:
     - [ ] <command or observable check>

--- a/skills/project-mgmt/planning-toolkit/wave-execution-planner/references/wave-format.md
+++ b/skills/project-mgmt/planning-toolkit/wave-execution-planner/references/wave-format.md
@@ -39,9 +39,9 @@ Use the plan slug from the requirements or a short descriptive identifier (e.g. 
 
 > <Gate note: what must be true before this wave starts. "None — start immediately" for Wave 1.>
 
-| Phase | Focus | Tasks | Status |
-|-------|-------|-------|--------|
-| [N](phase-N-<slug>.md) | <description> | <count> | Pending |
+| Phase | Focus | Tasks | Status | Model |
+|-------|-------|-------|--------|-------|
+| [N](phase-N-<slug>.md) | <description> | <count> | Pending | sonnet |
 
 Verification:
 - [ ] <command or check that must pass before Wave 2 starts>
@@ -77,6 +77,7 @@ Merge order: <branch A> → <branch B> → ...
 - **Status values**: `Pending` → `In Progress` → `Done`
 - Add a `> Gate:` blockquote at the top of each wave (except Wave 1).
 - Add a `Verification:` checklist at the bottom of each wave.
+- **Model column** (optional): specifies the agent model tier for each phase. Valid values: `haiku`, `sonnet`, `opus`. Omit the column or leave a cell blank to default to `sonnet`. See the `wave-executor` skill for how this value is used at execution time.
 
 ## Phase row format
 
@@ -86,6 +87,7 @@ Merge order: <branch A> → <branch B> → ...
 | Focus | 3–6 word description of what the phase accomplishes |
 | Tasks | Integer count of discrete tasks inside the phase |
 | Status | `Pending` / `In Progress` / `Done` |
+| Model | *(optional)* `haiku` / `sonnet` / `opus` — agent model tier. Defaults to `sonnet` if omitted. |
 
 If the plan has no separate phase files, use task IDs directly (e.g. `T1.1`, `T2.3`).
 
@@ -101,10 +103,10 @@ Use this for smaller plans where phases are not broken into separate files:
 Run **T1.1–T1.4 in parallel, each in its own worktree.**
 Each agent works independently; tasks touch different files with no overlap.
 
-- [ ] **T1.1** — `scripts/lib/http.ts` — branch `refactor/scripts-lib-http`
-- [ ] **T1.2** — `scripts/lib/dates.ts` — branch `refactor/scripts-lib-dates`
-- [ ] **T1.3** — `scripts/lib/wikidata.ts` — branch `refactor/scripts-lib-wikidata`
-- [ ] **T1.4** — `scripts/lib/paths.ts` — branch `refactor/scripts-lib-paths`
+- [ ] **T1.1** — `scripts/lib/http.ts` — branch `refactor/scripts-lib-http` — model: `haiku`
+- [ ] **T1.2** — `scripts/lib/dates.ts` — branch `refactor/scripts-lib-dates` — model: `sonnet`
+- [ ] **T1.3** — `scripts/lib/wikidata.ts` — branch `refactor/scripts-lib-wikidata` — model: `sonnet`
+- [ ] **T1.4** — `scripts/lib/paths.ts` — branch `refactor/scripts-lib-paths` — model: `haiku`
 
 **Wave 1 merge**: after all branches pass validation, merge in order:
 `refactor/scripts-lib-http` → `refactor/scripts-lib-dates` → `refactor/scripts-lib-wikidata` → `refactor/scripts-lib-paths`
@@ -113,6 +115,8 @@ Verification:
 - [ ] All merged; `main` CI green
 - [ ] No direct imports of old paths remain
 ```
+
+The `— model: haiku|sonnet|opus` suffix is optional on inline tasks. Omit it to default to `sonnet`.
 
 ## Dependency graph format
 

--- a/skills/project-mgmt/planning-toolkit/wave-executor/SKILL.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: wave-executor
+description: "Execute a wave-based plan by spawning parallel agents per wave, enforcing merge gates, and building self-contained per-agent prompts from wave document rows. Use when asked to: run the plan, execute the plan, start the waves, launch agents, execute wave N, run wave execution. Reads a wave document produced by wave-execution-planner."
+allowed-tools: Read, Bash, Agent
+---
+
+# Wave Executor
+
+Execute a wave document by spawning parallel agents per wave, pausing at merge gates, and verifying each wave before advancing.
+
+## When to Use
+
+- User says "run the plan", "execute the plan", "start wave N", "launch the agents"
+- A wave document exists at `.context/plans/<slug>.md`
+- The plan was produced by `wave-execution-planner` (or follows the same format)
+
+## When Not to Use
+
+- No wave document exists — run `wave-execution-planner` (Mode A) first
+- The user wants to update wave status only — use `wave-execution-planner` (Mode B) instead
+- The plan has only 1–2 sequential tasks with no parallelism — just run them directly
+
+## Workflow
+
+### 1. Locate the plan
+
+Ask for the plan slug if not provided. Load `.context/plans/<slug>.md`.
+
+Read the full document. Identify all waves in order and their current status. Skip waves already marked `— DONE`.
+
+### 2. For each pending wave — execute the loop
+
+Repeat steps 2a–2g for every wave that is not `— DONE`, in order.
+
+#### 2a. Check the gate
+
+Read the `> Gate:` blockquote at the top of the wave. If it requires a prior wave to be verified, confirm that wave's `Verification:` checklist is fully ticked (`[x]`). If not, stop and report the unmet gate to the user.
+
+#### 2b. Extract phases
+
+Parse the wave table or inline task list. For each row / item capture:
+
+- **branch** — the branch name. In phase tables: the phase identifier (use as branch if no explicit branch). In inline tasks: the value after `— branch`.
+- **focus** — the task description (Focus column, or phase file content if linked).
+- **model** — the `Model` column value, or `— model:` suffix on inline tasks. Default: `sonnet` if absent.
+- **writes** — if a `Writes` column or `— writes:` annotation is present, capture it. Otherwise derive from the phase file, or leave unspecified and let the agent determine scope from the focus.
+
+#### 2c. Build per-agent prompts
+
+Read `references/per-agent-template.md`.
+
+For each phase, fill the template slots with the values from step 2b. Append the model-tier addition from `references/model-tier-guide.md` matching the phase's `model` value.
+
+**Do not paraphrase the focus / task description. Copy it verbatim.**
+
+If the phase links to a phase file, read that file and include its full content under "Your task" rather than only the Focus cell value.
+
+#### 2d. Spawn agents in parallel
+
+Send a **single response** containing one `Agent` tool call per unblocked phase.
+
+Each call must set:
+- `subagent_type`: `"general-purpose"`
+- `model`: the exact tier string from step 2b (`"haiku"` / `"sonnet"` / `"opus"`)
+- `isolation`: `"worktree"` for all phases that commit to a branch (omit for phases that commit directly to main)
+- `description`: `"Wave N: <branch>"`
+- `prompt`: the filled per-agent prompt from step 2c
+
+#### 2e. Wait for all agents to complete
+
+Do not proceed until every agent in the wave has returned.
+
+#### 2f. STOP — merge gate
+
+After all agents complete, report to the user:
+
+> "Wave N agents done. Please merge the following branches to `main` before I continue:
+> [list branches]
+>
+> Then run the Verification checklist for this wave (copied below) and reply **'verified'** when all checks pass."
+
+Copy the wave's `Verification:` checklist verbatim into your message so the user can run each item.
+
+Wait for the user to reply before continuing.
+
+#### 2g. Update wave status and advance
+
+After the user confirms verification:
+
+1. Run `wave-execution-planner` Mode B on the wave document to tick the verification checkboxes and mark the wave `— DONE`.
+2. Report which wave is now unblocked.
+3. Continue the loop with the next wave.
+
+### 3. Report completion
+
+After all waves are done:
+- Summarise what was executed (waves, branches, agents).
+- Confirm the plan's `**Status**` field is set to `Complete`.
+- List any decisions or blockers flagged by agents during execution.
+
+## Anti-Patterns
+
+### NEVER paraphrase the task description
+
+**WHY**: Information loss — the verbatim focus or phase file contains constraints, tool names, and scope boundaries that summaries drop.
+
+**BAD** Summarise "Triage Mem0, Zep, MemoryOS, Letta via `tessl__triage-tool`" as "triage memory tools".
+**GOOD** Copy the full text verbatim into the per-agent prompt.
+
+### NEVER omit the `model` parameter on Agent calls
+
+**WHY**: Omitting it silently defaults to the orchestrator's model. For `haiku`-tier mechanical tasks, this wastes significant cost with no quality benefit.
+
+**BAD** `Agent(subagent_type="general-purpose", prompt=...)` with no `model`.
+**GOOD** `Agent(model="haiku", ...)` as specified in the wave document.
+
+### NEVER start the next wave before the gate passes
+
+**WHY**: Consolidation agents read files written by prior waves. Unmerged branches mean stale reads and incorrect output that is hard to detect.
+
+**BAD** Proceed to Wave N+1 as soon as Wave N agents return their results.
+**GOOD** STOP, ask the user to merge and verify, confirm gate before advancing.
+
+### NEVER spawn wave agents sequentially
+
+**WHY**: Defeats the parallelism that wave planning was designed to achieve.
+
+**BAD** Spawn one agent, wait for it, then spawn the next.
+**GOOD** Send a single response with all parallel agents in one message.
+
+### NEVER spawn agents for phases blocked by unmet dependencies
+
+**WHY**: A phase that needs a prior branch merged will read stale state and produce incorrect output.
+
+**BAD** Spawn `feat/synthesis` before `feat/rubric` is merged (it's in the `Blocked on` note).
+**GOOD** Check each phase's gate / blocked-on annotation; skip and report blocked phases.
+
+## References
+
+- [Per-agent prompt template](references/per-agent-template.md) — fill for every spawned agent
+- [Model tier guide](references/model-tier-guide.md) — when to use haiku / sonnet / opus
+- Wave format spec — defined in the `wave-execution-planner` skill (`wave-execution-planner/references/wave-format.md`)
+- Status tracking protocol — defined in the `wave-execution-planner` skill (`wave-execution-planner/references/status-tracking.md`); used in step 2g

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/capability.txt
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+spawn-parallel-agents-for-wave

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/criteria.json
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/criteria.json
@@ -1,0 +1,46 @@
+{
+  "context": "Agent was asked to execute Wave 0 of an auth migration plan. Evaluate whether it spawned agents correctly.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "all-three-agents-spawned",
+      "description": "Three Agent tool calls were made, one for feat/schema, one for feat/tokens, and one for feat/session",
+      "max_score": 15
+    },
+    {
+      "name": "agents-spawned-in-single-message",
+      "description": "All three Agent calls appear in a single response (parallel), not across separate sequential messages",
+      "max_score": 20
+    },
+    {
+      "name": "worktree-isolation-set",
+      "description": "Each Agent call sets isolation: 'worktree' (or equivalent parameter indicating branch isolation)",
+      "max_score": 15
+    },
+    {
+      "name": "correct-model-feat-schema",
+      "description": "The Agent call for feat/schema uses model: 'sonnet'",
+      "max_score": 10
+    },
+    {
+      "name": "correct-model-feat-tokens",
+      "description": "The Agent call for feat/tokens uses model: 'sonnet'",
+      "max_score": 10
+    },
+    {
+      "name": "correct-model-feat-session",
+      "description": "The Agent call for feat/session uses model: 'haiku'",
+      "max_score": 10
+    },
+    {
+      "name": "task-description-not-paraphrased",
+      "description": "Each agent prompt includes the Focus cell text verbatim (e.g. 'Add new auth schema columns'), not a reworded summary",
+      "max_score": 10
+    },
+    {
+      "name": "stops-after-agents-complete",
+      "description": "After spawning agents, the skill does not immediately proceed to Wave 1 — it waits for agent results and then stops to ask for merge confirmation",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/task.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/task.md
@@ -1,0 +1,31 @@
+# Task: Execute Wave 0 of an auth migration plan
+
+The wave document for an auth migration lives at `.context/plans/auth-migration.md`.
+Execute Wave 0.
+
+## Wave document excerpt
+
+```markdown
+# Auth Migration
+
+**Ticket / ref**: PLAT-412
+**Status**: Pending
+**Assignee**: platform team
+
+## Waves & Phases
+
+### Wave 0 — Bootstrap (parallel)
+
+> Gate: None — start immediately.
+
+| Phase | Focus | Tasks | Status | Model |
+|-------|-------|-------|--------|-------|
+| `feat/schema` | Add new auth schema columns | 2 | Pending | sonnet |
+| `feat/tokens` | Implement token generation service | 3 | Pending | sonnet |
+| `feat/session` | Scaffold session store interface | 2 | Pending | haiku |
+
+Verification:
+- [ ] All three branches merged to `main`
+- [ ] `tsc --noEmit` exits 0 on `main`
+- [ ] No references to the old auth schema remain in migration files
+```

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/capability.txt
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+assign-correct-model-tier-per-phase

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/criteria.json
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Agent was asked to execute a wave with mixed model tiers and one phase with no Model value. Evaluate whether model assignments are correct and the default is applied.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "haiku-for-delete-scripts",
+      "description": "The Agent call for feat/delete-scripts uses model: 'haiku'",
+      "max_score": 15
+    },
+    {
+      "name": "opus-for-cross-analysis",
+      "description": "The Agent call for feat/cross-analysis uses model: 'opus'",
+      "max_score": 15
+    },
+    {
+      "name": "sonnet-for-update-docs",
+      "description": "The Agent call for feat/update-docs uses model: 'sonnet'",
+      "max_score": 15
+    },
+    {
+      "name": "sonnet-default-for-index-rebuild",
+      "description": "The Agent call for feat/index-rebuild uses model: 'sonnet' (the default when Model cell is blank)",
+      "max_score": 20
+    },
+    {
+      "name": "all-four-agents-spawned-in-parallel",
+      "description": "All four Agent calls appear in a single response (parallel spawning)",
+      "max_score": 15
+    },
+    {
+      "name": "no-model-override-or-substitution",
+      "description": "No agent is given a model tier that differs from what is specified in the wave document (e.g. haiku phase does not receive sonnet or opus)",
+      "max_score": 20
+    }
+  ]
+}

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/task.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/task.md
@@ -1,0 +1,31 @@
+# Task: Execute a wave with mixed model tiers
+
+The wave document at `.context/plans/data-pipeline.md` has a single wave with phases
+spanning all three model tiers, plus one phase with no Model value specified.
+
+Execute Wave 1.
+
+## Wave document excerpt
+
+```markdown
+# Data Pipeline Overhaul
+
+**Status**: Pending
+
+## Waves & Phases
+
+### Wave 1 — Analysis and cleanup (parallel)
+
+> Gate: None — start immediately.
+
+| Phase | Focus | Tasks | Status | Model |
+|-------|-------|-------|--------|-------|
+| `feat/delete-scripts` | Delete deprecated sync scripts | 1 | Pending | haiku |
+| `feat/cross-analysis` | Write cross-cutting analysis from 8 source files | 1 | Pending | opus |
+| `feat/update-docs` | Update API reference tables | 2 | Pending | sonnet |
+| `feat/index-rebuild` | Run index rebuild and verify output | 1 | Pending | |
+
+Verification:
+- [ ] All four branches merged to `main`
+- [ ] No references to deprecated scripts remain
+```

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-3/capability.txt
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+stop-at-merge-gate-after-wave-completes

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-3/criteria.json
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-3/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "Wave 0 agents have all completed. Agent must stop, ask for merge confirmation, and provide the Verification checklist before advancing to Wave 1. Evaluate whether the merge gate is correctly enforced.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "does-not-spawn-wave-1-immediately",
+      "description": "The agent does NOT spawn a Wave 1 Agent call in its response — it explicitly stops before doing so",
+      "max_score": 25
+    },
+    {
+      "name": "asks-user-to-merge-branches",
+      "description": "The response asks the user to merge the three Wave 0 branches (feat/remove-terraform, feat/update-consumers, feat/cleanup-vars) to main before proceeding",
+      "max_score": 20
+    },
+    {
+      "name": "verification-checklist-provided",
+      "description": "The response includes the Wave 0 Verification checklist items verbatim so the user knows what to run before confirming",
+      "max_score": 20
+    },
+    {
+      "name": "waits-for-user-confirmation",
+      "description": "The response explicitly states it will wait for user confirmation (e.g. 'reply verified when done') before starting Wave 1",
+      "max_score": 20
+    },
+    {
+      "name": "lists-all-three-branches",
+      "description": "All three branch names (feat/remove-terraform, feat/update-consumers, feat/cleanup-vars) are listed in the merge request",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-3/task.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-3/task.md
@@ -1,0 +1,50 @@
+# Task: Wave 0 agents have finished — what happens next?
+
+You have been executing the plan at `.context/plans/infra-cleanup.md`.
+Wave 0 agents for all three branches have returned their results.
+The user is asking what comes next.
+
+## Wave document excerpt
+
+```markdown
+# Infra Cleanup
+
+**Status**: In Progress
+
+## Waves & Phases
+
+### Wave 0 — Remove legacy resources (parallel) — IN PROGRESS
+
+> Gate: None — start immediately.
+
+| Phase | Focus | Tasks | Status | Model |
+|-------|-------|-------|--------|-------|
+| `feat/remove-terraform` | Delete deprecated Terraform modules | 3 | In Progress | sonnet |
+| `feat/update-consumers` | Update all consumers of removed modules | 2 | In Progress | sonnet |
+| `feat/cleanup-vars` | Remove orphaned Terraform variables | 1 | In Progress | haiku |
+
+Verification:
+- [ ] All three branches merged to `main`
+- [ ] `terraform plan` exits 0 on `main` with no unexpected changes
+- [ ] No references to `legacy_*` remain in any `.tf` file
+
+### Wave 1 — Documentation and audit (sequential)
+
+> Gate: Wave 0 verified ✓
+
+| Phase | Focus | Tasks | Status | Model |
+|-------|-------|-------|--------|-------|
+| `feat/update-docs` | Update runbook and architecture diagrams | 2 | Pending | sonnet |
+
+Verification:
+- [ ] Runbook updated; diagrams reflect removed modules
+```
+
+## Agent results
+
+All three Wave 0 agents have completed and reported their work:
+- `feat/remove-terraform`: Deleted 4 deprecated modules; changes committed.
+- `feat/update-consumers`: Updated 6 consumer references; changes committed.
+- `feat/cleanup-vars`: Removed 11 orphaned variables; changes committed.
+
+What should happen next?

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-4/capability.txt
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-4/capability.txt
@@ -1,0 +1,1 @@
+skip-blocked-phases-and-report

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-4/criteria.json
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-4/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "Wave 1 has three phases. feat/synthesis is blocked on feat/rubric which is not yet merged. feat/consolidate and feat/benchmark-decision are unblocked. Evaluate whether the agent correctly skips the blocked phase and spawns only the unblocked ones.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "feat-synthesis-not-spawned",
+      "description": "No Agent call is made for feat/synthesis — it is correctly identified as blocked",
+      "max_score": 25
+    },
+    {
+      "name": "feat-consolidate-spawned",
+      "description": "An Agent call is made for feat/consolidate with model: 'haiku'",
+      "max_score": 20
+    },
+    {
+      "name": "feat-benchmark-decision-spawned",
+      "description": "An Agent call is made for feat/benchmark-decision with model: 'sonnet'",
+      "max_score": 20
+    },
+    {
+      "name": "unblocked-agents-spawned-in-parallel",
+      "description": "The two unblocked Agent calls (feat/consolidate and feat/benchmark-decision) appear in a single parallel response",
+      "max_score": 15
+    },
+    {
+      "name": "blocked-phase-reported-to-user",
+      "description": "The response clearly reports that feat/synthesis is blocked on feat/rubric not being merged, and states what is needed to unblock it",
+      "max_score": 20
+    }
+  ]
+}

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-4/task.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-4/task.md
@@ -1,0 +1,29 @@
+# Task: Execute Wave 1 where one phase is blocked
+
+Execute Wave 1 of the plan at `.context/plans/research-gap.md`.
+Wave 0 has been verified. However, not all Wave 0 branches have been merged yet.
+
+## Merged Wave 0 branches (confirmed on main)
+
+- `feat/triage-memory` ✓
+- `feat/triage-rag` ✓
+- `feat/triage-conv` ✓
+- `feat/academic-sweep` ✓
+
+## NOT yet merged
+
+- `feat/rubric` — still in review
+
+## Wave document excerpt
+
+```markdown
+### Wave 1 — Consolidate + Synthesise (parallel)
+
+> Gate: Wave 0 verified ✓
+
+| Phase | Focus | Tasks | Status | Writes | Blocked on | Model |
+|-------|-------|-------|--------|--------|------------|-------|
+| `feat/synthesis` | Write Key Themes section from 14 analysis files | 1 | Pending | `ANALYSIS.md` | `feat/rubric` merged | opus |
+| `feat/consolidate` | Flip PUNCHLIST, add REVIEWED rows, sync index | 3 | Pending | `REVIEWED.md`, `PUNCHLIST.md`, `REFERENCE_INDEX.md` | all Wave 0 triage branches merged | haiku |
+| `feat/benchmark-decision` | Resolve HELMET and LongBench disposition | 1 | Pending | `REVIEWED.md` | — | sonnet |
+```

--- a/skills/project-mgmt/planning-toolkit/wave-executor/references/model-tier-guide.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/references/model-tier-guide.md
@@ -1,0 +1,75 @@
+# Model Tier Guide
+
+The `Model` column in the wave document is the authoritative assignment.
+This guide explains the reasoning so you can judge edge cases and unlisted tasks.
+
+---
+
+## Tiers
+
+### haiku — mechanical operations
+
+Use when the task is fully determined by explicit instructions with no judgment calls.
+
+Characteristics:
+- Follows a checklist or script step-by-step
+- Output is verifiable against a known structure (rows added, files exist, exit codes)
+- No synthesis across multiple documents required
+- Failure mode: "step missed", not "wrong interpretation"
+
+Examples:
+- Pre-populating index files with a known list of items
+- Running sync/build scripts and verifying exit codes
+- Flipping status markers in a tracking file
+- Lint and consistency audit passes
+
+---
+
+### sonnet — structured output with bounded judgment
+
+Use when the task drives a skill or fills a template and the output format is pre-defined.
+Judgment is required but constrained to a small, known decision space.
+
+Characteristics:
+- Uses a tool or skill with a defined output schema
+- Must choose between a small set of options (e.g. promote / skip / flag)
+- Output quality matters but format is fixed and verifiable
+- Failure mode: "wrong choice in a known decision tree"
+
+Examples:
+- Triage tasks driven by `triage-tool` or `triage-paper` skills
+- Writing documents that follow a fixed template (rubrics, configuration files)
+- Binary decisions with a defined rationale format
+- Consolidation passes that add rows to existing tables from already-written sources
+
+---
+
+### opus — open-ended synthesis or deep evidence evaluation
+
+Use when the task requires reading multiple documents, reconciling conflicting evidence,
+or producing analysis whose quality cannot be checked against a schema.
+
+Characteristics:
+- Must draw cross-cutting conclusions from N source files
+- Evidence may be absent, weak, or contradictory — requires explicit acknowledgment
+- Output quality is judged on depth and accuracy, not format compliance
+- Failure mode: "shallow or confident-sounding but unsupported analysis"
+
+Examples:
+- Extracting cross-cutting themes from a set of analysis documents
+- Per-item deep analysis with evidence evaluation and rubric scoring
+- Writing synthesis sections that require comparing multiple sources
+
+---
+
+## Default
+
+Omitting the `Model` column or leaving a cell blank defaults to **`sonnet`**.
+
+## Decision rule for unlisted tasks
+
+Ask: "Could a `haiku` agent complete this correctly by following explicit steps?"
+
+- Yes → `haiku`
+- No, but the output format is defined and the decision space is small → `sonnet`
+- No, and the output quality depends on synthesis across documents → `opus`

--- a/skills/project-mgmt/planning-toolkit/wave-executor/references/per-agent-template.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/references/per-agent-template.md
@@ -1,0 +1,140 @@
+# Per-Agent Prompt Template
+
+Fill the `{slots}` from the wave document phase row before passing to the `Agent` tool.
+Append the model-tier addition from `model-tier-guide.md`.
+Do not include these instructions in the actual prompt.
+
+---
+
+## Template
+
+```
+You are working in the {repo} repository.
+
+## Your task
+
+{focus — copy verbatim from the wave document Focus cell or phase file. Do not summarise.}
+
+## Writes scope
+
+{If a Writes column or phase file specifies scope, state it here:}
+You may only write to:
+{writes}
+
+{If no writes scope is specified, use:}
+Limit your changes to files directly related to your task. Do not modify shared
+index files, changelogs, or summary documents unless your task explicitly names them.
+
+## Isolation
+
+Other agents may be running in parallel in separate worktrees.
+Only touch files within your writes scope.
+Do not read files owned by another concurrent agent's worktree — this causes merge conflicts.
+
+## When done
+
+Verify:
+1. Every file you created or modified exists and is non-empty.
+2. Any script or command named in your task ran without error.
+3. No file outside your writes scope was modified — check with: git diff --name-only
+
+Report:
+- Files written (exact paths).
+- Any decision or assumption you had to make.
+- Any blocker that prevented full completion.
+
+{model_tier_addition}
+```
+
+---
+
+## Model-tier additions
+
+Replace `{model_tier_addition}` with the block matching the phase's `Model` value.
+
+### haiku
+
+```
+Work mechanically. Follow each step in the task description in order.
+Do not infer, expand, or improve beyond the stated scope.
+If any step is ambiguous, take the most conservative interpretation and note it in your report.
+```
+
+### sonnet
+
+```
+Use the skill or script named in your task. Follow its output format exactly.
+Verify that any file you produced matches the expected structure before reporting done.
+If the skill requires a confirmation sub-step, take the default/conservative option and note it.
+```
+
+### opus
+
+```
+You may read any existing file in the repo to inform your analysis.
+Cite every file you read by path. If evidence is weak, contradictory, or absent, say so
+explicitly — do not hedge silently or fill gaps with plausible-sounding inference.
+Depth and accuracy matter more than speed.
+```
+
+---
+
+## Worked example
+
+Wave document row (phase table, Wave 0):
+
+| Phase | Focus | Tasks | Status | Model |
+|-------|-------|-------|--------|-------|
+| `feat/triage-memory` | Triage Mem0, Zep, MemoryOS, Letta via `tessl__triage-tool` | 4 | Pending | sonnet |
+
+Filled prompt:
+
+```
+You are working in the agentic-context repository.
+
+## Your task
+
+Triage Mem0, Zep, MemoryOS, Letta via `tessl__triage-tool`
+
+## Writes scope
+
+You may only write to:
+references/*.md
+
+Limit your changes to files directly related to your task. Do not modify shared
+index files, changelogs, or summary documents unless your task explicitly names them.
+
+## Isolation
+
+Other agents may be running in parallel in separate worktrees.
+Only touch files within your writes scope.
+Do not read files owned by another concurrent agent's worktree — this causes merge conflicts.
+
+## When done
+
+Verify:
+1. Every file you created or modified exists and is non-empty.
+2. Any script or command named in your task ran without error.
+3. No file outside your writes scope was modified — check with: git diff --name-only
+
+Report:
+- Files written (exact paths).
+- Any decision or assumption you had to make.
+- Any blocker that prevented full completion.
+
+Use the skill or script named in your task. Follow its output format exactly.
+Verify that any file you produced matches the expected structure before reporting done.
+If the skill requires a confirmation sub-step, take the default/conservative option and note it.
+```
+
+Corresponding `Agent` call:
+
+```
+Agent(
+  subagent_type="general-purpose",
+  model="sonnet",
+  isolation="worktree",
+  description="Wave 0: feat/triage-memory",
+  prompt=<above>
+)
+```


### PR DESCRIPTION
## Summary

- Adds new \`wave-executor\` skill: reads a wave document, spawns parallel agents per wave, enforces merge gates, and updates wave status after verification
- Extends \`wave-execution-planner\` wave format with an optional \`Model\` column (\`haiku\`/\`sonnet\`/\`opus\`, defaults to \`sonnet\`)
- Adds eval scenarios for both skills: 4 for \`wave-executor\`, 1 (scenario-7) for \`wave-execution-planner\`

## Changes

### New skill: \`wave-executor\`
- \`SKILL.md\` — workflow: locate plan → check gate → extract phases → build per-agent prompts → spawn in parallel → stop at merge gate → verify → advance
- \`references/per-agent-template.md\` — per-agent prompt template with model-tier additions
- \`references/model-tier-guide.md\` — haiku/sonnet/opus decision guide
- \`evals/scenario-{1-4}/\` — parallel spawning, model tier assignment, merge gate stop, blocked phase reporting

### Extended: \`wave-execution-planner\`
- \`references/wave-format.md\` — optional \`Model\` column in phase tables and inline task format
- \`references/wave-document.yaml\` — template updated with \`Model\` column
- \`evals/scenario-7/\` — eval for \`include-model-column-in-wave-document\` capability

### Updated: \`tile.json\`
- Registered \`wave-executor\` skill entry

## Test plan

- [ ] Pre-commit hooks pass (tessl-lint, yamllint, markdownlint, skill-artifacts, skill-frontmatter)
- [ ] Pre-push hooks pass (28 Cucumber integration scenarios, 304 Bun unit tests)
- [ ] \`wave-executor\` SKILL.md has no \`../\` path references outside code blocks
- [ ] All eval \`criteria.json\` files are valid \`weighted_checklist\` format
- [ ] \`wave-format.md\` Model column rules match \`wave-executor\` SKILL.md parsing logic