### PR TITLE
ci: grade-A skill audit gate (pre-push + CI) + post-merge fixes

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -12,79 +12,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  request-quality-audit:
-    name: Request Skill Quality Audit from Copilot
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Detect merged skills
-        id: skills
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          CHANGED=$(
-            gh api \
-              "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-              --paginate \
-              --jq '.[] | select(.status != "removed") | .filename' \
-            | grep -E '^skills/.*/(SKILL|AGENTS)\.md$' || true
-          )
-
-          if [ -z "$CHANGED" ]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          SKILL_DIRS=$(echo "$CHANGED" | xargs -I{} dirname {} | sort -u)
-
-          delimiter="$(openssl rand -hex 8)"
-          {
-            echo "dirs<<${delimiter}"
-            echo "${SKILL_DIRS}"
-            echo "${delimiter}"
-            echo "found=true"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Create quality audit issue for Copilot
-        if: steps.skills.outputs.found == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          SKILL_DIRS: ${{ steps.skills.outputs.dirs }}
-        run: |
-          body_file=$(mktemp)
-          {
-            printf 'PR #%s has been merged. @github-copilot please run the skill quality audit for the modified skills and commit the results.\n\n' "$PR_NUMBER"
-            printf '**Modified skills:**\n```\n'
-            printf '%s\n' "$SKILL_DIRS"
-            printf '```\n\n'
-            printf '**Steps:**\n'
-            printf '1. Run `bun run audit:skill <path>` for each skill listed above (or `bun run audit:skills` for all)\n'
-            printf '2. Verify the generated audit files under `.context/audits/`\n'
-            printf '3. Commit and push the updated audit files with message: `chore: update skill quality audits after PR #%s`\n' "$PR_NUMBER"
-          } > "$body_file"
-
-          # Check for an existing open issue for this PR's skill quality audit
-          existing_issue_number=$(
-            gh issue list \
-              --state open \
-              --search "Skill quality audit — PR #${PR_NUMBER}: in:title" \
-              --json number \
-              --jq '.[0].number' || true
-          )
-
-          if [ -n "$existing_issue_number" ]; then
-            echo "Found existing skill quality audit issue #${existing_issue_number} for PR #${PR_NUMBER}, adding a comment instead of creating a new issue."
-            gh issue comment "$existing_issue_number" --body-file "$body_file"
-          else
-            gh issue create \
-              --title "Skill quality audit — PR #${PR_NUMBER}: ${PR_TITLE}" \
-              --body-file "$body_file"
-          fi
   update-readme-and-tiles:
     name: Update README and TILES
     if: github.event.pull_request.merged == true
@@ -113,7 +40,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git pull --rebase --autostash origin main
-          git add README.md TILES.md
+          git add README.md docs/src/content/docs/tiles.md
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/skill-audit.yml
+++ b/.github/workflows/skill-audit.yml
@@ -1,0 +1,105 @@
+name: Skill Audit Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - "skills/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  skill-audit:
+    name: Skill Audit
+    # Fork PRs get a read-only token; skip to avoid comment-permission errors.
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      # skill-auditor combines its own D1-D9 scoring with skill-validator's structural checks.
+      - name: Install skill-validator
+        run: |
+          go install github.com/agent-ecosystem/skill-validator/cmd/skill-validator@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Build skill-auditor
+        run: cd tools/skill-auditor && go build -o ../../bin/skill-auditor .
+
+      - name: Find changed skill dirs
+        id: dirs
+        run: |
+          DIRS=$(git diff --name-only --diff-filter=AM \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            -- 'skills/**/SKILL.md' 2>/dev/null \
+            | xargs -I{} dirname {} | sort -u | tr '\n' ' ')
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+          [ -n "$DIRS" ] && echo "found=true" >> "$GITHUB_OUTPUT" || echo "found=false" >> "$GITHUB_OUTPUT"
+
+      - name: Audit changed skills
+        id: audit
+        if: steps.dirs.outputs.found == 'true'
+        run: |
+          set +e
+          rows=""
+          fail=0
+          for dir in ${{ steps.dirs.outputs.dirs }}; do
+            rel="${dir#skills/}"
+            json=$(bin/skill-auditor evaluate "$rel" --json 2>/dev/null)
+            grade=$(printf '%s' "$json" | python3 -c "import sys,json;print(json.load(sys.stdin).get('grade','?'))" 2>/dev/null)
+            total=$(printf '%s' "$json" | python3 -c "import sys,json;print(json.load(sys.stdin).get('total','?'))" 2>/dev/null)
+            [ -z "$grade" ] && grade="?"
+            case "$grade" in
+              A|A+) tier="✅ pass";;
+              B+|B|C+|C) tier="⚠️ warning";;
+              D|F) tier="❌ fail"; fail=1;;
+              *) tier="❓ error"; fail=1;;
+            esac
+            rows="${rows}| \`${rel}\` | ${grade} | ${total}/140 | ${tier} |\n"
+          done
+          {
+            echo "table<<AUDIT_EOF"
+            printf '| Skill | Grade | Score | Tier |\n'
+            printf '| --- | --- | --- | --- |\n'
+            printf "%b" "$rows"
+            echo "AUDIT_EOF"
+            echo "fail=$fail"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing audit comment
+        id: find-comment
+        if: steps.dirs.outputs.found == 'true'
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "## Skill Audit"
+
+      - name: Post audit comment
+        if: steps.dirs.outputs.found == 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            ## Skill Audit
+
+            ${{ steps.audit.outputs.table }}
+
+            **Gate:** ✅ pass = A / A+ (≥126) · ⚠️ warning = C – B+ (98–125, non-blocking) · ❌ fail = D / F (<98, blocks merge)
+
+      - name: Enforce gate (fail on D/F)
+        if: steps.dirs.outputs.found == 'true' && steps.audit.outputs.fail == '1'
+        run: |
+          echo "::error::One or more changed skills scored below C (D/F) or could not be audited. Raise them to at least grade C to pass; grade A for a green pass."
+          exit 1
+
+      - name: No skills changed
+        if: steps.dirs.outputs.found == 'false'
+        run: echo "No SKILL.md changed — nothing to audit."

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -69,3 +69,20 @@ pre-push:
           [ $code -eq 1 ] && rc=1
         done
         exit $rc
+    skill-audit:
+      glob: "skills/**/SKILL.md"
+      run: |
+        if [ ! -x bin/skill-auditor ]; then
+          (cd tools/skill-auditor && go build -o ../../bin/skill-auditor .) || { echo "skill-auditor build failed; skipping local audit (CI enforces the gate)"; exit 0; }
+        fi
+        rc=0
+        for f in {push_files}; do
+          rel="$(dirname "$f")"; rel="${rel#skills/}"
+          grade=$(bin/skill-auditor evaluate "$rel" --json 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin).get('grade','?'))" 2>/dev/null)
+          case "$grade" in
+            A|A+) echo "✅ $rel: $grade";;
+            B+|B|C+|C) echo "⚠️  $rel: $grade (warning — CI non-blocking)";;
+            *) echo "❌ $rel: ${grade:-?} (below C — blocked)"; rc=1;;
+          esac
+        done
+        exit $rc


### PR DESCRIPTION
## What

Enforces **conform-before-merge** for `tekhne` skills via a deterministic audit gate.

- **`skill-audit.yml`** (new): on PRs touching `skills/**`, builds `skill-auditor` + installs `skill-validator`, runs `skill-auditor evaluate` on each changed skill, **posts a PR comment with the grade table**, and **fails on D/F (<98)**.
  - Tiers: ✅ pass = A/A+ (≥126) · ⚠️ warning = C–B+ (98–125, non-blocking) · ❌ fail = D/F (<98, blocks).
- **`lefthook.yml`**: a `skill-audit` pre-push command mirrors the gate locally (builds `bin/skill-auditor` on demand; degrades gracefully if the build fails, since CI is authoritative).
- **`post-merge.yml`**: removes the broken **Copilot audit-request** job (it has never created an issue on any merge and is redundant now that audit gates + comments pre-merge), and fixes the `git add README.md TILES.md` path bug (→ `docs/src/content/docs/tiles.md`) that failed the readme job on every merge.

## Why

Every `tekhne` skill must reach grade A. The audit is deterministic (no hosted model → no 401 fragility). The pre-existing `bun … audit` wrapper was broken (path-doubling → 0/120 for everything); this gate calls `skill-auditor` directly. Grade A is aspirational (curated skills currently sit at C–B+), so the **blocking** line is D/F while A is the green target shown in the comment.

## Notes

- This PR touches only workflows + lefthook (no `skills/**`), so it does not self-gate.
- Follow-up (W2): retro-conform the ~13 already-merged raw skills (currently D/F) up to grade A.