### PR TITLE
refactor(planning-toolkit): abstract model tiers to fast/standard/smart

### DIFF
--- a/skills/project-mgmt/planning-toolkit/wave-execution-planner/evals/scenario-7/criteria.json
+++ b/skills/project-mgmt/planning-toolkit/wave-execution-planner/evals/scenario-7/criteria.json
@@ -1,5 +1,5 @@
 {
-  "context": "Agent was asked to create a wave document for a research consolidation with tasks of clearly different complexity. Evaluate whether the Model column is present and whether tier assignments are appropriate.",
+  "context": "Agent was asked to create a wave document for a research consolidation with tasks of clearly different complexity. Evaluate whether the Model column is present and whether tier assignments are appropriate. Tier names in the wave document are provider-agnostic: 'fast', 'standard', 'smart'.",
   "type": "weighted_checklist",
   "checklist": [
     {
@@ -8,23 +8,23 @@
       "max_score": 15
     },
     {
-      "name": "triage-phases-assigned-sonnet",
-      "description": "All 6 triage phases (skill-driven, template output) are assigned 'sonnet' in the Model column",
+      "name": "triage-phases-assigned-standard",
+      "description": "All 6 triage phases (skill-driven, template output) are assigned 'standard' in the Model column",
       "max_score": 20
     },
     {
-      "name": "synthesis-phase-assigned-opus",
-      "description": "The synthesis phase (cross-document analysis, high judgment) is assigned 'opus' in the Model column",
+      "name": "synthesis-phase-assigned-smart",
+      "description": "The synthesis phase (cross-document analysis, high judgment) is assigned 'smart' in the Model column",
       "max_score": 20
     },
     {
-      "name": "consolidation-phase-assigned-haiku",
-      "description": "The consolidation pass (PUNCHLIST flip, script run) is assigned 'haiku' in the Model column",
+      "name": "consolidation-phase-assigned-fast",
+      "description": "The consolidation pass (PUNCHLIST flip, script run) is assigned 'fast' in the Model column",
       "max_score": 20
     },
     {
-      "name": "cleanup-phase-assigned-haiku",
-      "description": "The cleanup audit phase (lint, consistency check) is assigned 'haiku' in the Model column",
+      "name": "cleanup-phase-assigned-fast",
+      "description": "The cleanup audit phase (lint, consistency check) is assigned 'fast' in the Model column",
       "max_score": 15
     },
     {

--- a/skills/project-mgmt/planning-toolkit/wave-execution-planner/references/wave-document.yaml
+++ b/skills/project-mgmt/planning-toolkit/wave-execution-planner/references/wave-document.yaml
@@ -51,7 +51,7 @@ sections:
 
     | Phase | Focus | Tasks | Status | Model |
     |-------|-------|-------|--------|-------|
-    | [<N>](<phase-N-slug>.md) | <3–6 word description> | <count> | Pending | sonnet |
+    | [<N>](<phase-N-slug>.md) | <3–6 word description> | <count> | Pending | standard |
 
     Verification:
     - [ ] <command or observable check>
@@ -65,7 +65,7 @@ sections:
 
     | Phase | Focus | Tasks | Status | Model |
     |-------|-------|-------|--------|-------|
-    | [<N>](<phase-N-slug>.md) | <3–6 word description> | <count> | Pending | sonnet |
+    | [<N>](<phase-N-slug>.md) | <3–6 word description> | <count> | Pending | standard |
 
     Verification:
     - [ ] <command or observable check>

--- a/skills/project-mgmt/planning-toolkit/wave-execution-planner/references/wave-format.md
+++ b/skills/project-mgmt/planning-toolkit/wave-execution-planner/references/wave-format.md
@@ -41,7 +41,7 @@ Use the plan slug from the requirements or a short descriptive identifier (e.g. 
 
 | Phase | Focus | Tasks | Status | Model |
 |-------|-------|-------|--------|-------|
-| [N](phase-N-<slug>.md) | <description> | <count> | Pending | sonnet |
+| [N](phase-N-<slug>.md) | <description> | <count> | Pending | standard |
 
 Verification:
 - [ ] <command or check that must pass before Wave 2 starts>
@@ -77,7 +77,7 @@ Merge order: <branch A> → <branch B> → ...
 - **Status values**: `Pending` → `In Progress` → `Done`
 - Add a `> Gate:` blockquote at the top of each wave (except Wave 1).
 - Add a `Verification:` checklist at the bottom of each wave.
-- **Model column** (optional): specifies the agent model tier for each phase. Valid values: `haiku`, `sonnet`, `opus`. Omit the column or leave a cell blank to default to `sonnet`. See the `wave-executor` skill for how this value is used at execution time.
+- **Model column** (optional): specifies the agent capability tier for each phase. Valid values: `fast`, `standard`, `smart`. Omit the column or leave a cell blank to default to `standard`. The `wave-executor` skill resolves these to concrete model IDs via its `references/model-map.yaml` at execution time.
 
 ## Phase row format
 
@@ -87,7 +87,7 @@ Merge order: <branch A> → <branch B> → ...
 | Focus | 3–6 word description of what the phase accomplishes |
 | Tasks | Integer count of discrete tasks inside the phase |
 | Status | `Pending` / `In Progress` / `Done` |
-| Model | *(optional)* `haiku` / `sonnet` / `opus` — agent model tier. Defaults to `sonnet` if omitted. |
+| Model | *(optional)* `fast` / `standard` / `smart` — agent capability tier. Defaults to `standard` if omitted. |
 
 If the plan has no separate phase files, use task IDs directly (e.g. `T1.1`, `T2.3`).
 
@@ -103,10 +103,10 @@ Use this for smaller plans where phases are not broken into separate files:
 Run **T1.1–T1.4 in parallel, each in its own worktree.**
 Each agent works independently; tasks touch different files with no overlap.
 
-- [ ] **T1.1** — `scripts/lib/http.ts` — branch `refactor/scripts-lib-http` — model: `haiku`
-- [ ] **T1.2** — `scripts/lib/dates.ts` — branch `refactor/scripts-lib-dates` — model: `sonnet`
-- [ ] **T1.3** — `scripts/lib/wikidata.ts` — branch `refactor/scripts-lib-wikidata` — model: `sonnet`
-- [ ] **T1.4** — `scripts/lib/paths.ts` — branch `refactor/scripts-lib-paths` — model: `haiku`
+- [ ] **T1.1** — `scripts/lib/http.ts` — branch `refactor/scripts-lib-http` — model: `fast`
+- [ ] **T1.2** — `scripts/lib/dates.ts` — branch `refactor/scripts-lib-dates` — model: `standard`
+- [ ] **T1.3** — `scripts/lib/wikidata.ts` — branch `refactor/scripts-lib-wikidata` — model: `standard`
+- [ ] **T1.4** — `scripts/lib/paths.ts` — branch `refactor/scripts-lib-paths` — model: `fast`
 
 **Wave 1 merge**: after all branches pass validation, merge in order:
 `refactor/scripts-lib-http` → `refactor/scripts-lib-dates` → `refactor/scripts-lib-wikidata` → `refactor/scripts-lib-paths`
@@ -116,7 +116,7 @@ Verification:
 - [ ] No direct imports of old paths remain
 ```
 
-The `— model: haiku|sonnet|opus` suffix is optional on inline tasks. Omit it to default to `sonnet`.
+The `— model: fast|standard|smart` suffix is optional on inline tasks. Omit it to default to `standard`.
 
 ## Dependency graph format
 

--- a/skills/project-mgmt/planning-toolkit/wave-executor/SKILL.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/SKILL.md
@@ -42,8 +42,15 @@ Parse the wave table or inline task list. For each row / item capture:
 
 - **branch** — the branch name. In phase tables: the phase identifier (use as branch if no explicit branch). In inline tasks: the value after `— branch`.
 - **focus** — the task description (Focus column, or phase file content if linked).
-- **model** — the `Model` column value, or `— model:` suffix on inline tasks. Default: `sonnet` if absent.
+- **model** — the `Model` column value, or `— model:` suffix on inline tasks. Default: `standard` if absent.
 - **writes** — if a `Writes` column or `— writes:` annotation is present, capture it. Otherwise derive from the phase file, or leave unspecified and let the agent determine scope from the focus.
+
+#### 2b.5. Resolve tiers to model IDs
+
+Read `references/model-map.yaml`. For each extracted `model` tier value, look up the
+corresponding concrete model ID. If a tier is absent from the map, use the `standard` entry.
+
+Carry the resolved model ID (not the tier name) forward to step 2d.
 
 #### 2c. Build per-agent prompts
 
@@ -61,7 +68,7 @@ Send a **single response** containing one `Agent` tool call per unblocked phase.
 
 Each call must set:
 - `subagent_type`: `"general-purpose"`
-- `model`: the exact tier string from step 2b (`"haiku"` / `"sonnet"` / `"opus"`)
+- `model`: the resolved model ID from step 2b.5 (e.g. `"haiku"` for a `fast`-tier phase)
 - `isolation`: `"worktree"` for all phases that commit to a branch (omit for phases that commit directly to main)
 - `description`: `"Wave N: <branch>"`
 - `prompt`: the filled per-agent prompt from step 2c
@@ -109,10 +116,10 @@ After all waves are done:
 
 ### NEVER omit the `model` parameter on Agent calls
 
-**WHY**: Omitting it silently defaults to the orchestrator's model. For `haiku`-tier mechanical tasks, this wastes significant cost with no quality benefit.
+**WHY**: Omitting it silently defaults to the orchestrator's model. For `fast`-tier mechanical tasks, this wastes significant cost with no quality benefit.
 
 **BAD** `Agent(subagent_type="general-purpose", prompt=...)` with no `model`.
-**GOOD** `Agent(model="haiku", ...)` as specified in the wave document.
+**GOOD** `Agent(model="haiku", ...)` — resolved from the `fast` tier in `model-map.yaml`.
 
 ### NEVER start the next wave before the gate passes
 
@@ -138,6 +145,7 @@ After all waves are done:
 ## References
 
 - [Per-agent prompt template](references/per-agent-template.md) — fill for every spawned agent
-- [Model tier guide](references/model-tier-guide.md) — when to use haiku / sonnet / opus
+- [Model tier guide](references/model-tier-guide.md) — when to use fast / standard / smart
+- [Model map](references/model-map.yaml) — resolves tier names to concrete model IDs; edit to switch providers
 - Wave format spec — defined in the `wave-execution-planner` skill (`wave-execution-planner/references/wave-format.md`)
 - Status tracking protocol — defined in the `wave-execution-planner` skill (`wave-execution-planner/references/status-tracking.md`); used in step 2g

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/criteria.json
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/criteria.json
@@ -1,5 +1,5 @@
 {
-  "context": "Agent was asked to execute Wave 0 of an auth migration plan. Evaluate whether it spawned agents correctly.",
+  "context": "Agent was asked to execute Wave 0 of an auth migration plan. The wave document uses provider-agnostic tier names ('standard', 'fast') which the skill must resolve to concrete model IDs via model-map.yaml before spawning agents. Evaluate whether it spawned agents correctly with the correct resolved model IDs.",
   "type": "weighted_checklist",
   "checklist": [
     {

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/task.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-1/task.md
@@ -20,9 +20,9 @@ Execute Wave 0.
 
 | Phase | Focus | Tasks | Status | Model |
 |-------|-------|-------|--------|-------|
-| `feat/schema` | Add new auth schema columns | 2 | Pending | sonnet |
-| `feat/tokens` | Implement token generation service | 3 | Pending | sonnet |
-| `feat/session` | Scaffold session store interface | 2 | Pending | haiku |
+| `feat/schema` | Add new auth schema columns | 2 | Pending | standard |
+| `feat/tokens` | Implement token generation service | 3 | Pending | standard |
+| `feat/session` | Scaffold session store interface | 2 | Pending | fast |
 
 Verification:
 - [ ] All three branches merged to `main`

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/criteria.json
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/criteria.json
@@ -1,5 +1,5 @@
 {
-  "context": "Agent was asked to execute a wave with mixed model tiers and one phase with no Model value. Evaluate whether model assignments are correct and the default is applied.",
+  "context": "Agent was asked to execute a wave with mixed model tiers ('fast', 'smart', 'standard') and one phase with no Model value. The skill must resolve tier names to concrete model IDs via model-map.yaml. Evaluate whether the resolved model IDs are correct and the default ('standard' → 'sonnet') is applied for the blank cell.",
   "type": "weighted_checklist",
   "checklist": [
     {

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/task.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-2/task.md
@@ -20,9 +20,9 @@ Execute Wave 1.
 
 | Phase | Focus | Tasks | Status | Model |
 |-------|-------|-------|--------|-------|
-| `feat/delete-scripts` | Delete deprecated sync scripts | 1 | Pending | haiku |
-| `feat/cross-analysis` | Write cross-cutting analysis from 8 source files | 1 | Pending | opus |
-| `feat/update-docs` | Update API reference tables | 2 | Pending | sonnet |
+| `feat/delete-scripts` | Delete deprecated sync scripts | 1 | Pending | fast |
+| `feat/cross-analysis` | Write cross-cutting analysis from 8 source files | 1 | Pending | smart |
+| `feat/update-docs` | Update API reference tables | 2 | Pending | standard |
 | `feat/index-rebuild` | Run index rebuild and verify output | 1 | Pending | |
 
 Verification:

--- a/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-4/task.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/evals/scenario-4/task.md
@@ -23,7 +23,7 @@ Wave 0 has been verified. However, not all Wave 0 branches have been merged yet.
 
 | Phase | Focus | Tasks | Status | Writes | Blocked on | Model |
 |-------|-------|-------|--------|--------|------------|-------|
-| `feat/synthesis` | Write Key Themes section from 14 analysis files | 1 | Pending | `ANALYSIS.md` | `feat/rubric` merged | opus |
-| `feat/consolidate` | Flip PUNCHLIST, add REVIEWED rows, sync index | 3 | Pending | `REVIEWED.md`, `PUNCHLIST.md`, `REFERENCE_INDEX.md` | all Wave 0 triage branches merged | haiku |
-| `feat/benchmark-decision` | Resolve HELMET and LongBench disposition | 1 | Pending | `REVIEWED.md` | — | sonnet |
+| `feat/synthesis` | Write Key Themes section from 14 analysis files | 1 | Pending | `ANALYSIS.md` | `feat/rubric` merged | smart |
+| `feat/consolidate` | Flip PUNCHLIST, add REVIEWED rows, sync index | 3 | Pending | `REVIEWED.md`, `PUNCHLIST.md`, `REFERENCE_INDEX.md` | all Wave 0 triage branches merged | fast |
+| `feat/benchmark-decision` | Resolve HELMET and LongBench disposition | 1 | Pending | `REVIEWED.md` | — | standard |
 ```

--- a/skills/project-mgmt/planning-toolkit/wave-executor/references/model-map.yaml
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/references/model-map.yaml
@@ -1,0 +1,11 @@
+# Model tier mapping
+# Maps abstract capability tiers (used in wave documents) to concrete model IDs
+# accepted by the Agent tool's `model` parameter.
+#
+# Edit this file to switch providers or pin to a specific model version.
+# Keys: tier names as written in the wave document Model column.
+# Values: model IDs passed to the Agent tool at execution time.
+
+fast:     haiku     # mechanical, script-driven, high-volume
+standard: sonnet    # skill-driven, template output, bounded judgment
+smart:    opus      # open-ended synthesis, deep evidence evaluation

--- a/skills/project-mgmt/planning-toolkit/wave-executor/references/model-tier-guide.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/references/model-tier-guide.md
@@ -1,13 +1,16 @@
 # Model Tier Guide
 
-The `Model` column in the wave document is the authoritative assignment.
+The `Model` column in the wave document is the authoritative capability assignment.
+Tier names are provider-agnostic — `wave-executor` resolves them to concrete model IDs
+via `references/model-map.yaml` at execution time.
+
 This guide explains the reasoning so you can judge edge cases and unlisted tasks.
 
 ---
 
 ## Tiers
 
-### haiku — mechanical operations
+### fast — mechanical operations
 
 Use when the task is fully determined by explicit instructions with no judgment calls.
 
@@ -25,7 +28,7 @@ Examples:
 
 ---
 
-### sonnet — structured output with bounded judgment
+### standard — structured output with bounded judgment
 
 Use when the task drives a skill or fills a template and the output format is pre-defined.
 Judgment is required but constrained to a small, known decision space.
@@ -44,7 +47,7 @@ Examples:
 
 ---
 
-### opus — open-ended synthesis or deep evidence evaluation
+### smart — open-ended synthesis or deep evidence evaluation
 
 Use when the task requires reading multiple documents, reconciling conflicting evidence,
 or producing analysis whose quality cannot be checked against a schema.
@@ -64,12 +67,27 @@ Examples:
 
 ## Default
 
-Omitting the `Model` column or leaving a cell blank defaults to **`sonnet`**.
+Omitting the `Model` column or leaving a cell blank defaults to **`standard`**.
 
 ## Decision rule for unlisted tasks
 
-Ask: "Could a `haiku` agent complete this correctly by following explicit steps?"
+Ask: "Could a `fast` agent complete this correctly by following explicit steps?"
 
-- Yes → `haiku`
-- No, but the output format is defined and the decision space is small → `sonnet`
-- No, and the output quality depends on synthesis across documents → `opus`
+- Yes → `fast`
+- No, but the output format is defined and the decision space is small → `standard`
+- No, and the output quality depends on synthesis across documents → `smart`
+
+---
+
+## Provider mapping
+
+Tier names are resolved at execution time using `references/model-map.yaml`.
+Current defaults (Anthropic):
+
+| Tier | Model ID |
+|------|----------|
+| `fast` | `haiku` |
+| `standard` | `sonnet` |
+| `smart` | `opus` |
+
+To use a different provider, update `model-map.yaml` — wave documents do not need to change.

--- a/skills/project-mgmt/planning-toolkit/wave-executor/references/per-agent-template.md
+++ b/skills/project-mgmt/planning-toolkit/wave-executor/references/per-agent-template.md
@@ -50,9 +50,9 @@ Report:
 
 ## Model-tier additions
 
-Replace `{model_tier_addition}` with the block matching the phase's `Model` value.
+Replace `{model_tier_addition}` with the block matching the phase's resolved tier.
 
-### haiku
+### fast
 
 ```
 Work mechanically. Follow each step in the task description in order.
@@ -60,7 +60,7 @@ Do not infer, expand, or improve beyond the stated scope.
 If any step is ambiguous, take the most conservative interpretation and note it in your report.
 ```
 
-### sonnet
+### standard
 
 ```
 Use the skill or script named in your task. Follow its output format exactly.
@@ -68,7 +68,7 @@ Verify that any file you produced matches the expected structure before reportin
 If the skill requires a confirmation sub-step, take the default/conservative option and note it.
 ```
 
-### opus
+### smart
 
 ```
 You may read any existing file in the repo to inform your analysis.
@@ -85,7 +85,7 @@ Wave document row (phase table, Wave 0):
 
 | Phase | Focus | Tasks | Status | Model |
 |-------|-------|-------|--------|-------|
-| `feat/triage-memory` | Triage Mem0, Zep, MemoryOS, Letta via `tessl__triage-tool` | 4 | Pending | sonnet |
+| `feat/triage-memory` | Triage Mem0, Zep, MemoryOS, Letta via `tessl__triage-tool` | 4 | Pending | standard |
 
 Filled prompt:
 
@@ -132,7 +132,7 @@ Corresponding `Agent` call:
 ```
 Agent(
   subagent_type="general-purpose",
-  model="sonnet",
+  model="sonnet",        # resolved from tier 'standard' via model-map.yaml
   isolation="worktree",
   description="Wave 0: feat/triage-memory",
   prompt=<above>


### PR DESCRIPTION
## Summary

- Replaces provider-specific tier names (`haiku`/`sonnet`/`opus`) with provider-agnostic capability tiers (`fast`/`standard`/`smart`) in the wave format spec and all wave documents
- Adds `model-map.yaml` to `wave-executor` for resolving tier names to concrete model IDs at execution time — edit this file to switch providers without touching any wave document

## Why

`haiku/sonnet/opus` are Anthropic product names. Wave documents are long-lived planning artifacts that should express capability intent, not vendor lineup. With this change, a wave document written today works unchanged if the executor maps to a different provider tomorrow.

## Changes

| File | Change |
|------|--------|
| `wave-format.md`, `wave-document.yaml` | `fast`/`standard`/`smart` tier names; `standard` default |
| `model-tier-guide.md` | Renamed sections; added Provider mapping table |
| `wave-executor/SKILL.md` | Step 2b.5: resolve tiers via `model-map.yaml` before spawning agents |
| `references/model-map.yaml` | New file — default Anthropic mapping (`fast→haiku`, `standard→sonnet`, `smart→opus`) |
| `per-agent-template.md` | Renamed tier sections; annotated worked example with resolution comment |
| All eval `task.md` files | Wave document excerpts updated to new tier names |
| Eval `criteria.json` | Scenario-7 expected values updated; context strings updated for 1 and 2 |

## Test plan

- [ ] Pre-commit hooks pass (all green above)
- [ ] Pre-push hooks pass (Cucumber + Bun)
- [ ] `model-map.yaml` is valid YAML with `fast`, `standard`, `smart` keys
- [ ] No remaining `haiku`/`sonnet`/`opus` tier names in wave format spec or eval task.md files