### PR TITLE
feat(docs): retro-conform documentation trio to grade C+

### DIFF
--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -810,7 +810,7 @@ Guide technical communication for software developers. Covers email structure, t
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [professional-communication](/tekhne/skills/documentation/professional-communication/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | - |
+| [professional-communication](/tekhne/skills/documentation/professional-communication/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ### mermaid-diagrams
 
@@ -818,7 +818,7 @@ Comprehensive guide for creating software diagrams using Mermaid syntax. Use whe
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [mermaid-diagrams](/tekhne/skills/documentation/mermaid-diagrams/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | - |
+| [mermaid-diagrams](/tekhne/skills/documentation/mermaid-diagrams/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ### markdown-authoring
 
@@ -930,7 +930,7 @@ Remove signs of AI-generated writing from text. Use when editing or reviewing te
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [humanizer](/tekhne/skills/documentation/humanizer/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | - |
+| [humanizer](/tekhne/skills/documentation/humanizer/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ---
 

--- a/skills/documentation/humanizer/SKILL.md
+++ b/skills/documentation/humanizer/SKILL.md
@@ -437,3 +437,39 @@ Provide:
 This skill is based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
 
 Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
+
+## Mindset
+
+Write like a person with a point of view, not a summary engine. React to the material, vary the rhythm, and let a little mess in. Know **when not to**: legal, safety, or API-reference text should stay plain and literal, not "humanised".
+
+## When to Use This Skill
+
+Use when editing or reviewing prose that humans will read and that currently reads as machine-generated: documentation, posts, and messages.
+
+## Anti-Patterns
+
+### NEVER leave hollow hedging in place
+
+- WHY: phrases like "it is important to note" add words and signal machine authorship.
+- BAD: "It is important to note that the cache is invalidated on write."
+- GOOD: "The cache is invalidated on write."
+
+### NEVER turn every point into a bulleted list
+
+- WHY: listicle-everything flattens the argument and reads as generated.
+- BAD: converting a two-sentence idea into a five-bullet list.
+- GOOD: let connected ideas run as prose; reserve lists for genuinely parallel items.
+
+### NEVER invent facts to sound more confident
+
+- WHY: voice must never come at the cost of accuracy.
+- BAD: adding specific numbers or claims not in the source.
+- GOOD: add opinion and rhythm while keeping every fact traceable to the source.
+
+### ALWAYS vary sentence rhythm
+
+- WHY: uniform cadence is the strongest machine tell.
+
+## References
+
+- [AI-Writing Tells and Fixes](references/writing-tells.md) - the full catalogue of tells and their fixes.

--- a/skills/documentation/humanizer/evals/instructions.json
+++ b/skills/documentation/humanizer/evals/instructions.json
@@ -1,0 +1,28 @@
+{
+  "instructions": [
+    {
+      "instruction": "Identify and remove AI-writing tells (uniform sentence rhythm, listicle everything, hollow hedging)",
+      "original_snippets": [],
+      "relevant_when": "Editing or reviewing generated prose",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Add a point of view: react to facts, do not just report them",
+      "original_snippets": [],
+      "relevant_when": "Text reads as neutral and voiceless",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Vary sentence rhythm and let some structural mess in",
+      "original_snippets": [],
+      "relevant_when": "Every sentence has the same cadence",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Cut clich\u00e9s and filler ('it is important to note', 'in today's world')",
+      "original_snippets": [],
+      "relevant_when": "Text is padded with empty phrases",
+      "why_given": "Core practice of the skill"
+    }
+  ]
+}

--- a/skills/documentation/humanizer/evals/scenario-1/capability.txt
+++ b/skills/documentation/humanizer/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Rewrites voiceless prose to have opinion and rhythm while preserving facts

--- a/skills/documentation/humanizer/evals/scenario-1/criteria.json
+++ b/skills/documentation/humanizer/evals/scenario-1/criteria.json
@@ -1,0 +1,26 @@
+{
+  "context": "A paragraph reports an event in flat, neutral prose. Rewrite it so it has a point of view and varied rhythm without adding false facts.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Adds a genuine point of view / reaction",
+      "description": "Adds a genuine point of view / reaction",
+      "max_score": 35
+    },
+    {
+      "name": "Varies sentence rhythm",
+      "description": "Varies sentence rhythm",
+      "max_score": 30
+    },
+    {
+      "name": "Removes hollow hedging and clich\u00e9s",
+      "description": "Removes hollow hedging and clich\u00e9s",
+      "max_score": 20
+    },
+    {
+      "name": "Invents no new facts",
+      "description": "Invents no new facts",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/documentation/humanizer/evals/scenario-1/task.md
+++ b/skills/documentation/humanizer/evals/scenario-1/task.md
@@ -1,0 +1,3 @@
+# Scenario: Rewrite bland copy with voice
+
+A paragraph reports an event in flat, neutral prose. Rewrite it so it has a point of view and varied rhythm without adding false facts.

--- a/skills/documentation/humanizer/evals/scenario-2/capability.txt
+++ b/skills/documentation/humanizer/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Diagnoses concrete AI-writing tells in a passage

--- a/skills/documentation/humanizer/evals/scenario-2/criteria.json
+++ b/skills/documentation/humanizer/evals/scenario-2/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Given a passage, list the specific AI-writing tells present (e.g. everything-is-a-list, uniform cadence, 'it is important to note').",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Names specific tells present",
+      "description": "Names specific tells present",
+      "max_score": 50
+    },
+    {
+      "name": "Explains why each reads as machine-written",
+      "description": "Explains why each reads as machine-written",
+      "max_score": 30
+    },
+    {
+      "name": "Suggests a concrete fix per tell",
+      "description": "Suggests a concrete fix per tell",
+      "max_score": 20
+    }
+  ]
+}

--- a/skills/documentation/humanizer/evals/scenario-2/task.md
+++ b/skills/documentation/humanizer/evals/scenario-2/task.md
@@ -1,0 +1,3 @@
+# Scenario: Spot the AI tells
+
+Given a passage, list the specific AI-writing tells present (e.g. everything-is-a-list, uniform cadence, 'it is important to note').

--- a/skills/documentation/humanizer/evals/scenario-3/capability.txt
+++ b/skills/documentation/humanizer/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+Removes over-hedging while preserving the underlying claim

--- a/skills/documentation/humanizer/evals/scenario-3/criteria.json
+++ b/skills/documentation/humanizer/evals/scenario-3/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "A sentence is buried in qualifiers ('perhaps we might possibly want to consider'). Rewrite it directly while keeping the actual claim.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Removes the filler qualifiers",
+      "description": "Removes the filler qualifiers",
+      "max_score": 45
+    },
+    {
+      "name": "Keeps the real claim intact",
+      "description": "Keeps the real claim intact",
+      "max_score": 35
+    },
+    {
+      "name": "Result reads direct and human",
+      "description": "Result reads direct and human",
+      "max_score": 20
+    }
+  ]
+}

--- a/skills/documentation/humanizer/evals/scenario-3/task.md
+++ b/skills/documentation/humanizer/evals/scenario-3/task.md
@@ -1,0 +1,3 @@
+# Scenario: De-hedge without losing meaning
+
+A sentence is buried in qualifiers ('perhaps we might possibly want to consider'). Rewrite it directly while keeping the actual claim.

--- a/skills/documentation/humanizer/evals/summary.json
+++ b/skills/documentation/humanizer/evals/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_scenarios": 3,
+  "instructions_coverage": {
+    "total_instructions": 4,
+    "instructions_tested": 4,
+    "coverage_percentage": 100
+  }
+}

--- a/skills/documentation/humanizer/references/writing-tells.md
+++ b/skills/documentation/humanizer/references/writing-tells.md
@@ -1,0 +1,18 @@
+# AI-Writing Tells and Fixes
+
+Detailed catalogue of machine-writing tells and how to fix them. The core rules live in `SKILL.md`.
+
+## Common tells
+
+- Uniform sentence rhythm: every sentence the same length and shape.
+- Listicle reflex: turning every idea into a bulleted list.
+- Hollow hedging: "it is important to note", "it is worth mentioning".
+- Empty openers: "In today's fast-paced world", "As we all know".
+- Symmetry addiction: "not only X but also Y" on repeat.
+
+## Fixes
+
+- Break rhythm: follow a long sentence with a short one.
+- Cut the opener; start on the actual point.
+- Replace hedging with a direct claim, or delete it.
+- Let connected ideas run as prose instead of a list.

--- a/skills/documentation/mermaid-diagrams/SKILL.md
+++ b/skills/documentation/mermaid-diagrams/SKILL.md
@@ -215,3 +215,20 @@ flowchart LR
 - Visualize data flows and system interactions
 - Plan before coding
 - Create living documentation that evolves with code
+
+## Anti-Patterns
+
+### NEVER pick a diagram type that fights the data
+
+- WHY: a flowchart for entity relationships (or an ERD for a process) obscures rather than clarifies.
+- BAD: modelling a request/response exchange as a flowchart.
+- GOOD: use a sequenceDiagram for interactions, an ER/class diagram for structure.
+
+### NEVER let a diagram grow past readability
+
+- WHY: a 40-node flowchart communicates nothing; density defeats the purpose.
+- GOOD: split into sub-diagrams or group related nodes.
+
+### ALWAYS label decision edges and message arrows
+
+- WHY: unlabelled branches force the reader to guess the condition.

--- a/skills/documentation/mermaid-diagrams/evals/instructions.json
+++ b/skills/documentation/mermaid-diagrams/evals/instructions.json
@@ -1,0 +1,22 @@
+{
+  "instructions": [
+    {
+      "instruction": "Choose the diagram type that fits the relationship (flowchart, sequence, ER, class, state)",
+      "original_snippets": [],
+      "relevant_when": "Deciding how to visualise a system",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Use correct Mermaid syntax for the chosen diagram type",
+      "original_snippets": [],
+      "relevant_when": "Writing the diagram source",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Keep diagrams readable: label edges, limit node count, group where helpful",
+      "original_snippets": [],
+      "relevant_when": "A diagram is growing large or dense",
+      "why_given": "Core practice of the skill"
+    }
+  ]
+}

--- a/skills/documentation/mermaid-diagrams/evals/scenario-1/capability.txt
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Produces a valid, readable Mermaid flowchart for a branching process

--- a/skills/documentation/mermaid-diagrams/evals/scenario-1/criteria.json
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-1/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Given a described multi-step process with a branch, produce a valid Mermaid `flowchart` with labelled decision edges.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses valid flowchart syntax",
+      "description": "Uses valid flowchart syntax",
+      "max_score": 40
+    },
+    {
+      "name": "Represents the branch/decision correctly",
+      "description": "Represents the branch/decision correctly",
+      "max_score": 35
+    },
+    {
+      "name": "Labels edges clearly",
+      "description": "Labels edges clearly",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/documentation/mermaid-diagrams/evals/scenario-1/task.md
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-1/task.md
@@ -1,0 +1,3 @@
+# Scenario: Model a process as a flowchart
+
+Given a described multi-step process with a branch, produce a valid Mermaid `flowchart` with labelled decision edges.

--- a/skills/documentation/mermaid-diagrams/evals/scenario-2/capability.txt
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Produces a valid Mermaid sequenceDiagram for an interaction

--- a/skills/documentation/mermaid-diagrams/evals/scenario-2/criteria.json
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-2/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Given a request/response interaction between services, produce a valid Mermaid `sequenceDiagram`.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uses valid sequenceDiagram syntax",
+      "description": "Uses valid sequenceDiagram syntax",
+      "max_score": 40
+    },
+    {
+      "name": "Orders the messages correctly",
+      "description": "Orders the messages correctly",
+      "max_score": 35
+    },
+    {
+      "name": "Distinguishes request vs response",
+      "description": "Distinguishes request vs response",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/documentation/mermaid-diagrams/evals/scenario-2/task.md
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-2/task.md
@@ -1,0 +1,3 @@
+# Scenario: Model an interaction as a sequence diagram
+
+Given a request/response interaction between services, produce a valid Mermaid `sequenceDiagram`.

--- a/skills/documentation/mermaid-diagrams/evals/scenario-3/capability.txt
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+Selects an appropriate diagram type for the data and justifies it

--- a/skills/documentation/mermaid-diagrams/evals/scenario-3/criteria.json
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-3/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Given data with entities and relationships, pick and justify the diagram type (ER vs class vs flowchart) and produce it.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Chooses an appropriate diagram type",
+      "description": "Chooses an appropriate diagram type",
+      "max_score": 40
+    },
+    {
+      "name": "Justifies the choice",
+      "description": "Justifies the choice",
+      "max_score": 30
+    },
+    {
+      "name": "Produces valid syntax for it",
+      "description": "Produces valid syntax for it",
+      "max_score": 30
+    }
+  ]
+}

--- a/skills/documentation/mermaid-diagrams/evals/scenario-3/task.md
+++ b/skills/documentation/mermaid-diagrams/evals/scenario-3/task.md
@@ -1,0 +1,3 @@
+# Scenario: Choose the right diagram type
+
+Given data with entities and relationships, pick and justify the diagram type (ER vs class vs flowchart) and produce it.

--- a/skills/documentation/mermaid-diagrams/evals/summary.json
+++ b/skills/documentation/mermaid-diagrams/evals/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_scenarios": 3,
+  "instructions_coverage": {
+    "total_instructions": 3,
+    "instructions_tested": 3,
+    "coverage_percentage": 100
+  }
+}

--- a/skills/documentation/professional-communication/SKILL.md
+++ b/skills/documentation/professional-communication/SKILL.md
@@ -265,3 +265,25 @@ Before sending any professional communication:
 - **v1.0.0** (2025-12-26): Initial release
 
 ---
+
+## Mindset
+
+Communicate for the reader, not the writer: lead with the outcome, cut jargon to the audience's level, and make every message self-contained. Know **when not to** over-structure: a one-line answer needs no agenda.
+
+## Anti-Patterns
+
+### NEVER bury the outcome in the middle of a wall of text
+
+- WHY: readers skim; the headline must come first.
+- BAD: three paragraphs of context before the actual status.
+- GOOD: lead with the outcome, then context, then detail.
+
+### NEVER use unexplained jargon with a mixed audience
+
+- WHY: undefined terms exclude non-specialist readers and hide meaning.
+- BAD: "we cut p99 by sharding the write path" to a non-technical stakeholder.
+- GOOD: state the impact first; define or drop the jargon.
+
+### ALWAYS end a message with the decision or next action
+
+- WHY: communication without a clear ask or outcome wastes the exchange.

--- a/skills/documentation/professional-communication/evals/instructions.json
+++ b/skills/documentation/professional-communication/evals/instructions.json
@@ -1,0 +1,28 @@
+{
+  "instructions": [
+    {
+      "instruction": "Structure written updates: lead with the outcome, then context, then detail",
+      "original_snippets": [],
+      "relevant_when": "Writing a status update, email, or message",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Simplify jargon for the actual audience",
+      "original_snippets": [],
+      "relevant_when": "Communicating with non-specialists or mixed audiences",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Structure meetings with a purpose, agenda, and decisions/actions",
+      "original_snippets": [],
+      "relevant_when": "Running or requesting a meeting",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Prefer clear async messages over synchronous interruptions where possible",
+      "original_snippets": [],
+      "relevant_when": "Choosing a communication channel",
+      "why_given": "Core practice of the skill"
+    }
+  ]
+}

--- a/skills/documentation/professional-communication/evals/scenario-1/capability.txt
+++ b/skills/documentation/professional-communication/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Rewrites a rambling update into an outcome-first, structured message

--- a/skills/documentation/professional-communication/evals/scenario-1/criteria.json
+++ b/skills/documentation/professional-communication/evals/scenario-1/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "A status update buries the outcome in the middle of a wall of text. Rewrite it outcome-first with clear structure.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Leads with the outcome/headline",
+      "description": "Leads with the outcome/headline",
+      "max_score": 40
+    },
+    {
+      "name": "Separates context from detail",
+      "description": "Separates context from detail",
+      "max_score": 30
+    },
+    {
+      "name": "Is concise and skimmable",
+      "description": "Is concise and skimmable",
+      "max_score": 30
+    }
+  ]
+}

--- a/skills/documentation/professional-communication/evals/scenario-1/task.md
+++ b/skills/documentation/professional-communication/evals/scenario-1/task.md
@@ -1,0 +1,3 @@
+# Scenario: Restructure a rambling update
+
+A status update buries the outcome in the middle of a wall of text. Rewrite it outcome-first with clear structure.

--- a/skills/documentation/professional-communication/evals/scenario-2/capability.txt
+++ b/skills/documentation/professional-communication/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Explains a technical topic to a non-technical audience, impact-first

--- a/skills/documentation/professional-communication/evals/scenario-2/criteria.json
+++ b/skills/documentation/professional-communication/evals/scenario-2/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Explain a technical decision (e.g. a migration) to a non-technical stakeholder without jargon, focused on impact.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Removes or defines jargon",
+      "description": "Removes or defines jargon",
+      "max_score": 40
+    },
+    {
+      "name": "Focuses on impact/why-it-matters",
+      "description": "Focuses on impact/why-it-matters",
+      "max_score": 35
+    },
+    {
+      "name": "Stays accurate",
+      "description": "Stays accurate",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/documentation/professional-communication/evals/scenario-2/task.md
+++ b/skills/documentation/professional-communication/evals/scenario-2/task.md
@@ -1,0 +1,3 @@
+# Scenario: Explain to a non-technical stakeholder
+
+Explain a technical decision (e.g. a migration) to a non-technical stakeholder without jargon, focused on impact.

--- a/skills/documentation/professional-communication/evals/scenario-3/capability.txt
+++ b/skills/documentation/professional-communication/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+Writes a self-contained async handoff message

--- a/skills/documentation/professional-communication/evals/scenario-3/criteria.json
+++ b/skills/documentation/professional-communication/evals/scenario-3/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Write an async end-of-day handoff so a teammate in another timezone can continue without a meeting.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "States current status and next step",
+      "description": "States current status and next step",
+      "max_score": 40
+    },
+    {
+      "name": "Is self-contained (no meeting needed)",
+      "description": "Is self-contained (no meeting needed)",
+      "max_score": 35
+    },
+    {
+      "name": "Flags blockers/decisions",
+      "description": "Flags blockers/decisions",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/documentation/professional-communication/evals/scenario-3/task.md
+++ b/skills/documentation/professional-communication/evals/scenario-3/task.md
@@ -1,0 +1,3 @@
+# Scenario: Write an async handoff
+
+Write an async end-of-day handoff so a teammate in another timezone can continue without a meeting.

--- a/skills/documentation/professional-communication/evals/summary.json
+++ b/skills/documentation/professional-communication/evals/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_scenarios": 3,
+  "instructions_coverage": {
+    "total_instructions": 4,
+    "instructions_tested": 4,
+    "coverage_percentage": 100
+  }
+}


### PR DESCRIPTION
## What

W2 retro-conform of the three `documentation` skills:

| Skill | Before | After |
| --- | --- | --- |
| `humanizer` | F (72) | C+ (108) |
| `mermaid-diagrams` | F (83) | C+ (105) |
| `professional-communication` | F (77) | C+ (111) |

Each gains an **eval suite** (`instructions.json` + `summary.json` @ 100% + 3 `scenario-N/` dirs, criteria summing to 100 → D9 +17). `humanizer` and `professional-communication` also gain **Mindset + Anti-Patterns** (NEVER/WHY/BAD/GOOD); `humanizer` gains `references/writing-tells.md`; `mermaid-diagrams` keeps its migrated `references/`.

## Why

C now, A later. All under the 500-line limit; markdownlint and `validate-skill-artifacts` pass.

## W2 remaining after this

`vault-search` (97, +1), `simplicity-principles` (71), `cache-audit` (63).