### PR TITLE
feat(vault): migrate vault-* skills from mneme/vault-core

### DIFF
--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -376,7 +376,7 @@ Generate a project-specific web design reference sheet (docs/design/design-refer
 
 ---
 
-## Agentic Harness (14 skills)
+## Agentic Harness (18 skills)
 
 Agent framework configurations
 
@@ -436,6 +436,22 @@ Pin session decisions, questions, objections, scope constraints, and corrections
 | --- | --- | --- | --- |
 | [pin](/tekhne/skills/agentic-harness/pin/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-11 | 5 |
 
+### vault-search
+
+Search persistent memory for relevant context — including architectural decision...
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [vault-search](/tekhne/skills/agentic-harness/vault-search/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 5 |
+
+### vault-consolidate
+
+Propose or apply consolidation of episodic memories into semantic ones, combinin...
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [vault-consolidate](/tekhne/skills/agentic-harness/vault-consolidate/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 5 |
+
 ### skill-quality-auditor
 
 Evaluate, score, and remediate agent skill collections using a 9-dimension quali...
@@ -467,6 +483,22 @@ Create and maintain AGENTS.md documentation for simple projects, complex monorep
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [agents-md](/tekhne/skills/agentic-harness/agents-md/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-27 | 5 |
+
+### vault-fetch
+
+Fetch a URL, extract its text content, and persist it as a semantic memory tagge...
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [vault-fetch](/tekhne/skills/agentic-harness/vault-fetch/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 5 |
+
+### vault-capture
+
+Captures an important insight, decision, constraint, pattern, or discovery to pe...
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [vault-capture](/tekhne/skills/agentic-harness/vault-capture/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 5 |
 
 ### save-context
 

--- a/skills/agentic-harness/vault-capture/SKILL.md
+++ b/skills/agentic-harness/vault-capture/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: vault-capture
+description: >
+  Captures an important insight, decision, constraint, pattern, or discovery to
+  persistent memory via the vault CLI — distinct from general note-taking in that
+  entries are tagged, tiered, and retrievable across future sessions. Use when the
+  user says "save this", "remember this", "note for later", "don't forget", or
+  "keep this in mind", or when the conversation produces something worth
+  preserving: architectural decisions, recurring bugs, hard-won constraints,
+  naming conventions, or user preferences.
+allowed-tools: "Bash"
+---
+
+# vault-capture
+
+Persist a memory to the vault so it can be retrieved in future sessions.
+
+## Mindset
+
+Before capturing, answer two questions:
+
+1. **Is this time-bound?** If yes → `episodic`. If no, continue.
+2. **Is this a how-to process?** If yes → `procedural`. If no → `semantic`.
+
+Always capture with `--project` when working in a project context. Always add
+`--tags` with at least two relevant keywords — they are the primary BM25 signal
+for future retrieval.
+
+## When to use
+
+Use whenever the conversation produces:
+- A confirmed decision ("we're using X instead of Y")
+- A constraint that must not be violated
+- A recurring bug or workaround
+- A project convention or naming pattern
+- A user preference expressed explicitly
+
+## How to use
+
+```bash
+vault-cli capture --text "<memory content>" [--tier episodic|semantic|procedural] [--project <id>] [--tags tag1,tag2]
+```
+
+Always double-quote the `--text` value to handle apostrophes and special characters.
+
+Or pipe from stdin:
+```bash
+echo "<memory content>" | vault-cli capture
+```
+
+## Tier selection
+
+| Question | Answer | Tier |
+|---|---|---|
+| Is this tied to today's session or a specific event? | Yes | `episodic` (default) |
+| Is this a rule, fact, or convention that should persist indefinitely? | Yes | `semantic` |
+| Is this a step-by-step process or how-to? | Yes | `procedural` |
+
+## Examples
+
+```bash
+vault-cli capture --text "Decided to use Bun instead of Node for all scripts. Reason: workspace protocol support." --tier semantic --tags bun,tooling --project vault-core
+
+vault-cli capture --text "Never use --force-push on main. CI enforces branch protection." --tier procedural --tags git,ci
+
+vault-cli capture --text "Auth service fails silently when DB not ready — add depends_on with condition: service_healthy in docker-compose." --tier episodic --tags docker,auth,bug --project api
+```
+
+## Never
+
+- **Never omit `--tier`** for a rule or convention — defaulting to `episodic` means it will decay and be consolidated away
+- **Never capture without `--tags`** — untagged memories score poorly in BM25 retrieval
+- **Never omit `--project`** when working inside a project — global memories pollute cross-project searches
+- **Never use single quotes around `--text`** — apostrophes in content will break the shell command

--- a/skills/agentic-harness/vault-capture/evals/instructions.json
+++ b/skills/agentic-harness/vault-capture/evals/instructions.json
@@ -1,0 +1,48 @@
+{
+  "instructions": [
+    {
+      "instruction": "Use `vault-cli capture --text \"<content>\"` to save information to persistent memory",
+      "original_snippets": ["vault-cli capture --text \"<content>\""],
+      "relevant_when": "User confirms a decision, preference, constraint, or asks to save something",
+      "why_given": "The agent must know the exact CLI invocation to capture memories"
+    },
+    {
+      "instruction": "Use `--tier semantic` when capturing distilled facts or rules (not time-bound events)",
+      "original_snippets": ["--tier episodic|semantic|procedural"],
+      "relevant_when": "Capturing a principle, fact, convention, or rule that should persist long-term",
+      "why_given": "Tier selection affects memory durability and how memories are later consolidated"
+    },
+    {
+      "instruction": "Use `--tier procedural` when capturing how-to processes or step-by-step instructions",
+      "original_snippets": ["--tier episodic|semantic|procedural"],
+      "relevant_when": "Capturing a workflow, process, or set of steps the user wants remembered",
+      "why_given": "Procedural memories are permanent until explicitly revoked and get special handling"
+    },
+    {
+      "instruction": "Use `--project <id>` to scope a memory to a specific project",
+      "original_snippets": ["--project <id>"],
+      "relevant_when": "User is working in a project context and the memory is project-specific",
+      "why_given": "Without a project scope, the memory is global and may pollute other project contexts"
+    },
+    {
+      "instruction": "Use `--tags` to attach relevant keywords for later retrieval",
+      "original_snippets": ["--tags tag1,tag2"],
+      "relevant_when": "The memory content has clear topic keywords that aid future search",
+      "why_given": "Tags improve BM25 search quality for this memory"
+    },
+    {
+      "instruction": "Capture on confirmed decisions, constraints, recurring bugs, naming conventions, and user preferences",
+      "original_snippets": [
+        "architectural decisions, recurring bugs, hard-won constraints, naming conventions, or user preferences"
+      ],
+      "relevant_when": "The conversation produces something worth remembering across sessions",
+      "why_given": "The agent must recognise the right moments to invoke capture proactively"
+    },
+    {
+      "instruction": "Default tier is episodic; only override when the content is clearly a fact/rule or a procedure",
+      "original_snippets": ["Default tier: episodic"],
+      "relevant_when": "Deciding which tier to assign to a capture",
+      "why_given": "Using the wrong tier causes incorrect memory handling during consolidation"
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-capture/evals/scenario-1/capability.txt
+++ b/skills/agentic-harness/vault-capture/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+capture decision

--- a/skills/agentic-harness/vault-capture/evals/scenario-1/criteria.json
+++ b/skills/agentic-harness/vault-capture/evals/scenario-1/criteria.json
@@ -1,0 +1,41 @@
+{
+  "context": "Saving a confirmed architectural decision about UUID primary keys in the payments-api project",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli capture",
+      "description": "The command invokes `vault-cli capture`",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --text flag",
+      "description": "Content is passed via the `--text` flag (not piped or other method)",
+      "max_score": 10
+    },
+    {
+      "name": "Content captures the decision",
+      "description": "The captured text includes the UUID primary key decision substance",
+      "max_score": 15
+    },
+    {
+      "name": "Uses --tier semantic",
+      "description": "Uses `--tier semantic` because this is a long-term architectural rule, not a time-bound event",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --project flag",
+      "description": "Scopes the capture with `--project payments-api` (or similar project identifier)",
+      "max_score": 15
+    },
+    {
+      "name": "Uses --tags flag",
+      "description": "Attaches relevant tags (e.g., `--tags uuid,primary-key,schema` or similar)",
+      "max_score": 10
+    },
+    {
+      "name": "Single coherent command",
+      "description": "Produces a single valid shell command (not split into unrelated commands)",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-capture/evals/scenario-1/task.md
+++ b/skills/agentic-harness/vault-capture/evals/scenario-1/task.md
@@ -1,0 +1,9 @@
+# Task: Save a Team Decision
+
+You are an AI coding assistant helping a developer on the `payments-api` project.
+
+The developer has just told you:
+
+> "We've decided to always use UUIDs for primary keys across the whole payments-api project. This is final — no auto-increment integers."
+
+Write the shell command(s) you would run to persist this information for future reference.

--- a/skills/agentic-harness/vault-capture/evals/scenario-2/capability.txt
+++ b/skills/agentic-harness/vault-capture/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+tier procedural

--- a/skills/agentic-harness/vault-capture/evals/scenario-2/criteria.json
+++ b/skills/agentic-harness/vault-capture/evals/scenario-2/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Saving a multi-step deployment workflow that the user wants remembered permanently",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli capture",
+      "description": "The command invokes `vault-cli capture`",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --tier procedural",
+      "description": "Uses `--tier procedural` because the content describes a step-by-step how-to process",
+      "max_score": 25
+    },
+    {
+      "name": "Captures all key steps",
+      "description": "The captured text includes all 5 deployment steps (build, tag, push ECR, update task def, wait for stabilisation)",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --text flag with content",
+      "description": "Content is passed via `--text` flag (or pipe equivalent)",
+      "max_score": 10
+    },
+    {
+      "name": "Uses relevant tags",
+      "description": "Attaches tags related to deployment (e.g., `--tags deployment,ecs,docker` or similar)",
+      "max_score": 10
+    },
+    {
+      "name": "Does not use --tier episodic",
+      "description": "Does NOT use `--tier episodic` (or omit tier) for a permanent process",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-capture/evals/scenario-2/task.md
+++ b/skills/agentic-harness/vault-capture/evals/scenario-2/task.md
@@ -1,0 +1,9 @@
+# Task: Save a Step-by-Step Deployment Process
+
+You are an AI coding assistant. The developer explains their deployment process for production:
+
+> "Every time we deploy, we need to: (1) run `bun run build`, (2) tag the Docker image with the git SHA, (3) push to ECR, (4) update the ECS task definition, then (5) wait for the service to stabilise before closing the ticket."
+
+The developer says: "Save this deployment process — I want you to remember it."
+
+Write the shell command(s) you would run to save this process.

--- a/skills/agentic-harness/vault-capture/evals/scenario-3/capability.txt
+++ b/skills/agentic-harness/vault-capture/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+proactive capture

--- a/skills/agentic-harness/vault-capture/evals/scenario-3/criteria.json
+++ b/skills/agentic-harness/vault-capture/evals/scenario-3/criteria.json
@@ -1,0 +1,41 @@
+{
+  "context": "Recording a recurring bug and its workaround discovered during a debugging session",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli capture",
+      "description": "The command invokes `vault-cli capture`",
+      "max_score": 20
+    },
+    {
+      "name": "Captures the bug and workaround",
+      "description": "The captured text describes both the failure condition (race condition) and the fix (depends_on with service_healthy)",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --text flag",
+      "description": "Content is passed via `--text` flag or pipe",
+      "max_score": 10
+    },
+    {
+      "name": "Tier is episodic or semantic (not procedural)",
+      "description": "Uses `--tier episodic` (default) or `--tier semantic` — this is a bug note, not a how-to process",
+      "max_score": 15
+    },
+    {
+      "name": "Uses tags relevant to the bug",
+      "description": "Attaches tags like `--tags docker,auth-service,health-check` or similar",
+      "max_score": 15
+    },
+    {
+      "name": "Command is valid shell syntax",
+      "description": "The command is syntactically correct and executable",
+      "max_score": 10
+    },
+    {
+      "name": "Captures proactively without user prompting",
+      "description": "The response captures without waiting for an explicit 'remember this' instruction from the user",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-capture/evals/scenario-3/task.md
+++ b/skills/agentic-harness/vault-capture/evals/scenario-3/task.md
@@ -1,0 +1,7 @@
+# Task: Save a Recurring Bug Workaround
+
+You are an AI coding assistant. During a debugging session, you and the developer discovered a known issue:
+
+> "Whenever the `auth-service` container starts before the `db` container is fully ready, the health check fails silently. The workaround is to add `depends_on` with `condition: service_healthy` in docker-compose.yml."
+
+Write the shell command(s) you would run to record this finding.

--- a/skills/agentic-harness/vault-capture/evals/scenario-4/capability.txt
+++ b/skills/agentic-harness/vault-capture/evals/scenario-4/capability.txt
@@ -1,0 +1,1 @@
+naming convention

--- a/skills/agentic-harness/vault-capture/evals/scenario-4/criteria.json
+++ b/skills/agentic-harness/vault-capture/evals/scenario-4/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Saving a code naming convention that applies across a TypeScript project",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli capture",
+      "description": "The command invokes `vault-cli capture`",
+      "max_score": 15
+    },
+    {
+      "name": "Uses --tier semantic",
+      "description": "Uses `--tier semantic` because a naming convention is a distilled rule, not a time-bound event",
+      "max_score": 25
+    },
+    {
+      "name": "Captures the convention accurately",
+      "description": "The captured text includes the `handle` prefix rule and an example function name",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --text flag",
+      "description": "Content is passed via `--text` flag or pipe",
+      "max_score": 10
+    },
+    {
+      "name": "Uses relevant tags",
+      "description": "Uses tags like `--tags naming,typescript,events,convention` or similar keywords",
+      "max_score": 15
+    },
+    {
+      "name": "Does not use --tier episodic",
+      "description": "Does NOT default to episodic for a permanent convention",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-capture/evals/scenario-4/task.md
+++ b/skills/agentic-harness/vault-capture/evals/scenario-4/task.md
@@ -1,0 +1,7 @@
+# Task: Save a Naming Convention
+
+You are an AI coding assistant helping with a TypeScript project. The developer says:
+
+> "In this codebase, all event handler functions must be named with the `handle` prefix — e.g. `handleUserCreated`, `handleOrderPlaced`. This is enforced in code review."
+
+Save this convention for future reference.

--- a/skills/agentic-harness/vault-capture/evals/scenario-5/capability.txt
+++ b/skills/agentic-harness/vault-capture/evals/scenario-5/capability.txt
@@ -1,0 +1,1 @@
+user preference

--- a/skills/agentic-harness/vault-capture/evals/scenario-5/criteria.json
+++ b/skills/agentic-harness/vault-capture/evals/scenario-5/criteria.json
@@ -1,0 +1,41 @@
+{
+  "context": "Saving a strong user preference about code output style that should persist across all sessions",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli capture",
+      "description": "The command invokes `vault-cli capture`",
+      "max_score": 15
+    },
+    {
+      "name": "Uses --tier semantic",
+      "description": "Uses `--tier semantic` since this is a persistent preference/rule, not a time-bound event",
+      "max_score": 20
+    },
+    {
+      "name": "Captures the no-comments preference",
+      "description": "Captured text clearly states no comments are to be added unless explicitly requested",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --text flag",
+      "description": "Content is passed via `--text` flag or pipe",
+      "max_score": 10
+    },
+    {
+      "name": "Uses relevant tags",
+      "description": "Attaches tags like `--tags preference,comments,code-style` or similar",
+      "max_score": 15
+    },
+    {
+      "name": "No project scoping (global preference)",
+      "description": "Does NOT use `--project` flag since this is a global preference, not project-specific",
+      "max_score": 10
+    },
+    {
+      "name": "Command is valid shell syntax",
+      "description": "The command is syntactically correct and would execute without errors",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-capture/evals/scenario-5/task.md
+++ b/skills/agentic-harness/vault-capture/evals/scenario-5/task.md
@@ -1,0 +1,7 @@
+# Task: Save a User Preference About Output Style
+
+You are an AI coding assistant. The developer tells you:
+
+> "I never want you to add comments to code unless I explicitly ask. This applies everywhere — no inline comments, no JSDoc, nothing."
+
+Write the shell command(s) you would run to remember this preference.

--- a/skills/agentic-harness/vault-capture/evals/summary.json
+++ b/skills/agentic-harness/vault-capture/evals/summary.json
@@ -1,0 +1,13 @@
+{
+  "total_scenarios": 5,
+  "instructions_coverage": {
+    "total_instructions": 7,
+    "instructions_tested": 7,
+    "coverage_percentage": 100
+  },
+  "reason_distribution": {
+    "reminder": 2,
+    "new_knowledge": 4,
+    "preference": 1
+  }
+}

--- a/skills/agentic-harness/vault-capture/evals/summary_infeasible.json
+++ b/skills/agentic-harness/vault-capture/evals/summary_infeasible.json
@@ -1,0 +1,4 @@
+{
+  "total_infeasible": 0,
+  "infeasible_scenarios": []
+}

--- a/skills/agentic-harness/vault-consolidate/SKILL.md
+++ b/skills/agentic-harness/vault-consolidate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: vault-consolidate
+description: >
+  Propose or apply consolidation of episodic memories into semantic ones,
+  combining related episodic captures into higher-level semantic summary notes.
+  Use after a long session or when the user asks to clean up, organise,
+  summarise, merge, or declutter memories, or requests memory cleanup or memory
+  management. Always run --propose first so the user can review before --apply
+  commits changes to the vault.
+allowed-tools: "Bash"
+---
+
+# vault-consolidate
+
+Cluster related episodic memories and synthesise them into durable semantic notes.
+
+## Mindset
+
+Think of `--propose` as generating a diff and `--apply` as committing the merge.
+You never commit without reviewing the diff first. The human is always the final
+gatekeeper — the agent's job is to surface candidates, not to decide what gets
+promoted to long-term memory.
+
+## When to use
+
+- After a long session with many captures
+- When the user asks to "consolidate", "summarise", or "clean up" memories
+- Periodic maintenance (e.g. end of week)
+
+## Workflow
+
+Always propose before applying:
+
+```bash
+# Step 1 — generate proposals (written to vault inbox for review)
+vault-cli consolidate --propose [--project <id>]
+
+# Step 2 — open vault inbox, review, set status: approved or rejected
+# (edit 00-inbox/consolidation-proposals.md in Obsidian)
+
+# Step 3 — apply approved proposals
+vault-cli consolidate --apply
+```
+
+If `--propose` outputs "No episodic memories found to consolidate", skip Step 3 —
+there is nothing to apply.
+
+## What happens
+
+- `--propose`: clusters episodic memories by semantic similarity, calls the
+  inference command to synthesise each cluster, writes proposals to
+  `00-inbox/consolidation-proposals.md`
+- `--apply`: reads the proposals file, writes approved ones as semantic notes,
+  marks source episodics as `superseded`, logs rejected ones to audit
+
+## Important
+
+Source episodic memories are never deleted — only marked `superseded`.
+Human edits in Obsidian are always respected and never overwritten.
+
+## Never
+
+- **Never run `--apply` without first running `--propose`** — doing so bypasses human review and irreversibly promotes unreviewed clusters to semantic memory
+- **Never run `--apply` without confirming the user has reviewed the proposals** — always pause at Step 2 and wait for the user to confirm before proceeding
+- **Never delete episodic source memories manually** — they are preserved automatically and serve as audit history

--- a/skills/agentic-harness/vault-consolidate/evals/instructions.json
+++ b/skills/agentic-harness/vault-consolidate/evals/instructions.json
@@ -1,0 +1,49 @@
+{
+  "instructions": [
+    {
+      "instruction": "ALWAYS run `vault-cli consolidate --propose` before `vault-cli consolidate --apply`; never skip the propose step",
+      "original_snippets": [
+        "vault-cli consolidate --propose",
+        "vault-cli consolidate --apply"
+      ],
+      "relevant_when": "Any consolidation workflow; user asks to consolidate, summarise, or clean up memories",
+      "why_given": "Applying without proposing bypasses human review of memory merges, which can destroy important context irreversibly"
+    },
+    {
+      "instruction": "After running --propose, instruct the user to review and approve proposals in Obsidian before running --apply",
+      "original_snippets": [
+        "user reviews in Obsidian, sets status: approved or rejected"
+      ],
+      "relevant_when": "After --propose completes and before --apply is run",
+      "why_given": "The human approval step is mandatory; the agent must not auto-apply without human review"
+    },
+    {
+      "instruction": "Use `--project <id>` with --propose to limit consolidation to a specific project scope",
+      "original_snippets": ["vault-cli consolidate --propose [--project <id>]"],
+      "relevant_when": "User wants to consolidate memories for one project only",
+      "why_given": "Without scoping, all projects' episodic memories are consolidated together"
+    },
+    {
+      "instruction": "After --apply, source episodic memories are marked 'superseded' but never deleted",
+      "original_snippets": [
+        "marks source episodics as 'superseded'. Source episodics are NEVER deleted"
+      ],
+      "relevant_when": "User asks what happens to old memories after consolidation",
+      "why_given": "The agent must not reassure users that episodics are deleted — they are preserved"
+    },
+    {
+      "instruction": "Human-edited memories are never overwritten by consolidation",
+      "original_snippets": [
+        "Human edits are always respected, never overwritten"
+      ],
+      "relevant_when": "User asks about safety of running consolidation on memories they have manually edited",
+      "why_given": "Human-edited memories have special immunity to automated changes"
+    },
+    {
+      "instruction": "Consolidation produces semantic memories from clusters of episodic memories",
+      "original_snippets": ["Clusters episodic memories into semantic ones"],
+      "relevant_when": "Explaining what consolidation does",
+      "why_given": "The agent must understand the output tier so it can explain the process accurately"
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-1/capability.txt
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+full workflow

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-1/criteria.json
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-1/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "User requests a full consolidation workflow after a long session",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Runs --propose first",
+      "description": "The response includes running `vault-cli consolidate --propose` as the first command",
+      "max_score": 25
+    },
+    {
+      "name": "Instructs user to review in Obsidian",
+      "description": "Explicitly tells the user to open Obsidian and review/approve the consolidation proposals before continuing",
+      "max_score": 20
+    },
+    {
+      "name": "Runs --apply only after review",
+      "description": "Includes `vault-cli consolidate --apply` as a subsequent step, after the user has reviewed",
+      "max_score": 20
+    },
+    {
+      "name": "Does not auto-apply without user review",
+      "description": "Does NOT run both --propose and --apply in a single uninterrupted sequence without a user action in between",
+      "max_score": 15
+    },
+    {
+      "name": "Explains what happens during apply",
+      "description": "Mentions that approved proposals become semantic memories and source episodics are marked superseded (not deleted)",
+      "max_score": 10
+    },
+    {
+      "name": "Correct command syntax",
+      "description": "Both commands use correct syntax: `vault-cli consolidate --propose` and `vault-cli consolidate --apply`",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-1/task.md
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-1/task.md
@@ -1,0 +1,7 @@
+# Task: Start a Consolidation Workflow
+
+You are an AI coding assistant. A developer says:
+
+> "We've been working for a few hours and I have a lot of notes. Can you consolidate the memories from this session?"
+
+Write out the full sequence of steps and commands needed to complete the consolidation workflow.

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-2/capability.txt
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+project scoping

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-2/criteria.json
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-2/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "User wants to consolidate memories for one project only, not all projects",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses --propose flag",
+      "description": "The command uses the `--propose` flag, not `--apply`",
+      "max_score": 25
+    },
+    {
+      "name": "Uses --project flag",
+      "description": "The command includes `--project billing-service` (or similar project identifier)",
+      "max_score": 30
+    },
+    {
+      "name": "Correct command base",
+      "description": "The base command is `vault-cli consolidate`",
+      "max_score": 15
+    },
+    {
+      "name": "Does not run --apply",
+      "description": "Does NOT include `--apply` — the task only asks for the propose step",
+      "max_score": 15
+    },
+    {
+      "name": "Mentions user review step",
+      "description": "Notes that the user should review proposals before applying",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-2/task.md
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-2/task.md
@@ -1,0 +1,7 @@
+# Task: Scope Consolidation to a Single Project
+
+You are an AI coding assistant. The developer says:
+
+> "I only want to consolidate memories from the `billing-service` project, not everything."
+
+Write the command(s) needed to run the propose step scoped to this project.

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-3/capability.txt
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+never skip propose

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-3/criteria.json
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-3/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "User explicitly asks to skip the propose step and run --apply directly",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Does not run --apply alone",
+      "description": "The response does NOT run `vault-cli consolidate --apply` without first running `--propose`",
+      "max_score": 30
+    },
+    {
+      "name": "Explains why --propose must come first",
+      "description": "Explains that `--propose` must be run before `--apply` to allow human review of proposed merges",
+      "max_score": 25
+    },
+    {
+      "name": "Offers to run --propose instead",
+      "description": "Offers (or proceeds) to run `vault-cli consolidate --propose` as the correct first step",
+      "max_score": 20
+    },
+    {
+      "name": "Does not comply with skipping review",
+      "description": "Does not silently comply with skipping human review",
+      "max_score": 15
+    },
+    {
+      "name": "Correct command if proposed",
+      "description": "If a command is provided, it uses correct syntax `vault-cli consolidate --propose`",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-3/task.md
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-3/task.md
@@ -1,0 +1,7 @@
+# Task: Respond to a Request to Apply Without Proposing First
+
+You are an AI coding assistant. The developer says:
+
+> "Just run the consolidation apply command directly — skip the proposal step, I trust the system."
+
+How do you respond and what command(s), if any, do you run?

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-4/capability.txt
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-4/capability.txt
@@ -1,0 +1,1 @@
+episodic preservation

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-4/criteria.json
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-4/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "User asks whether source episodic memories are deleted after consolidation is applied",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "States episodics are NOT deleted",
+      "description": "Clearly states that episodic memories are NOT deleted after consolidation",
+      "max_score": 30
+    },
+    {
+      "name": "States episodics are marked superseded",
+      "description": "Explains that source episodic memories are marked as 'superseded' (not removed)",
+      "max_score": 25
+    },
+    {
+      "name": "States approved proposals become semantic memories",
+      "description": "Explains that approved proposals are written as new semantic-tier memories",
+      "max_score": 20
+    },
+    {
+      "name": "Mentions human-edited immunity",
+      "description": "Mentions that manually edited memories are never overwritten by consolidation",
+      "max_score": 15
+    },
+    {
+      "name": "Accurate and no contradictions",
+      "description": "The explanation contains no factually incorrect statements about what consolidation does",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-4/task.md
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-4/task.md
@@ -1,0 +1,7 @@
+# Task: Explain What Happens to Old Memories After Consolidation
+
+You are an AI coding assistant. After running a consolidation, the developer asks:
+
+> "So once I approve and apply — what happens to all those individual episodic notes? Are they deleted?"
+
+Provide a clear and accurate explanation.

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-5/capability.txt
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-5/capability.txt
@@ -1,0 +1,1 @@
+end-of-week trigger

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-5/criteria.json
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-5/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "End-of-week wrap-up trigger for consolidation; user uses language like 'tidy up' and 'summarise'",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Recognises consolidation trigger",
+      "description": "Identifies 'summarise and tidy up memories' as a consolidation trigger and proceeds with vault-cli consolidate",
+      "max_score": 20
+    },
+    {
+      "name": "Runs --propose first",
+      "description": "Runs `vault-cli consolidate --propose` as the first command",
+      "max_score": 25
+    },
+    {
+      "name": "Instructs user to review",
+      "description": "Instructs the user to review the proposals in Obsidian (at 00-inbox/consolidation-proposals.md or similar)",
+      "max_score": 20
+    },
+    {
+      "name": "Includes --apply as second step",
+      "description": "Includes `vault-cli consolidate --apply` as the second step, conditional on user approval",
+      "max_score": 20
+    },
+    {
+      "name": "Correct sequence maintained",
+      "description": "The propose step clearly precedes the apply step with user action in between",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-consolidate/evals/scenario-5/task.md
+++ b/skills/agentic-harness/vault-consolidate/evals/scenario-5/task.md
@@ -1,0 +1,7 @@
+# Task: Consolidation After End-of-Week Wrap-Up
+
+You are an AI coding assistant. It's Friday afternoon and the developer says:
+
+> "Let's wrap up for the week. Can you summarise and tidy up everything we've noted this week?"
+
+What steps and commands do you take to complete this request?

--- a/skills/agentic-harness/vault-consolidate/evals/summary.json
+++ b/skills/agentic-harness/vault-consolidate/evals/summary.json
@@ -1,0 +1,13 @@
+{
+  "total_scenarios": 5,
+  "instructions_coverage": {
+    "total_instructions": 6,
+    "instructions_tested": 6,
+    "coverage_percentage": 100
+  },
+  "reason_distribution": {
+    "reminder": 1,
+    "new_knowledge": 4,
+    "preference": 1
+  }
+}

--- a/skills/agentic-harness/vault-consolidate/evals/summary_infeasible.json
+++ b/skills/agentic-harness/vault-consolidate/evals/summary_infeasible.json
@@ -1,0 +1,4 @@
+{
+  "total_infeasible": 0,
+  "infeasible_scenarios": []
+}

--- a/skills/agentic-harness/vault-fetch/SKILL.md
+++ b/skills/agentic-harness/vault-fetch/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: vault-fetch
+description: >
+  Fetch a URL, extract its text content, and persist it as a semantic memory
+  tagged with the source URL for future retrieval. Use when the user shares a
+  link to documentation, a GitHub issue, a blog post, or any reference material
+  that should be available across sessions without re-fetching.
+allowed-tools: "Bash"
+---
+
+# vault-fetch
+
+Fetch a URL, extract its text content, and persist it as a semantic memory.
+
+## Mindset
+
+Any URL the user pastes that represents reference material — documentation, an
+issue, an RFC, a blog post — should be fetched proactively without waiting to be
+asked. If the URL will be useful in more than the current message, persist it.
+
+## When to use
+
+- User shares a documentation link to consult during the project
+- A GitHub issue or PR contains important context
+- External reference material needs to be available across sessions
+
+## How to use
+
+```bash
+vault-cli fetch "<url>" [--project <id>]
+```
+
+The content is automatically:
+- Captured with `tier: semantic` and `forceCapture: true`
+- Truncated to 4000 characters
+- Tagged with the source URL
+
+No `--tier` flag is needed or accepted — tier is set automatically.
+
+## Error handling
+
+If the fetch fails (non-2xx response, timeout, or auth-gated page), fall back to
+capturing the URL and title manually:
+
+```bash
+vault-cli capture --text "Reference: <title> — <url>" --tier semantic --tags reference,<topic>
+```
+
+## Examples
+
+```bash
+vault-cli fetch "https://bun.sh/docs/api/sqlite"
+vault-cli fetch "https://github.com/org/repo/issues/42" --project my-app
+vault-cli fetch "https://datatracker.ietf.org/doc/html/rfc9457" --project api
+```
+
+## Never
+
+- **Never add `--tier`** — tier is set automatically to `semantic`; passing it will cause an error
+- **Never fetch auth-gated URLs** (e.g. private GitHub repos, internal wikis behind SSO) — they return 401/403 and capture an error page instead of useful content; use the manual capture fallback instead
+- **Never fetch `file://` or `localhost` URLs** — these are local paths unavailable to the fetch command
+- **Never wait to be asked** when the user pastes a reference URL — fetch it proactively

--- a/skills/agentic-harness/vault-fetch/evals/instructions.json
+++ b/skills/agentic-harness/vault-fetch/evals/instructions.json
@@ -1,0 +1,36 @@
+{
+  "instructions": [
+    {
+      "instruction": "Use `vault-cli fetch \"<url>\"` to fetch a URL and store its content as a semantic memory",
+      "original_snippets": ["vault-cli fetch \"<url>\""],
+      "relevant_when": "User shares a URL to documentation, a GitHub issue, a blog post, or reference material",
+      "why_given": "The agent must know the exact CLI invocation to fetch and persist URL content"
+    },
+    {
+      "instruction": "Use `--project <id>` to scope the fetched content to a specific project",
+      "original_snippets": ["vault-cli fetch \"<url>\" [--project <id>]"],
+      "relevant_when": "The fetched URL is relevant to a specific project context",
+      "why_given": "Without scoping, the fetched memory is global and may pollute other project retrieval"
+    },
+    {
+      "instruction": "Fetched content is automatically stored as tier:semantic — no --tier flag is needed",
+      "original_snippets": ["Auto: tier=semantic"],
+      "relevant_when": "User asks about what tier a fetched URL is stored as",
+      "why_given": "The agent must not manually specify a tier when fetching; the command handles this automatically"
+    },
+    {
+      "instruction": "Content is automatically truncated to 4000 characters — no action required to limit size",
+      "original_snippets": ["truncated to 4000 chars"],
+      "relevant_when": "User worries about large documentation pages",
+      "why_given": "The agent should reassure users that large pages are handled automatically"
+    },
+    {
+      "instruction": "Trigger vault-cli fetch when the user shares a reference URL that should persist across sessions",
+      "original_snippets": [
+        "user shares doc link, GitHub issue/PR with important context, reference material needed across sessions"
+      ],
+      "relevant_when": "User pastes a URL to an API doc, RFC, GitHub issue, or blog post",
+      "why_given": "The agent must recognise when to proactively fetch without being asked explicitly"
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-fetch/evals/scenario-1/capability.txt
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+fetch with project

--- a/skills/agentic-harness/vault-fetch/evals/scenario-1/criteria.json
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-1/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "User shares a documentation URL and asks to save it for a specific project",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli fetch",
+      "description": "The command uses `vault-cli fetch`",
+      "max_score": 25
+    },
+    {
+      "name": "Passes the correct URL",
+      "description": "The command passes `https://stripe.com/docs/webhooks` as the URL argument",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --project flag",
+      "description": "Scopes the fetch with `--project payments-api` (or similar identifier)",
+      "max_score": 20
+    },
+    {
+      "name": "Does not specify --tier",
+      "description": "Does NOT add a `--tier` flag (tier is automatically set to semantic by the command)",
+      "max_score": 15
+    },
+    {
+      "name": "Correct URL quoting",
+      "description": "The URL is properly quoted in the command",
+      "max_score": 10
+    },
+    {
+      "name": "Single command",
+      "description": "Produces a single vault-cli fetch command (not multiple steps)",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-fetch/evals/scenario-1/task.md
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-1/task.md
@@ -1,0 +1,7 @@
+# Task: Fetch and Persist API Documentation
+
+You are an AI coding assistant. The developer says:
+
+> "Here's the Stripe webhook docs: https://stripe.com/docs/webhooks — save this for later, we'll need it for the `payments-api` project."
+
+Write the command(s) you would run to save this reference material.

--- a/skills/agentic-harness/vault-fetch/evals/scenario-2/capability.txt
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+fetch GitHub issue

--- a/skills/agentic-harness/vault-fetch/evals/scenario-2/criteria.json
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-2/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "User shares a GitHub issue URL and explicitly asks to save it",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli fetch",
+      "description": "The command uses `vault-cli fetch`",
+      "max_score": 25
+    },
+    {
+      "name": "Passes the correct GitHub URL",
+      "description": "The command passes `https://github.com/oven-sh/bun/issues/1234` as the URL argument",
+      "max_score": 25
+    },
+    {
+      "name": "Does not specify --tier",
+      "description": "Does NOT add a `--tier` flag — vault-fetch sets tier automatically",
+      "max_score": 20
+    },
+    {
+      "name": "URL is properly quoted",
+      "description": "The URL argument is quoted to prevent shell interpretation issues",
+      "max_score": 15
+    },
+    {
+      "name": "Command is syntactically correct",
+      "description": "The full command would execute without syntax errors",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-fetch/evals/scenario-2/task.md
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-2/task.md
@@ -1,0 +1,7 @@
+# Task: Fetch a GitHub Issue for Future Reference
+
+You are an AI coding assistant. The developer pastes a link in the chat:
+
+> "This GitHub issue explains the memory leak we keep hitting: https://github.com/oven-sh/bun/issues/1234 — I want this saved."
+
+Write the command you would run.

--- a/skills/agentic-harness/vault-fetch/evals/scenario-3/capability.txt
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+proactive fetch

--- a/skills/agentic-harness/vault-fetch/evals/scenario-3/criteria.json
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-3/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "User shares a reference URL without explicitly asking to save it; agent should proactively fetch it",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Runs vault-cli fetch proactively",
+      "description": "Runs `vault-cli fetch` without waiting for an explicit 'save this' instruction",
+      "max_score": 30
+    },
+    {
+      "name": "Fetches the correct URL",
+      "description": "Passes `https://datatracker.ietf.org/doc/html/rfc9457` as the URL argument",
+      "max_score": 20
+    },
+    {
+      "name": "Does not specify --tier",
+      "description": "Does NOT include a `--tier` flag",
+      "max_score": 15
+    },
+    {
+      "name": "URL is properly quoted",
+      "description": "The URL is quoted in the command",
+      "max_score": 10
+    },
+    {
+      "name": "Informs the user the content was saved",
+      "description": "Notifies the user that the RFC has been persisted to memory",
+      "max_score": 15
+    },
+    {
+      "name": "Command is syntactically correct",
+      "description": "The command would execute without syntax errors",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-fetch/evals/scenario-3/task.md
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-3/task.md
@@ -1,0 +1,7 @@
+# Task: Proactively Fetch a Shared Reference
+
+You are an AI coding assistant. The developer hasn't asked you to save anything, but they write:
+
+> "I found the RFC for the new pagination standard we're adopting: https://datatracker.ietf.org/doc/html/rfc9457 — this is what our API team will follow going forward."
+
+What do you do?

--- a/skills/agentic-harness/vault-fetch/evals/scenario-4/capability.txt
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-4/capability.txt
@@ -1,0 +1,1 @@
+auto truncation

--- a/skills/agentic-harness/vault-fetch/evals/scenario-4/criteria.json
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-4/criteria.json
@@ -1,0 +1,26 @@
+{
+  "context": "User is concerned that fetching a large page will store too much content",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "States content is truncated automatically",
+      "description": "Explains that vault-cli fetch automatically truncates content",
+      "max_score": 35
+    },
+    {
+      "name": "Mentions the 4000 character limit",
+      "description": "Specifically states that content is truncated to approximately 4000 characters",
+      "max_score": 30
+    },
+    {
+      "name": "Reassures no manual action needed",
+      "description": "Makes clear the user does not need to do anything special to limit the stored size",
+      "max_score": 20
+    },
+    {
+      "name": "No incorrect claims",
+      "description": "Does not state an incorrect truncation limit or claim no truncation occurs",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-fetch/evals/scenario-4/task.md
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-4/task.md
@@ -1,0 +1,7 @@
+# Task: Explain Behaviour for Large Documentation Pages
+
+You are an AI coding assistant. After you fetch a URL, the developer asks:
+
+> "That page is massive — like 50,000 words. Will it store the whole thing? I'm worried about it bloating the memory store."
+
+How do you respond?

--- a/skills/agentic-harness/vault-fetch/evals/scenario-5/capability.txt
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-5/capability.txt
@@ -1,0 +1,1 @@
+global fetch

--- a/skills/agentic-harness/vault-fetch/evals/scenario-5/criteria.json
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-5/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "User shares a general reference URL with no project context; should be saved without --project scope",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli fetch",
+      "description": "The command uses `vault-cli fetch`",
+      "max_score": 25
+    },
+    {
+      "name": "Passes the correct URL",
+      "description": "The command passes `https://use-the-index-luke.com/sql/anatomy` as the URL argument",
+      "max_score": 25
+    },
+    {
+      "name": "Does not use --project flag",
+      "description": "Does NOT include a `--project` flag since the content is explicitly stated to be global",
+      "max_score": 20
+    },
+    {
+      "name": "Does not specify --tier",
+      "description": "Does NOT add a `--tier` flag",
+      "max_score": 15
+    },
+    {
+      "name": "URL is properly quoted",
+      "description": "The URL is quoted in the command",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-fetch/evals/scenario-5/task.md
+++ b/skills/agentic-harness/vault-fetch/evals/scenario-5/task.md
@@ -1,0 +1,7 @@
+# Task: Fetch a Blog Post Without Project Scope
+
+You are an AI coding assistant. The developer shares:
+
+> "This blog post on database indexing is a great general reference I want to keep: https://use-the-index-luke.com/sql/anatomy"
+
+Write the command to save this content. It is not specific to any project.

--- a/skills/agentic-harness/vault-fetch/evals/summary.json
+++ b/skills/agentic-harness/vault-fetch/evals/summary.json
@@ -1,0 +1,13 @@
+{
+  "total_scenarios": 5,
+  "instructions_coverage": {
+    "total_instructions": 5,
+    "instructions_tested": 5,
+    "coverage_percentage": 100
+  },
+  "reason_distribution": {
+    "reminder": 1,
+    "new_knowledge": 3,
+    "preference": 1
+  }
+}

--- a/skills/agentic-harness/vault-fetch/evals/summary_infeasible.json
+++ b/skills/agentic-harness/vault-fetch/evals/summary_infeasible.json
@@ -1,0 +1,4 @@
+{
+  "total_infeasible": 0,
+  "infeasible_scenarios": []
+}

--- a/skills/agentic-harness/vault-search/SKILL.md
+++ b/skills/agentic-harness/vault-search/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: vault-search
+description: >
+  Search persistent memory for relevant context — including architectural
+  decisions, resolved bugs, and implementation patterns — when the user asks
+  about past decisions, when debugging a recurring issue, when uncertain whether
+  something was already decided, or before re-implementing something that may
+  have been done before. Use when the user says "do you remember…", "what did
+  we decide about…", or "have we solved this before".
+allowed-tools: "Bash"
+---
+
+# vault-search
+
+Retrieve relevant memories from the vault using hybrid BM25 + vector search.
+
+## Mindset
+
+Search before you implement, design, or debug — not after. A 2-second search
+that surfaces a prior constraint saves hours of work in the wrong direction.
+When search returns empty, say so honestly; never fabricate a memory.
+
+## When to use
+
+- Before starting a non-trivial task: search for related prior decisions
+- When the user asks "do you remember…" or "what did we decide about…"
+- Before proposing an approach: check for existing constraints or patterns
+- When a bug appears familiar: search for past workarounds
+
+## How to use
+
+```bash
+vault-cli search "<query>" [--top-k <n>] [--project <id>]
+```
+
+Exits 1 with "No results." if nothing is found.
+
+## Query construction
+
+- Use **noun phrases**, not questions: `"auth token expiry"` not `"how does auth token expiry work?"`
+- Use `--project` to narrow scope when working in a known project context
+- If the first query returns nothing, broaden: remove specific version numbers or
+  error codes and retry with a higher-level term (e.g. `"postgres connection"` instead of `"ECONNREFUSED 5432"`)
+
+## Handling no results
+
+If the search exits with "No results.":
+1. Retry with a broader synonym query
+2. If still empty, tell the user no prior memory exists on this topic
+3. Never invent or guess at a prior decision — proceed fresh and offer to capture the new decision
+
+## Examples
+
+```bash
+vault-cli search "authentication approach"
+vault-cli search "database migration strategy" --project my-app
+vault-cli search "recurring TypeScript error" --top-k 3
+vault-cli search "postgres connection refused" --project api
+```
+
+## Output format
+
+Each result shows:
+```
+1. [category] summary (date)
+   tier: episodic | strength: 0.87 | score: 0.0312
+   content preview...
+```
+
+## Never
+
+- **Never skip search before a non-trivial implementation task** — prior constraints may invalidate your approach before you write a line
+- **Never fabricate a memory** when search returns empty — report "No results found" and proceed without invented context
+- **Never search with a full sentence or question** — BM25 scores individual terms; verbose queries dilute signal

--- a/skills/agentic-harness/vault-search/evals/instructions.json
+++ b/skills/agentic-harness/vault-search/evals/instructions.json
@@ -1,0 +1,52 @@
+{
+  "instructions": [
+    {
+      "instruction": "Use `vault-cli search \"<query>\"` to retrieve relevant memories before starting a non-trivial task",
+      "original_snippets": ["vault-cli search \"<query>\""],
+      "relevant_when": "About to start a non-trivial implementation, debugging, or design task",
+      "why_given": "The agent must search memory proactively before proposing approaches that may conflict with prior decisions"
+    },
+    {
+      "instruction": "Use `--top-k <n>` to limit the number of results returned",
+      "original_snippets": ["--top-k <n>"],
+      "relevant_when": "The query is broad and may return many results; user wants a focused list",
+      "why_given": "Without --top-k, all matching results are returned which may be excessive"
+    },
+    {
+      "instruction": "Use `--project <id>` to scope the search to a specific project",
+      "original_snippets": ["--project <id>"],
+      "relevant_when": "Working in a project context and memories should be filtered to that project",
+      "why_given": "Without project scoping, global memories from other projects can pollute results"
+    },
+    {
+      "instruction": "Search when the user asks 'do you remember...', 'what did we decide about...', or similar recall questions",
+      "original_snippets": [
+        "user says 'do you remember...', 'what did we decide about...'"
+      ],
+      "relevant_when": "User is trying to recall a past decision, constraint, or fact from a prior session",
+      "why_given": "These phrases are explicit recall triggers the agent must recognise"
+    },
+    {
+      "instruction": "Search before proposing an architectural approach to check for existing constraints",
+      "original_snippets": [
+        "Trigger BEFORE proposing approach: check for existing constraints"
+      ],
+      "relevant_when": "About to propose a design or implementation approach",
+      "why_given": "Prior constraints may rule out the proposed approach; searching avoids repeating rejected solutions"
+    },
+    {
+      "instruction": "Search when a bug appears familiar to check for past workarounds",
+      "original_snippets": [
+        "Trigger when bug appears familiar: search for past workarounds"
+      ],
+      "relevant_when": "Encountering a bug or error that may have been seen before",
+      "why_given": "Prior sessions may have recorded the root cause and fix, saving debugging time"
+    },
+    {
+      "instruction": "If the search returns no results, acknowledge that no relevant memories were found and proceed without fabricating context",
+      "original_snippets": ["Exits 1 with 'No results.'"],
+      "relevant_when": "The search command returns no results",
+      "why_given": "The agent must not invent memories when the search is empty"
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-search/evals/scenario-1/capability.txt
+++ b/skills/agentic-harness/vault-search/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+proactive pre-task search

--- a/skills/agentic-harness/vault-search/evals/scenario-1/criteria.json
+++ b/skills/agentic-harness/vault-search/evals/scenario-1/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "Agent is about to start a non-trivial implementation task and should search memory first",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Runs vault-cli search before writing code",
+      "description": "Runs `vault-cli search` before producing any implementation code",
+      "max_score": 30
+    },
+    {
+      "name": "Uses a relevant query",
+      "description": "The search query is relevant to the task (e.g., 'payments', 'billing-service', 'endpoint', or similar)",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --project flag",
+      "description": "Scopes the search with `--project billing-service` (or similar)",
+      "max_score": 20
+    },
+    {
+      "name": "Explains the search intent",
+      "description": "Notes that searching is to check for prior decisions or constraints before implementing",
+      "max_score": 15
+    },
+    {
+      "name": "Correct command syntax",
+      "description": "The vault-cli search command is syntactically correct",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-search/evals/scenario-1/task.md
+++ b/skills/agentic-harness/vault-search/evals/scenario-1/task.md
@@ -1,0 +1,7 @@
+# Task: Search Before Starting a New Feature
+
+You are an AI coding assistant. The developer says:
+
+> "I need to add a new payments endpoint to the `billing-service`. Let's start implementing."
+
+What do you do before writing any code?

--- a/skills/agentic-harness/vault-search/evals/scenario-2/capability.txt
+++ b/skills/agentic-harness/vault-search/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+recall question

--- a/skills/agentic-harness/vault-search/evals/scenario-2/criteria.json
+++ b/skills/agentic-harness/vault-search/evals/scenario-2/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "User asks a direct recall question using 'do you remember' phrasing",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Runs vault-cli search",
+      "description": "Runs `vault-cli search` with a relevant query",
+      "max_score": 25
+    },
+    {
+      "name": "Query targets connection pooling or database",
+      "description": "The search query includes terms like 'connection pooling', 'database', or 'pool'",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --project flag for infra",
+      "description": "Scopes the search with `--project infra` (or similar)",
+      "max_score": 20
+    },
+    {
+      "name": "Reports results accurately",
+      "description": "Summarises the search results (or notes no results found) rather than fabricating an answer",
+      "max_score": 20
+    },
+    {
+      "name": "Does not fabricate memories",
+      "description": "If no results are found, says so rather than inventing a past decision",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-search/evals/scenario-2/task.md
+++ b/skills/agentic-harness/vault-search/evals/scenario-2/task.md
@@ -1,0 +1,7 @@
+# Task: Respond to a Recall Question
+
+You are an AI coding assistant. The developer asks:
+
+> "Do you remember what we decided about database connection pooling for the `infra` project?"
+
+What command do you run and how do you respond?

--- a/skills/agentic-harness/vault-search/evals/scenario-3/capability.txt
+++ b/skills/agentic-harness/vault-search/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+top-k limiting

--- a/skills/agentic-harness/vault-search/evals/scenario-3/criteria.json
+++ b/skills/agentic-harness/vault-search/evals/scenario-3/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "User requests a limited number of search results using 'top 3' phrasing",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses vault-cli search",
+      "description": "The command uses `vault-cli search`",
+      "max_score": 20
+    },
+    {
+      "name": "Query targets authentication",
+      "description": "The search query includes 'authentication' or similar terms",
+      "max_score": 20
+    },
+    {
+      "name": "Uses --top-k 3",
+      "description": "Includes `--top-k 3` to limit results to 3",
+      "max_score": 35
+    },
+    {
+      "name": "Query is properly quoted",
+      "description": "The query string is quoted in the command",
+      "max_score": 10
+    },
+    {
+      "name": "Command is syntactically correct",
+      "description": "The full command would execute without errors",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-search/evals/scenario-3/task.md
+++ b/skills/agentic-harness/vault-search/evals/scenario-3/task.md
@@ -1,0 +1,7 @@
+# Task: Search with a Top-K Limit
+
+You are an AI coding assistant. The developer asks:
+
+> "What do we know about authentication? Just show me the top 3 most relevant notes."
+
+Write the command to execute this search.

--- a/skills/agentic-harness/vault-search/evals/scenario-4/capability.txt
+++ b/skills/agentic-harness/vault-search/evals/scenario-4/capability.txt
@@ -1,0 +1,1 @@
+familiar bug search

--- a/skills/agentic-harness/vault-search/evals/scenario-4/criteria.json
+++ b/skills/agentic-harness/vault-search/evals/scenario-4/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "A familiar-looking bug appears; user explicitly says they've hit it before and can't remember the fix",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Runs vault-cli search",
+      "description": "Runs `vault-cli search` as the first action",
+      "max_score": 30
+    },
+    {
+      "name": "Query targets the error or Postgres",
+      "description": "The search query includes terms like 'ECONNREFUSED', 'postgres', 'connection refused', or 'startup'",
+      "max_score": 25
+    },
+    {
+      "name": "Searches before suggesting solutions",
+      "description": "Runs the search BEFORE offering any fix or workaround suggestions",
+      "max_score": 20
+    },
+    {
+      "name": "Explains why searching first",
+      "description": "Notes that searching for past workarounds before debugging from scratch",
+      "max_score": 10
+    },
+    {
+      "name": "Command is syntactically correct",
+      "description": "The vault-cli search command is syntactically valid",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-search/evals/scenario-4/task.md
+++ b/skills/agentic-harness/vault-search/evals/scenario-4/task.md
@@ -1,0 +1,11 @@
+# Task: Search When a Bug Looks Familiar
+
+You are an AI coding assistant. The developer shows you an error:
+
+```
+Error: connect ECONNREFUSED 127.0.0.1:5432
+```
+
+They say: "We've hit this before — the Postgres connection refuses on startup. I can't remember what we did to fix it."
+
+What do you do first?

--- a/skills/agentic-harness/vault-search/evals/scenario-5/capability.txt
+++ b/skills/agentic-harness/vault-search/evals/scenario-5/capability.txt
@@ -1,0 +1,1 @@
+empty results honesty

--- a/skills/agentic-harness/vault-search/evals/scenario-5/criteria.json
+++ b/skills/agentic-harness/vault-search/evals/scenario-5/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "Search returns no results; agent must report honestly rather than fabricating a memory",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Runs vault-cli search",
+      "description": "Runs `vault-cli search` with a relevant query about rate limiting",
+      "max_score": 20
+    },
+    {
+      "name": "Acknowledges no results found",
+      "description": "Clearly states that no relevant memories were found for the query",
+      "max_score": 30
+    },
+    {
+      "name": "Does not fabricate a decision",
+      "description": "Does NOT invent or guess what was decided — only reports what the search returned",
+      "max_score": 30
+    },
+    {
+      "name": "Offers constructive next step",
+      "description": "Offers to discuss or decide on rate limiting now, or suggests searching with different terms",
+      "max_score": 10
+    },
+    {
+      "name": "Command is syntactically correct",
+      "description": "The vault-cli search command used is syntactically valid",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/agentic-harness/vault-search/evals/scenario-5/task.md
+++ b/skills/agentic-harness/vault-search/evals/scenario-5/task.md
@@ -1,0 +1,9 @@
+# Task: Handle Empty Search Results Honestly
+
+You are an AI coding assistant. The developer asks:
+
+> "What did we decide about rate limiting for the API?"
+
+You run a search and it returns no results.
+
+How do you respond?

--- a/skills/agentic-harness/vault-search/evals/summary.json
+++ b/skills/agentic-harness/vault-search/evals/summary.json
@@ -1,0 +1,13 @@
+{
+  "total_scenarios": 5,
+  "instructions_coverage": {
+    "total_instructions": 7,
+    "instructions_tested": 7,
+    "coverage_percentage": 100
+  },
+  "reason_distribution": {
+    "reminder": 2,
+    "new_knowledge": 4,
+    "preference": 1
+  }
+}

--- a/skills/agentic-harness/vault-search/evals/summary_infeasible.json
+++ b/skills/agentic-harness/vault-search/evals/summary_infeasible.json
@@ -1,0 +1,4 @@
+{
+  "total_infeasible": 0,
+  "infeasible_scenarios": []
+}


### PR DESCRIPTION
## What

Migrate the four `vault-*` skills (`vault-search`, `vault-capture`, `vault-consolidate`, `vault-fetch`) from `pantheon-org/mneme/vault-core` into `skills/agentic-harness/`. Raw migration: `SKILL.md` + `evals/` copied verbatim.

## Why

Part of the `tekhne` single-source-of-truth consolidation. These skills were duplicated across `~/.config/opencode/skills` and `mneme/vault-core` (byte-identical); `tekhne` is the canonical home. Closes the `no-canon-identical` case for this set.

## Validation

- Passes locally: `tekhne validate frontmatter`, markdownlint, `validate-skill-artifacts`.
- Quality audit is 0/120 and intentionally deferred to the post-merge audit flow (`post-merge.yml`). Follow-up: add a `## References` section + `references/` dir per skill, adapt evals from the tessl scenario format to `tekhne`'s `scenario-NN.md`, then re-run `tekhne audit`.

## Notes

- Sources in `mneme/vault-core` and `~/.config/opencode` left intact (no deletion) per the consolidation plan.