### PR TITLE
feat: retro-conform final three raw skills (W2 complete)

### DIFF
--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -482,7 +482,7 @@ Audit your Claude Code setup against prompt caching best practices. Checks order
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [cache-audit](/tekhne/skills/agentic-harness/cache-audit/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | - |
+| [cache-audit](/tekhne/skills/agentic-harness/cache-audit/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ### load-context
 
@@ -630,7 +630,7 @@ Use when designing solutions, adding features, or refactoring by applying KISS, 
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [simplicity-principles](/tekhne/skills/software-engineering/simplicity-principles/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | - |
+| [simplicity-principles](/tekhne/skills/software-engineering/simplicity-principles/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ### bridge
 

--- a/skills/agentic-harness/cache-audit/SKILL.md
+++ b/skills/agentic-harness/cache-audit/SKILL.md
@@ -187,3 +187,29 @@ If everything passes: say so clearly and note the estimated cost savings from th
 | 4. Models | One model per conversation, subagents for switches | Inline model switching |
 | 5. Size | Trim dynamic injections to minimum needed | Dump full git status (40k chars) |
 | 6. Forks | Same prefix for compaction/subagents | Different system prompt for summary calls |
+
+## When to Use This Skill
+
+Use when auditing or configuring prompt caching for an agent setup, or when cache savings are lower than expected. Apply it whenever the system prompt, tool list, or context ordering changes. Know when not to bother: a one-shot call with no reuse gains nothing from caching.
+
+## Mindset
+
+Cache reuse is an ordering problem: stable content first, volatile content last, breakpoint in between. Audit for churn that silently busts the cache. Know **when not to** cache: genuinely per-request content should stay after the breakpoint.
+
+## Anti-Patterns
+
+### NEVER place volatile content before the stable prefix
+
+- WHY: any change early in the prompt invalidates the entire downstream cache.
+- BAD: conversation or timestamps ahead of the system prompt and tools.
+- GOOD: static system prompt and tools first, volatile turns last.
+
+### NEVER regenerate the tool list in a new order each turn
+
+- WHY: reordering is a byte change that busts the cached prefix every turn.
+- BAD: building the tool array from an unordered map per request.
+- GOOD: emit tools in a stable, sorted order.
+
+### ALWAYS measure the cache hit rate before and after a change
+
+- WHY: cache wins are invisible without measurement; attribute misses to specific churn.

--- a/skills/agentic-harness/cache-audit/evals/instructions.json
+++ b/skills/agentic-harness/cache-audit/evals/instructions.json
@@ -1,0 +1,28 @@
+{
+  "instructions": [
+    {
+      "instruction": "Order context stable-first: static system prompt and tools before volatile conversation",
+      "original_snippets": [],
+      "relevant_when": "Auditing a prompt/cache setup",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Place cache breakpoints after the largest stable prefix",
+      "original_snippets": [],
+      "relevant_when": "Configuring prompt caching",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Keep the tool list and system prompt stable across turns to preserve cache hits",
+      "original_snippets": [],
+      "relevant_when": "Tool definitions or system prompt change between turns",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Measure the cache hit rate and attribute misses to churn",
+      "original_snippets": [],
+      "relevant_when": "Cache savings are lower than expected",
+      "why_given": "Core practice of the skill"
+    }
+  ]
+}

--- a/skills/agentic-harness/cache-audit/evals/scenario-1/capability.txt
+++ b/skills/agentic-harness/cache-audit/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Reorders context so the stable prefix comes first for cache reuse

--- a/skills/agentic-harness/cache-audit/evals/scenario-1/criteria.json
+++ b/skills/agentic-harness/cache-audit/evals/scenario-1/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "A setup puts the volatile conversation before the static system prompt and tools, defeating caching. Reorder it.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Moves stable content (system prompt, tools) to the front",
+      "description": "Moves stable content (system prompt, tools) to the front",
+      "max_score": 45
+    },
+    {
+      "name": "Explains why ordering affects cache reuse",
+      "description": "Explains why ordering affects cache reuse",
+      "max_score": 30
+    },
+    {
+      "name": "Preserves behaviour",
+      "description": "Preserves behaviour",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/agentic-harness/cache-audit/evals/scenario-1/task.md
+++ b/skills/agentic-harness/cache-audit/evals/scenario-1/task.md
@@ -1,0 +1,3 @@
+# Scenario: Reorder volatile-before-stable context
+
+A setup puts the volatile conversation before the static system prompt and tools, defeating caching. Reorder it.

--- a/skills/agentic-harness/cache-audit/evals/scenario-2/capability.txt
+++ b/skills/agentic-harness/cache-audit/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Identifies where a cache breakpoint should be placed

--- a/skills/agentic-harness/cache-audit/evals/scenario-2/criteria.json
+++ b/skills/agentic-harness/cache-audit/evals/scenario-2/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "A large stable prefix has no cache breakpoint, so nothing is cached. Identify where the breakpoint belongs.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Places the breakpoint after the largest stable prefix",
+      "description": "Places the breakpoint after the largest stable prefix",
+      "max_score": 45
+    },
+    {
+      "name": "Explains the effect on cost/latency",
+      "description": "Explains the effect on cost/latency",
+      "max_score": 30
+    },
+    {
+      "name": "Avoids breakpointing volatile content",
+      "description": "Avoids breakpointing volatile content",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/agentic-harness/cache-audit/evals/scenario-2/task.md
+++ b/skills/agentic-harness/cache-audit/evals/scenario-2/task.md
@@ -1,0 +1,3 @@
+# Scenario: Find the missing cache breakpoint
+
+A large stable prefix has no cache breakpoint, so nothing is cached. Identify where the breakpoint belongs.

--- a/skills/agentic-harness/cache-audit/evals/scenario-3/capability.txt
+++ b/skills/agentic-harness/cache-audit/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+Diagnoses cache-busting churn and stabilises the prefix

--- a/skills/agentic-harness/cache-audit/evals/scenario-3/criteria.json
+++ b/skills/agentic-harness/cache-audit/evals/scenario-3/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Cache hit rate is low; the tool list is regenerated in a new order each turn. Diagnose and fix the churn.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Identifies the churning tool list as the cause",
+      "description": "Identifies the churning tool list as the cause",
+      "max_score": 40
+    },
+    {
+      "name": "Proposes stabilising the order/content",
+      "description": "Proposes stabilising the order/content",
+      "max_score": 35
+    },
+    {
+      "name": "Ties the fix to cache-hit improvement",
+      "description": "Ties the fix to cache-hit improvement",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/agentic-harness/cache-audit/evals/scenario-3/task.md
+++ b/skills/agentic-harness/cache-audit/evals/scenario-3/task.md
@@ -1,0 +1,3 @@
+# Scenario: Diagnose a low cache hit rate
+
+Cache hit rate is low; the tool list is regenerated in a new order each turn. Diagnose and fix the churn.

--- a/skills/agentic-harness/cache-audit/evals/summary.json
+++ b/skills/agentic-harness/cache-audit/evals/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_scenarios": 3,
+  "instructions_coverage": {
+    "total_instructions": 4,
+    "instructions_tested": 4,
+    "coverage_percentage": 100
+  }
+}

--- a/skills/agentic-harness/cache-audit/references/checklist.md
+++ b/skills/agentic-harness/cache-audit/references/checklist.md
@@ -1,0 +1,8 @@
+# Prompt-Cache Audit Checklist
+
+Reference checklist. Core guidance is in `SKILL.md`.
+
+- Stable content (system prompt, tool definitions) sits before volatile conversation.
+- A cache breakpoint follows the largest stable prefix.
+- Tool list and system prompt are byte-stable across turns (no reordering or timestamps).
+- Cache hit rate is measured; misses are attributed to specific churn.

--- a/skills/agentic-harness/vault-search/SKILL.md
+++ b/skills/agentic-harness/vault-search/SKILL.md
@@ -72,3 +72,29 @@ Each result shows:
 - **Never skip search before a non-trivial implementation task** — prior constraints may invalidate your approach before you write a line
 - **Never fabricate a memory** when search returns empty — report "No results found" and proceed without invented context
 - **Never search with a full sentence or question** — BM25 scores individual terms; verbose queries dilute signal
+
+## Mindset
+
+Search memory first; do not re-derive what was already decided. Treat retrieval as cheap and re-work as expensive. Know **when not to**: trivial, self-evident steps do not need a memory lookup.
+
+## Anti-Patterns
+
+### NEVER re-implement something without searching memory first
+
+- WHY: past decisions, constraints, and fixes are often already recorded; re-deriving them wastes effort and risks contradicting a prior decision.
+- BAD: writing a new approach from scratch for a recurring problem.
+- GOOD: `vault-cli search "<topic>"` first, then build on what returns.
+
+### NEVER search with the user's literal phrasing when concrete nouns work better
+
+- WHY: memory is indexed on concepts, not surface wording.
+- BAD: searching the whole question verbatim.
+- GOOD: extract the key nouns and search those.
+
+### ALWAYS treat an empty result as meaningful
+
+- WHY: a miss suggests the decision is genuinely new and worth capturing.
+
+## References
+
+- [Vault Search: Query Tips](references/query-tips.md) - practical query construction guidance.

--- a/skills/agentic-harness/vault-search/references/query-tips.md
+++ b/skills/agentic-harness/vault-search/references/query-tips.md
@@ -1,0 +1,8 @@
+# Vault Search: Query Tips
+
+Guidance for effective memory retrieval. Core usage is in `SKILL.md`.
+
+- Search before implementing, debugging, or designing anything non-trivial.
+- Use concrete nouns from the task, not the literal user phrasing.
+- Broaden then narrow: start with a topic term, then add constraints.
+- Treat a miss as signal: if nothing returns, the decision may be new.

--- a/skills/software-engineering/simplicity-principles/SKILL.md
+++ b/skills/software-engineering/simplicity-principles/SKILL.md
@@ -422,3 +422,25 @@ interface Props {
 - Simple != simplistic (handle errors, edge cases properly)
 
 ### When in doubt, choose the simpler path
+
+## Mindset
+
+Default to the simplest thing that works; add complexity only when a real, present requirement forces it. Know **when not to** simplify: do not collapse a genuinely necessary abstraction just to cut lines.
+
+## Anti-Patterns
+
+### NEVER add configurability or extension points for imagined future needs
+
+- WHY: YAGNI: speculative generality is cost with no present benefit and usually guesses wrong.
+- BAD: a plugin/factory/config layer for a single current use case.
+- GOOD: implement the one case directly; generalise when a second real case arrives.
+
+### NEVER abstract on the first duplication
+
+- WHY: premature abstraction couples unrelated code to a shape that is not yet clear.
+- BAD: extracting a shared helper the moment two lines look similar.
+- GOOD: wait for the rule of three; duplicate until the shape stabilises.
+
+### ALWAYS prefer the design a newcomer can read in one pass
+
+- WHY: simplicity is measured by comprehension cost, not cleverness.

--- a/skills/software-engineering/simplicity-principles/evals/instructions.json
+++ b/skills/software-engineering/simplicity-principles/evals/instructions.json
@@ -1,0 +1,28 @@
+{
+  "instructions": [
+    {
+      "instruction": "Apply KISS: choose the simplest design that solves the actual problem",
+      "original_snippets": [],
+      "relevant_when": "Designing or reviewing a solution",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Apply YAGNI: do not build for imagined future requirements",
+      "original_snippets": [],
+      "relevant_when": "Tempted to add configurability or extension points now",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Apply DRY to knowledge, not just characters: dedupe a single source of truth",
+      "original_snippets": [],
+      "relevant_when": "The same decision/rule is encoded in several places",
+      "why_given": "Core practice of the skill"
+    },
+    {
+      "instruction": "Avoid premature abstraction: prefer duplication until the shape is clear",
+      "original_snippets": [],
+      "relevant_when": "Two similar pieces of code appear",
+      "why_given": "Core practice of the skill"
+    }
+  ]
+}

--- a/skills/software-engineering/simplicity-principles/evals/scenario-1/capability.txt
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-1/capability.txt
@@ -1,0 +1,1 @@
+Removes unnecessary machinery down to the simplest working design

--- a/skills/software-engineering/simplicity-principles/evals/scenario-1/criteria.json
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-1/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "A feature is implemented with a plugin system, a factory, and a config layer for a single use case. Simplify it to the least machinery that works.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Removes speculative machinery (factory/plugin/config)",
+      "description": "Removes speculative machinery (factory/plugin/config)",
+      "max_score": 40
+    },
+    {
+      "name": "Keeps the actual behaviour",
+      "description": "Keeps the actual behaviour",
+      "max_score": 35
+    },
+    {
+      "name": "Justifies the simpler design",
+      "description": "Justifies the simpler design",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/software-engineering/simplicity-principles/evals/scenario-1/task.md
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-1/task.md
@@ -1,0 +1,3 @@
+# Scenario: Simplify an over-engineered solution
+
+A feature is implemented with a plugin system, a factory, and a config layer for a single use case. Simplify it to the least machinery that works.

--- a/skills/software-engineering/simplicity-principles/evals/scenario-2/capability.txt
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-2/capability.txt
@@ -1,0 +1,1 @@
+Strips unused speculative generality per YAGNI

--- a/skills/software-engineering/simplicity-principles/evals/scenario-2/criteria.json
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-2/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Code adds parameters and hooks 'in case we need them later', none used today. Strip the unused generality.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Identifies the unused/imagined-future code",
+      "description": "Identifies the unused/imagined-future code",
+      "max_score": 40
+    },
+    {
+      "name": "Removes it without breaking current behaviour",
+      "description": "Removes it without breaking current behaviour",
+      "max_score": 40
+    },
+    {
+      "name": "Explains the YAGNI rationale",
+      "description": "Explains the YAGNI rationale",
+      "max_score": 20
+    }
+  ]
+}

--- a/skills/software-engineering/simplicity-principles/evals/scenario-2/task.md
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-2/task.md
@@ -1,0 +1,3 @@
+# Scenario: Remove speculative generality (YAGNI)
+
+Code adds parameters and hooks 'in case we need them later', none used today. Strip the unused generality.

--- a/skills/software-engineering/simplicity-principles/evals/scenario-3/capability.txt
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-3/capability.txt
@@ -1,0 +1,1 @@
+Makes a justified DRY-vs-duplication call rather than reflexively abstracting

--- a/skills/software-engineering/simplicity-principles/evals/scenario-3/criteria.json
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-3/criteria.json
@@ -1,0 +1,21 @@
+{
+  "context": "Two functions share ~6 similar lines. Decide whether to abstract now or wait, and justify against DRY and premature-abstraction.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Weighs DRY against premature abstraction",
+      "description": "Weighs DRY against premature abstraction",
+      "max_score": 40
+    },
+    {
+      "name": "Reaches a justified decision",
+      "description": "Reaches a justified decision",
+      "max_score": 35
+    },
+    {
+      "name": "Ties the call to whether the shape is stable",
+      "description": "Ties the call to whether the shape is stable",
+      "max_score": 25
+    }
+  ]
+}

--- a/skills/software-engineering/simplicity-principles/evals/scenario-3/task.md
+++ b/skills/software-engineering/simplicity-principles/evals/scenario-3/task.md
@@ -1,0 +1,3 @@
+# Scenario: DRY vs premature abstraction
+
+Two functions share ~6 similar lines. Decide whether to abstract now or wait, and justify against DRY and premature-abstraction.

--- a/skills/software-engineering/simplicity-principles/evals/summary.json
+++ b/skills/software-engineering/simplicity-principles/evals/summary.json
@@ -1,0 +1,8 @@
+{
+  "total_scenarios": 3,
+  "instructions_coverage": {
+    "total_instructions": 4,
+    "instructions_tested": 4,
+    "coverage_percentage": 100
+  }
+}

--- a/skills/software-engineering/simplicity-principles/references/heuristics.md
+++ b/skills/software-engineering/simplicity-principles/references/heuristics.md
@@ -1,0 +1,8 @@
+# Simplicity Heuristics
+
+Quick checks for KISS / YAGNI / DRY. Core guidance is in `SKILL.md`.
+
+- KISS: could a junior read this in one pass? If not, simplify.
+- YAGNI: is this parameter/hook used by a real caller today? If not, remove it.
+- DRY: is the same *decision* encoded in two places? Dedupe knowledge, not incidental character overlap.
+- Rule of three: tolerate duplication until the third occurrence reveals the shape.


### PR DESCRIPTION
## What

The last W2 retro-conform batch:

| Skill | Before | After |
| --- | --- | --- |
| `agentic-harness/vault-search` | D (97) | B (115) |
| `software-engineering/simplicity-principles` | F (71) | C (101) |
| `agentic-harness/cache-audit` | F (63) | C (99) |

`simplicity-principles` and `cache-audit` gain full eval suites + `references/` + Mindset/Anti-Patterns (and cache-audit a When-to-Use). `vault-search` already had evals, so it gains only Anti-Patterns/Mindset + a `references/` file.

## Why

**Completes W2** — every raw-migrated skill (vault, journal-entry-creator, the deadalus keep-list, and the recon keep-list) now clears the audit gate at ≥ C. C now, A later. All under 500 lines; markdownlint + `validate-skill-artifacts` pass.