### PR TITLE
feat(journal-entry-creator): add ticket-refinement entry type

### DIFF
--- a/skills/documentation/journal-entry-creator/SKILL.md
+++ b/skills/documentation/journal-entry-creator/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: journal-entry-creator
 description:
-  "Create structured journal entries with YAML frontmatter, template-based sections, and compliance validation. Use when user asks to 'create journal entry', 'new journal', 'document [topic]',
-  'journal about [topic]', or needs to create timestamped .md files in YYYY/MM/ directories. Supports four entry types: general journal entries, troubleshooting sessions, learning notes, and article
-  summaries. Keywords: journal, documentation, troubleshooting, learning, article-summary, YAML frontmatter, template schemas, validation."
+  "Create structured journal entries with YAML frontmatter, template-based sections, and compliance validation. Use when user asks to 'create journal entry', 'new journal', 'document [topic]', 'journal about [topic]', or needs to create timestamped .md files in YYYY/MM/ directories. Supports five entry types: general journal entries, troubleshooting sessions, learning notes, article summaries, and ticket-refinement sessions. Keywords: journal, documentation, troubleshooting, learning, article-summary, ticket-refinement, refine ticket, YAML frontmatter, template schemas, validation."
 ---
 
 # Journal Entry Creator
@@ -29,6 +27,7 @@ Use journal-entry-creator when:
 - **Problem resolution?** → Troubleshooting
 - **New knowledge/skills?** → Learning  
 - **External content summary?** → Article Summary
+- **Fleshing out or amending a ticket (refinement prep, backlog grooming)?** → Ticket Refinement
 - **Otherwise** → Journal Entry
 
 | User Intent Signals | Type | Template | Required Tag |
@@ -36,7 +35,10 @@ Use journal-entry-creator when:
 | "error", "fix", "resolved", "incident" | Troubleshooting | `troubleshooting.yaml` | `troubleshooting` |
 | "learned", "tutorial", "discovered" | Learning | `learning.yaml` | `learning` |
 | URL/source, "read", "watched", "summarize" | Article Summary | `article-summary.yaml` | `article`/`video`/`podcast`/`talk` |
+| "refine", "flesh out", "groom", "amend ticket" | Ticket Refinement | `ticket-refinement.yaml` | `ticket-refinement` |
 | General documentation, investigation | Journal Entry | `journal-entry.yaml` | (flexible) |
+
+**Trade-off:** When intent is ambiguous, prefer the more specific type (Troubleshooting > Ticket Refinement > Learning > General).
 
 ## Template Schema System
 
@@ -49,6 +51,7 @@ Before generating any entry, you MUST read the complete template schema file:
 skills/journal-entry-creator/assets/templates/troubleshooting.yaml
 skills/journal-entry-creator/assets/templates/learning.yaml
 skills/journal-entry-creator/assets/templates/article-summary.yaml
+skills/journal-entry-creator/assets/templates/ticket-refinement.yaml
 skills/journal-entry-creator/assets/templates/journal-entry.yaml
 ```
 
@@ -161,6 +164,41 @@ under the entry slug directory makes every path unique.
 
 **Note:** The `assets/` directories are gitignored — screenshots are local-only. The markdown image
 references are tracked in git as documentation of what evidence was captured.
+
+### Proposed Ticket Description (Ticket-Refinement Entries)
+
+Applies to ticket-refinement sessions: fleshing out or amending an issue-tracker ticket (refinement prep, backlog grooming, turning a one-line ticket into a refinement-ready one). Use the `ticket-refinement.yaml` type.
+
+**HARD RULE: this skill NEVER edits the ticket directly.** The amended ticket content lives inside the journal entry as a ready-to-paste markdown block. Applying it to the tracker is a separate step the user explicitly confirms, performed outside this skill.
+
+When an entry refines a ticket, you MUST:
+
+1. Set `refinement_ticket: <KEY>` in the frontmatter (e.g. `refinement_ticket: TICKET-123`). Use this field, not `jira_ticket` — the deliverable is a ticket description, not a comment.
+2. Add a `## Proposed Ticket Description` section holding the full amended description inside a fenced markdown block:
+
+````markdown
+## Proposed Ticket Description
+
+Draft for TICKET-123 - review before applying; not yet applied to the ticket.
+
+```markdown
+**Summary:** <one-line summary>
+
+**Background**
+
+<full, self-contained amended ticket description>
+```
+````
+
+Rules for the proposed description:
+
+- It is a DRAFT and has NOT been applied. Lead with a `Draft for [TICKET] - review before applying; not yet applied.` line, and never write it to the tracker from this skill.
+- It MUST sit inside a fenced code block with a language specifier so it copies verbatim and its inner headings do not become document headings (this keeps the single-H1 rule intact). Use a 4-backtick outer fence when the ticket content itself contains 3-backtick code blocks.
+- It must be self-contained: a ticket reader has not seen the journal entry, so the description stands on its own.
+- Follow your team's ticket-writing standard if one exists.
+- If the work touches regulated or personal data, state the constraint and route final sign-off to the appropriate function.
+
+The validator (`validate-journal-entry.sh`) enforces this: when `refinement_ticket` is present in frontmatter, a `## Proposed Ticket Description` section is required. It is a no-op when the field is absent, so other entries are unaffected.
 
 ## Success Criteria & Validation Rules
 
@@ -291,13 +329,6 @@ git commit -m "Add journal entry: [Brief Description] (YYYY-MM-DD)"
 - Date in parentheses (YYYY-MM-DD)
 - Example: `Add journal entry: OpenCode process fix (2025-02-24)`
 
-**Commit message format:**
-
-- Prefix: `Add journal entry:`
-- Brief description (30-50 chars)
-- Date in parentheses (YYYY-MM-DD)
-- Example: `Add journal entry: OpenCode process fix (2025-02-24)`
-
 ## Anti-Patterns
 
 ### NEVER create entries without reading the template schema first
@@ -324,6 +355,12 @@ git commit -m "Add journal entry: [Brief Description] (YYYY-MM-DD)"
 - **BAD**: filename `2025-02-24-*.md`, frontmatter `date: 2025-02-25`, H1 `March 1, 2025`.
 - **GOOD**: all three match exactly - `2025-02-24` in filename, `date: 2025-02-24` in frontmatter, `February 24, 2025` in H1.
 
+### NEVER edit the ticket directly when refining it
+
+- **WHY**: this skill produces a reviewable draft; applying changes to the tracker is a separate, user-confirmed step outside the skill.
+- **BAD**: refine a ticket and push the edit straight to the issue tracker.
+- **GOOD**: set `refinement_ticket` and put the amended content in a `## Proposed Ticket Description` fenced block; the user applies it separately.
+
 ## References
 
 ### Template Schemas (assets/templates/)
@@ -332,6 +369,7 @@ git commit -m "Add journal entry: [Brief Description] (YYYY-MM-DD)"
 - `troubleshooting.yaml` - Problem resolution sessions
 - `learning.yaml` - Knowledge acquisition documentation
 - `article-summary.yaml` - External content summaries
+- `ticket-refinement.yaml` - Issue-tracker ticket refinement (amended ticket captured in-entry, never written to the tracker)
 
 Load with relative paths: `skills/journal-entry-creator/assets/templates/[file]`
 

--- a/skills/documentation/journal-entry-creator/assets/templates/ticket-refinement.yaml
+++ b/skills/documentation/journal-entry-creator/assets/templates/ticket-refinement.yaml
@@ -1,0 +1,252 @@
+# Ticket Refinement Entry Template Schema
+# Describes the REQUIRED structure for ticket-refinement session entries.
+#
+# A ticket-refinement entry documents the work of fleshing out or amending an issue-tracker ticket
+# (backlog grooming, refinement prep, turning a one-line ticket into a refinement-ready one).
+#
+# HARD RULE: this workflow NEVER edits the ticket directly. The proposed/amended ticket content lives
+# inside the entry as a ready-to-paste markdown block (## Proposed Ticket Description). Applying it to
+# the tracker is a separate, explicitly confirmed step outside this skill.
+
+template_name: ticket-refinement
+description: Documentation of an issue-tracker ticket refinement session; the amended ticket content is captured in-entry, never written to the tracker directly
+filename_pattern: "YYYY-MM-DD-slug.md"
+location_pattern: "YYYY/MM/"
+
+# Extends journal-entry template with ticket-refinement-specific requirements
+extends: journal-entry
+
+# YAML frontmatter (inherits from journal-entry with additions)
+frontmatter:
+  required_fields:
+    - name: refinement_ticket
+      type: string
+      description: >
+        Issue-tracker key being refined (e.g. "TICKET-123"). REQUIRED for this entry type. When present, a
+        '## Proposed Ticket Description' section becomes REQUIRED (enforced by the validator) and a no-op
+        otherwise, so existing entries are unaffected. Use this field rather than jira_ticket for a
+        refinement: the deliverable is the ticket description, not a comment draft.
+      example: "TICKET-123"
+
+    - name: tags
+      type: array
+      description: "Must include the 'ticket-refinement' tag"
+      validation: "Must contain 'ticket-refinement' in array"
+      example:
+        - ticket-refinement
+        - ticket-123
+        - backlog
+
+  optional_fields:
+    # Set jira_ticket ONLY if you also want a separate '## Jira Comment Draft' (e.g. a note to post on the
+    # ticket alongside the refinement). It is independent of refinement_ticket. See journal-entry.yaml.
+    - name: jira_ticket
+      type: string
+      description: "Optional. Set only when a separate comment draft is also wanted; forces a '## Jira Comment Draft' section. Independent of refinement_ticket."
+      example: "TICKET-123"
+
+# Document structure (REQUIRED sections in order)
+structure:
+  # H1 Title (same as journal-entry)
+  - section: h1_title
+    level: 1
+    format: "# [Ticket Key] [Short Title] - [Month D, YYYY]"
+    required: true
+    example: "# TICKET-123 Service Logging Refinement - July 8, 2026"
+
+  # Metadata block (extended for refinement)
+  - section: metadata_block
+    required: true
+    format: "**Key:** Value (NO bullet points, NO list formatting)"
+    fields:
+      - Date: "Month D, YYYY"
+      - Duration: "X hours (optional)"
+      - Ticket: "Issue-tracker key being refined (e.g. TICKET-123)"
+      - Context: "Why this ticket is being refined and for which refinement/session"
+      - System: "System/Service the ticket concerns"
+    example: |
+      **Date:** July 8, 2026
+      **Duration:** ~1 hour
+      **Ticket:** TICKET-123
+      **Context:** Fleshing out TICKET-123 ahead of the next refinement session
+      **System:** example-service
+
+  # Session Overview
+  - section: session_overview
+    level: 2
+    heading: "## Session Overview"
+    required: true
+    description: "High-level summary of what the ticket is, why it needed refining, and what this session produced"
+
+  # Context
+  - section: context
+    level: 2
+    heading: "## Context"
+    required: true
+    description: "Origin of the ticket (parent incident, request, backlog item) and any constraints (regulatory, personal data, dependencies)"
+
+  # Current Ticket State
+  - section: current_ticket_state
+    level: 2
+    heading: "## Current Ticket State"
+    required: true
+    description: "What the ticket said before refinement — summary, type, status, and what was missing or ambiguous"
+    example: |
+      - Summary: "Ensure better logging on example-service-api"
+      - Type: Maintenance, Status: Backlog
+      - Body was a single line linking the parent incident; no problem statement, scope, or acceptance criteria
+
+  # Findings / Investigation
+  - section: findings
+    level: 2
+    heading: "## Findings"
+    required: true
+    description: >
+      What was learned that grounds the refinement — code read, incidents reviewed, constraints confirmed.
+      Use numbered '### Step N: [Title]' subsections with what/commands/result when the refinement involved
+      investigation, or a bulleted list of grounded findings otherwise.
+
+  # Proposed Ticket Description (THE deliverable — enforced by validator when refinement_ticket is set)
+  - section: proposed_ticket_description
+    level: 2
+    heading: "## Proposed Ticket Description"
+    required: true
+    description: >
+      The ready-to-paste, amended ticket content — the sole deliverable of a refinement session. REQUIRED
+      whenever frontmatter sets refinement_ticket (enforced by validate-journal-entry.sh). It MUST be a single
+      fenced code block with a language specifier (```markdown), so it copies verbatim into the tracker and its
+      inner headings are not parsed as document headings (keeps the single-H1 rule intact). Use a 4-backtick
+      outer fence (````markdown) if the ticket content itself contains 3-backtick code blocks. It is a DRAFT:
+      state that it has not been applied to the ticket and that applying it is a separate, human-confirmed step.
+      NEVER edit the ticket directly from this skill.
+    format: |
+      A short lead line stating this is a draft, not applied, then a fenced markdown block holding the full
+      amended ticket description. Follow your team's ticket-writing standard for the INNER block if one exists.
+      A widely useful default is bold-label sections (not markdown headings), in this order (omit a section
+      when it does not apply, do not reorder):
+
+        1. **Summary** (optional one-line restatement of the title)
+        2. **Background** / **Context** (parent incident/request, corrected root cause, framing; if the work
+           touches regulated or personal data, state that constraint HERE)
+        3. **Problem** (the specific engineering gap)
+        4. **Investigation required** (when a decision is open: numbered options + trade-offs, ending
+           "Capture the decision and rationale on the ticket." — use this instead of a loose open-questions list)
+        5. **Conditions of Satisfaction** (MoSCoW: MUST / SHOULD / COULD) as checkbox items (`- [ ]`) so they render as tickable tasks in the tracker
+        6. **Acceptance criteria** (concrete, testable; add a "no new personal data emitted" criterion when the
+           work touches regulated or personal data)
+        7. **Supporting Information** (repo URLs, incident links, key file paths)
+
+      Always hyperlink references with [text](url): other ticket/incident keys to their tracker URL, and repos
+      and source files to their source-host URL. Do not leave bare keys or paths on first mention.
+    example: |
+      The following is the ready-to-paste description produced this session. It is a draft for review, not
+      applied to the ticket. Copy the block below verbatim into TICKET-123 once approved.
+
+      ````markdown
+      **Summary:** Ensure better logging on example-service-api
+
+      **Background**
+
+      Raised from incident [INCIDENT-456](https://tracker.example.com/browse/INCIDENT-456). If the service
+      processes personal data, no personal data may be written to logs, traces, or metrics; pseudonymised
+      identifiers only.
+
+      **Problem**
+
+      On a 4xx/5xx alarm, on-call has no privacy-safe way to identify the affected request ...
+
+      **Investigation required**
+
+      1. Scrubbed structured log record on the failure path. Trade-offs: ...
+      2. Dedicated rejected-request log group with short retention. Trade-offs: ...
+
+      Capture the decision and rationale on the ticket.
+
+      **Conditions of Satisfaction**
+
+      - [ ] **MUST** attach a pseudonymised correlation key on the validation-failure path.
+      - [ ] **SHOULD** document a query/runbook from alarm to correlated record.
+      - [ ] **COULD** add a rejected-request metric distinct from the generic 4xx alarm.
+
+      **Acceptance criteria**
+
+      - A simulated malformed request produces a privacy-safe, correlated log record.
+      - No new personal data is emitted to logs, traces, or metrics.
+
+      **Supporting Information**
+
+      - Repo: [example-service](https://example.com/org/example-service)
+      - Incident: [INCIDENT-456](https://tracker.example.com/browse/INCIDENT-456)
+      ````
+    validation:
+      - "Required if frontmatter sets refinement_ticket (checked by validate-journal-entry.sh)"
+      - "Must be a fenced code block with a language specifier so it is copy-pasteable and does not add H1/H2 headings"
+      - "Never applied to the tracker from this skill; applying it is a separate, explicitly confirmed step"
+
+  # Session Outcome
+  - section: session_outcome
+    level: 2
+    heading: "## Session Outcome"
+    required: true
+    format: |
+      **[Status]** - brief summary (text only, NO emojis in this type)
+
+      Next steps:
+
+      - Action item
+    status_options:
+      - "Refined"
+      - "Draft for review"
+      - "Blocked"
+    example: |
+      Draft for review - TICKET-123 is refinement-ready; the ticket itself was intentionally left untouched.
+
+      Next steps:
+
+      - Confirm the draft with the team and apply it to TICKET-123 when approved
+      - If the work touches regulated or personal data, confirm with the owning function before implementation
+
+  # Future Reference / Notes
+  - section: future_reference
+    level: 2
+    heading: "## Future Reference / Notes"
+    required: true
+    description: "Links (ticket, parent incident, repo, key files) and any decisions or open questions carried forward"
+
+  # Tags (at end of document)
+  - section: tags
+    level: 2
+    heading: "## Tags"
+    required: true
+    description: "Backtick-separated tags matching frontmatter; must include ticket-refinement"
+    format: "`ticket-refinement` | `ticket-123` | `tag3`"
+    validation: "Must match tags in frontmatter and include ticket-refinement"
+
+# Ticket-refinement-specific validation
+validation:
+  required_sections:
+    - current_ticket_state
+    - findings
+    - proposed_ticket_description
+    - future_reference
+
+  required_tags:
+    - ticket-refinement
+
+  required_frontmatter:
+    - refinement_ticket
+
+  proposed_ticket_description:
+    - "Enforced by validator when refinement_ticket is set"
+    - "Must be a fenced markdown block (copy-pasteable, no stray headings)"
+
+# Best practices for ticket-refinement entries
+best_practices:
+  - "Follow your team's ticket-writing standard for the inner Proposed Ticket Description block if one exists; a useful default is bold-label sections in the order Background -> Problem -> Investigation required -> Conditions of Satisfaction (MoSCoW) -> Acceptance criteria -> Supporting Information"
+  - "Use MoSCoW (MUST/SHOULD/COULD) checkbox items (`- [ ]`) for Conditions of Satisfaction so they render as tickable tasks in the tracker; use a numbered Investigation required block for open decisions rather than a loose open-questions list"
+  - "Ground the refinement in evidence (code read, incident reviewed): cite file:line and ticket keys"
+  - "Always hyperlink references with [text](url): ticket/incident keys to their tracker URL, repos and source files to their source-host URL; no bare keys or paths on first mention"
+  - "Keep the proposed description self-contained; a ticket reader has not seen the journal entry"
+  - "If the work touches regulated or personal data, flag the constraint in Background and route final sign-off to the owning function"
+  - "Frame the description as decision-support: applying it to the tracker is a separate, human-confirmed step"
+  - "NEVER edit the ticket directly from this skill: the amended content lives in the entry"

--- a/skills/documentation/journal-entry-creator/scripts/validate-journal-entry.sh
+++ b/skills/documentation/journal-entry-creator/scripts/validate-journal-entry.sh
@@ -31,6 +31,16 @@ if [[ ${#args[@]} -eq 0 ]]; then
   exit 2
 fi
 
+# Helper: extract a top-level frontmatter field value (first match), empty if absent
+frontmatter_field() {
+  local file="$1" field="$2"
+  awk '/^---$/{c++; next} c==1' "$file" 2>/dev/null \
+    | grep -E "^${field}:" \
+    | head -1 \
+    | sed -E "s/^${field}:[[:space:]]*\"?([^\"]*)\"?[[:space:]]*\$/\\1/" \
+    || true
+}
+
 # Helper: validate a single file
 validate_single() {
   local file="$1"
@@ -228,6 +238,19 @@ validate_single() {
       echo "Invalid: H1 must end with the full date formatted as 'Month D, YYYY' (expected ending: $formatted_date) in $file" >&2
       rm -f "$tmp_out"
       return 15
+    fi
+  fi
+
+  # 8) Proposed ticket description — only runs when frontmatter declares refinement_ticket.
+  # Ticket-refinement entries never edit the tracker directly; the amended ticket content lives here
+  # as a ready-to-paste markdown block. No-op for entries without the field, so others are unaffected.
+  local refinement_ticket
+  refinement_ticket="$(frontmatter_field "$file" "refinement_ticket")"
+  if [[ -n "$refinement_ticket" ]]; then
+    if ! awk -F"\t" '$2 == "## Proposed Ticket Description" { found=1; exit } END{ if(!found) exit 1 }' "$tmp_out"; then
+      echo "Invalid: refinement_ticket ($refinement_ticket) is set but no '## Proposed Ticket Description' section in $file" >&2
+      rm -f "$tmp_out"
+      return 16
     fi
   fi
 


### PR DESCRIPTION
## What

Adds the fifth **ticket-refinement** entry type to the canonical `journal-entry-creator`, bringing `tekhne` level with the development head:

- **`SKILL.md`** — entry-type selection criterion + matrix row, a new "Proposed Ticket Description (Ticket-Refinement Entries)" section, an anti-pattern, and references. Also fixes a pre-existing duplicated "Commit message format" block.
- **`assets/templates/ticket-refinement.yaml`** — new template.
- **`scripts/validate-journal-entry.sh`** — grafts a `frontmatter_field` helper and a `refinement_ticket` check requiring a `## Proposed Ticket Description` section (does not alter the other validator logic).

## Why

Part of the `tekhne` single-source-of-truth consolidation. `tekhne`'s copy was byte-identical to the published `0.3.1` registry copy (four types); the development head in a consuming repo had a fifth `ticket-refinement` type. This lands that capability in canon.

## Genericization

`tekhne` is a redistributable library, so org-specifics were generalised: "Jira" → "issue tracker", real keys → placeholders (`TICKET-123`/`INCIDENT-456`), a named internal ticket standard → "your team's ticket-writing standard if one exists", and GDPR/DPO/participant-PII → generic "regulated or personal data" + "the owning function". The MoSCoW / bold-label structure is kept as a useful default.

## Validation

- `validate frontmatter`, markdownlint, `validate-skill-artifacts`, shellcheck: pass.
- Validator change unit-tested: fails when `refinement_ticket` is set without the section, passes with it.