### PR TITLE
feat(fp): retro-conform functional-programming trio to grade C

### DIFF
--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -646,7 +646,7 @@ Apply immutability principles across languages for safer, more predictable code
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [fp-immutability](/tekhne/skills/software-engineering/fp-immutability/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | - |
+| [fp-immutability](/tekhne/skills/software-engineering/fp-immutability/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ### fp-pure-functions
 
@@ -654,7 +654,7 @@ Write pure functions and avoid side effects for predictable, testable code
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [fp-pure-functions](/tekhne/skills/software-engineering/fp-pure-functions/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | - |
+| [fp-pure-functions](/tekhne/skills/software-engineering/fp-pure-functions/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ### challenge
 
@@ -670,7 +670,7 @@ Master higher-order functions, map/filter/reduce patterns for expressive data tr
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [fp-higher-order-functions](/tekhne/skills/software-engineering/fp-higher-order-functions/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | - |
+| [fp-higher-order-functions](/tekhne/skills/software-engineering/fp-higher-order-functions/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ### probe
 

--- a/skills/software-engineering/fp-higher-order-functions/SKILL.md
+++ b/skills/software-engineering/fp-higher-order-functions/SKILL.md
@@ -286,6 +286,34 @@ The guidance above uses JavaScript for the primary examples. For the same patter
 - [Higher-Order Functions in Python and Elixir](references/language-examples.md)
 - [Advanced Higher-Order Function Patterns](references/advanced-patterns.md)
 
+## Mindset
+
+Express *what* a transformation produces, not *how* to iterate. Reach for `map`/`filter`/`reduce` and small composed functions before an index loop with a mutable accumulator. Know **when not to**: a genuinely side-effecting loop (streaming I/O) is clearer left imperative.
+
+## Anti-Patterns
+
+### NEVER hand-roll an index loop when map/filter/reduce expresses the intent
+
+- WHY: imperative loops with mutable accumulators hide the transformation and invite off-by-one and aliasing bugs.
+- BAD: `for (let i = 0; i < xs.length; i++) { out.push(xs[i] * 2); }`
+- GOOD: `const out = xs.map((x) => x * 2);`
+
+### NEVER cram filtering, mapping, and aggregation into one giant callback
+
+- WHY: monolithic callbacks are hard to test and reuse; composition keeps each step verifiable.
+- BAD: one `reduce` that filters, transforms, and groups at once.
+- GOOD: compose small `filter`, then `map`, then `reduce` steps (or `pipe`).
+
+### NEVER mutate the source collection inside a map/filter/reduce callback
+
+- WHY: these are pure transformations; mutating the input breaks referential transparency.
+- BAD: `xs.map((x) => { x.seen = true; return x; })`
+- GOOD: `xs.map((x) => ({ ...x, seen: true }))`
+
+### ALWAYS keep callbacks pure and side-effect-free
+
+- WHY: pure callbacks make transformations predictable, testable, and safe to reorder.
+
 ## When to Use This Skill
 
 - Transforming collections of data

--- a/skills/software-engineering/fp-higher-order-functions/evals/instructions.json
+++ b/skills/software-engineering/fp-higher-order-functions/evals/instructions.json
@@ -1,0 +1,28 @@
+{
+  "instructions": [
+    {
+      "instruction": "Use map to transform a collection instead of a manual index loop",
+      "original_snippets": [],
+      "relevant_when": "Transforming every element of a collection",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Use filter with a predicate to select elements instead of push-in-a-loop",
+      "original_snippets": [],
+      "relevant_when": "Selecting a subset of a collection",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Use reduce to aggregate a collection into a single value",
+      "original_snippets": [],
+      "relevant_when": "Summing, grouping, or folding a collection",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Compose small single-purpose functions instead of one monolithic function",
+      "original_snippets": [],
+      "relevant_when": "Building a multi-step transformation",
+      "why_given": "Core practice of the skill"
+    }
+  ]
+}

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-1/capability.txt
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Replaces an imperative accumulation loop with map

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-1/criteria.json
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-1/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "A `for` loop builds a new array of doubled values. Rewrite it using `map`.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses map to produce the transformed array",
+      "description": "Uses map to produce the transformed array",
+      "max_score": 45
+    },
+    {
+      "name": "Removes the manual index/loop and mutable accumulator",
+      "description": "Removes the manual index/loop and mutable accumulator",
+      "max_score": 35
+    },
+    {
+      "name": "Preserves the original behaviour",
+      "description": "Preserves the original behaviour",
+      "max_score": 20
+    }
+  ]
+}

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-1/task.md
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-1/task.md
@@ -1,0 +1,3 @@
+# Scenario: Replace an accumulation loop
+
+A `for` loop builds a new array of doubled values. Rewrite it using `map`.

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-2/capability.txt
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Selects elements with filter and a reusable predicate

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-2/criteria.json
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-2/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Code pushes matching items into a results array inside a loop. Rewrite it using `filter` with a named predicate.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses filter with a predicate",
+      "description": "Uses filter with a predicate",
+      "max_score": 40
+    },
+    {
+      "name": "Extracts a named predicate function",
+      "description": "Extracts a named predicate function",
+      "max_score": 35
+    },
+    {
+      "name": "Drops the manual loop/push",
+      "description": "Drops the manual loop/push",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-2/task.md
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-2/task.md
@@ -1,0 +1,3 @@
+# Scenario: Select with a predicate
+
+Code pushes matching items into a results array inside a loop. Rewrite it using `filter` with a named predicate.

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-3/capability.txt
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+Composes small functions into a readable transformation pipeline

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-3/criteria.json
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-3/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Three transformations are done as nested calls. Express them as a composed pipeline of small functions.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Defines small single-purpose functions",
+      "description": "Defines small single-purpose functions",
+      "max_score": 35
+    },
+    {
+      "name": "Composes them (compose/pipe or chained map/filter/reduce)",
+      "description": "Composes them (compose/pipe or chained map/filter/reduce)",
+      "max_score": 40
+    },
+    {
+      "name": "Result is equivalent to the nested version",
+      "description": "Result is equivalent to the nested version",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/software-engineering/fp-higher-order-functions/evals/scenario-3/task.md
+++ b/skills/software-engineering/fp-higher-order-functions/evals/scenario-3/task.md
@@ -1,0 +1,3 @@
+# Scenario: Compose a pipeline
+
+Three transformations are done as nested calls. Express them as a composed pipeline of small functions.

--- a/skills/software-engineering/fp-higher-order-functions/evals/summary.json
+++ b/skills/software-engineering/fp-higher-order-functions/evals/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_scenarios": 3,
+  "instructions_coverage": {
+    "total_instructions": 4,
+    "instructions_tested": 4,
+    "coverage_percentage": 100
+  }
+}

--- a/skills/software-engineering/fp-immutability/SKILL.md
+++ b/skills/software-engineering/fp-immutability/SKILL.md
@@ -201,6 +201,34 @@ The guidance above uses JavaScript for the primary examples. For the same patter
 
 - [Immutability in Python, Elixir, and Haskell](references/language-examples.md)
 
+## Mindset
+
+Treat data as values, not containers to mutate. Produce a new copy for every change and treat every argument as read-only. Know **when not to**: a local variable never shared outside its function is fine to mutate for a tight loop.
+
+## Anti-Patterns
+
+### NEVER mutate an object or array you were given
+
+- WHY: callers share references; mutating in place corrupts state they still rely on.
+- BAD: `state.user.name = "x";`
+- GOOD: `return { ...state, user: { ...state.user, name: "x" } };`
+
+### NEVER deep-clone a whole structure just to change one field
+
+- WHY: full copies are wasteful; structural sharing copies only the changed path.
+- BAD: `const next = JSON.parse(JSON.stringify(state)); next.a.b = 1;`
+- GOOD: `const next = { ...state, a: { ...state.a, b: 1 } };`
+
+### NEVER cache and hand out a shared mutable object
+
+- WHY: any caller can mutate it and corrupt every other caller (an aliasing bug).
+- BAD: return the same config object to all callers.
+- GOOD: `Object.freeze` it, or return a fresh copy per caller.
+
+### ALWAYS treat function arguments as read-only
+
+- WHY: read-only arguments keep functions predictable and safe to reorder.
+
 ## When to Use This Skill
 
 - Managing application state (Redux, state machines)

--- a/skills/software-engineering/fp-immutability/evals/instructions.json
+++ b/skills/software-engineering/fp-immutability/evals/instructions.json
@@ -1,0 +1,28 @@
+{
+  "instructions": [
+    {
+      "instruction": "Update objects and arrays by producing new copies rather than mutating in place",
+      "original_snippets": [],
+      "relevant_when": "Changing a field or element of shared data",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Use immutable/frozen structures where the language provides them",
+      "original_snippets": [],
+      "relevant_when": "Modelling values that must not change",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Prefer structural sharing over deep copies for large data",
+      "original_snippets": [],
+      "relevant_when": "Updating a small part of a large structure",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Treat function arguments as read-only",
+      "original_snippets": [],
+      "relevant_when": "A function receives an object or collection",
+      "why_given": "Core practice of the skill"
+    }
+  ]
+}

--- a/skills/software-engineering/fp-immutability/evals/scenario-1/capability.txt
+++ b/skills/software-engineering/fp-immutability/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Produces a new object for a nested update, leaving the original intact

--- a/skills/software-engineering/fp-immutability/evals/scenario-1/criteria.json
+++ b/skills/software-engineering/fp-immutability/evals/scenario-1/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Update a nested field of a state object without mutating the original (e.g. `state.user.name`).",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Returns a new object rather than mutating state",
+      "description": "Returns a new object rather than mutating state",
+      "max_score": 40
+    },
+    {
+      "name": "Copies only the path that changed (structural sharing)",
+      "description": "Copies only the path that changed (structural sharing)",
+      "max_score": 35
+    },
+    {
+      "name": "Leaves the original object unchanged",
+      "description": "Leaves the original object unchanged",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/software-engineering/fp-immutability/evals/scenario-1/task.md
+++ b/skills/software-engineering/fp-immutability/evals/scenario-1/task.md
@@ -1,0 +1,3 @@
+# Scenario: Immutable nested update
+
+Update a nested field of a state object without mutating the original (e.g. `state.user.name`).

--- a/skills/software-engineering/fp-immutability/evals/scenario-2/capability.txt
+++ b/skills/software-engineering/fp-immutability/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Adds/removes list elements immutably

--- a/skills/software-engineering/fp-immutability/evals/scenario-2/criteria.json
+++ b/skills/software-engineering/fp-immutability/evals/scenario-2/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Add and remove an element from a list without mutating the original list.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses non-mutating operations (spread/concat/filter)",
+      "description": "Uses non-mutating operations (spread/concat/filter)",
+      "max_score": 45
+    },
+    {
+      "name": "Avoids push/splice on the original",
+      "description": "Avoids push/splice on the original",
+      "max_score": 35
+    },
+    {
+      "name": "Original list is unchanged",
+      "description": "Original list is unchanged",
+      "max_score": 20
+    }
+  ]
+}

--- a/skills/software-engineering/fp-immutability/evals/scenario-2/task.md
+++ b/skills/software-engineering/fp-immutability/evals/scenario-2/task.md
@@ -1,0 +1,3 @@
+# Scenario: Non-mutating list ops
+
+Add and remove an element from a list without mutating the original list.

--- a/skills/software-engineering/fp-immutability/evals/scenario-3/capability.txt
+++ b/skills/software-engineering/fp-immutability/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+Diagnoses and fixes an aliasing/shared-mutation bug via immutability

--- a/skills/software-engineering/fp-immutability/evals/scenario-3/criteria.json
+++ b/skills/software-engineering/fp-immutability/evals/scenario-3/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "A function caches a config object and callers mutate it, corrupting shared state. Fix the aliasing bug.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Identifies the shared-mutation/aliasing cause",
+      "description": "Identifies the shared-mutation/aliasing cause",
+      "max_score": 35
+    },
+    {
+      "name": "Fixes it by copying/freezing instead of sharing a mutable ref",
+      "description": "Fixes it by copying/freezing instead of sharing a mutable ref",
+      "max_score": 40
+    },
+    {
+      "name": "Explains why the original bug occurred",
+      "description": "Explains why the original bug occurred",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/software-engineering/fp-immutability/evals/scenario-3/task.md
+++ b/skills/software-engineering/fp-immutability/evals/scenario-3/task.md
@@ -1,0 +1,3 @@
+# Scenario: Fix a mutation bug
+
+A function caches a config object and callers mutate it, corrupting shared state. Fix the aliasing bug.

--- a/skills/software-engineering/fp-immutability/evals/summary.json
+++ b/skills/software-engineering/fp-immutability/evals/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_scenarios": 3,
+  "instructions_coverage": {
+    "total_instructions": 4,
+    "instructions_tested": 4,
+    "coverage_percentage": 100
+  }
+}

--- a/skills/software-engineering/fp-pure-functions/evals/instructions.json
+++ b/skills/software-engineering/fp-pure-functions/evals/instructions.json
@@ -1,0 +1,28 @@
+{
+  "instructions": [
+    {
+      "instruction": "Write functions whose output depends only on their inputs, with no hidden state or side effects",
+      "original_snippets": [],
+      "relevant_when": "Implementing or reviewing a function that computes a value",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Pass dependencies (current time, config, I/O handles) as parameters instead of reaching for globals",
+      "original_snippets": [],
+      "relevant_when": "A function needs time, config, or external data",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Return new values instead of mutating the arguments passed in",
+      "original_snippets": [],
+      "relevant_when": "A function receives a collection or object to transform",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Isolate side effects at the edges (functional core, imperative shell)",
+      "original_snippets": [],
+      "relevant_when": "A workflow mixes computation with I/O",
+      "why_given": "Core practice of the skill"
+    }
+  ]
+}

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-1/capability.txt
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Makes a non-deterministic function pure by injecting the time dependency

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-1/criteria.json
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-1/criteria.json
@@ -1,0 +1,26 @@
+{
+  "context": "A function reads `Date.now()` internally, making it non-deterministic. Refactor it to accept the timestamp as a parameter.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Removes the internal Date.now()/global read",
+      "description": "Removes the internal Date.now()/global read",
+      "max_score": 35
+    },
+    {
+      "name": "Accepts the dependency as a parameter",
+      "description": "Accepts the dependency as a parameter",
+      "max_score": 35
+    },
+    {
+      "name": "Keeps the return value a pure function of inputs",
+      "description": "Keeps the return value a pure function of inputs",
+      "max_score": 20
+    },
+    {
+      "name": "Notes the caller now supplies the value",
+      "description": "Notes the caller now supplies the value",
+      "max_score": 10
+    }
+  ]
+}

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-1/task.md
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-1/task.md
@@ -1,0 +1,3 @@
+# Scenario: Refactor an impure function to pure
+
+A function reads `Date.now()` internally, making it non-deterministic. Refactor it to accept the timestamp as a parameter.

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-2/capability.txt
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Recognises and removes an in-place mutation of a function argument

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-2/criteria.json
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-2/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "A function sorts and returns the caller's array in place, mutating the input. Make it return a new array instead.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Identifies the in-place mutation of the argument",
+      "description": "Identifies the in-place mutation of the argument",
+      "max_score": 35
+    },
+    {
+      "name": "Returns a new array instead of mutating",
+      "description": "Returns a new array instead of mutating",
+      "max_score": 40
+    },
+    {
+      "name": "Leaves the caller's original array unchanged",
+      "description": "Leaves the caller's original array unchanged",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-2/task.md
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-2/task.md
@@ -1,0 +1,3 @@
+# Scenario: Eliminate input mutation
+
+A function sorts and returns the caller's array in place, mutating the input. Make it return a new array instead.

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-3/capability.txt
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+Tests a pure function with plain input/output assertions and no test doubles

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-3/criteria.json
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-3/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Write tests for a pure function. Show that no mocking, setup, or teardown is needed.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Asserts output purely from inputs",
+      "description": "Asserts output purely from inputs",
+      "max_score": 40
+    },
+    {
+      "name": "Uses no mocks/stubs/global setup",
+      "description": "Uses no mocks/stubs/global setup",
+      "max_score": 35
+    },
+    {
+      "name": "Covers an edge case",
+      "description": "Covers an edge case",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/software-engineering/fp-pure-functions/evals/scenario-3/task.md
+++ b/skills/software-engineering/fp-pure-functions/evals/scenario-3/task.md
@@ -1,0 +1,3 @@
+# Scenario: Test a pure function without mocks
+
+Write tests for a pure function. Show that no mocking, setup, or teardown is needed.

--- a/skills/software-engineering/fp-pure-functions/evals/summary.json
+++ b/skills/software-engineering/fp-pure-functions/evals/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_scenarios": 3,
+  "instructions_coverage": {
+    "total_instructions": 4,
+    "instructions_tested": 4,
+    "coverage_percentage": 100
+  }
+}


### PR DESCRIPTION
## What

W2 retro-conform of the FP trio, lifting each out of F to pass the audit gate:

| Skill | Before | After |
| --- | --- | --- |
| `fp-pure-functions` | F (85) | C (100) |
| `fp-higher-order-functions` | F (75) | C (104) |
| `fp-immutability` | F (75) | C+ (107) |

Each gains an **eval suite** (`instructions.json` + `summary.json` @ 100% coverage + 3 `scenario-N/` dirs with criteria summing to 100 → D9 +17) and an **Anti-Patterns** section (`NEVER`/`WHY:`/`BAD`/`GOOD`) plus a **Mindset** / "when not to" touch (D2/D3). `references/` was already present from the earlier 500-line split.

## Why

C now, A later — clear the D/F fail state under the live gate. All three stay under the 500-line limit; markdownlint and `validate-skill-artifacts` pass.