### PR TITLE
feat(journal-entry-creator): conform to grade C (W2 final)

### DIFF
--- a/skills/documentation/journal-entry-creator/SKILL.md
+++ b/skills/documentation/journal-entry-creator/SKILL.md
@@ -8,6 +8,10 @@ description:
 
 Automate creation of structured journal entries with template schemas, frontmatter validation, and compliance checking.
 
+## Mindset
+
+Every entry is a durable, queryable record, not a scratch note: get the frontmatter, triple-synced dates, and structure right the first time so future search and tooling can rely on them. Know **when not to** use this skill: a throwaway note with no frontmatter needs no ceremony.
+
 ## When to Use This Skill
 
 Use journal-entry-creator when:


### PR DESCRIPTION
## What

Lifts `documentation/journal-entry-creator` from **D (96)** to **C (101)** by adding a `## Mindset` section (with a "when not to" clause) → D2.

## Why

The ticket-refinement graft (#97) merged before the gate existed and left the skill at D. This is the final W2 item — with it, **every conformed skill clears the gate at ≥ C**.

## Note

Its eval suite is still the legacy flat `scenario-NN.md` format (D9 4/20); converting to `scenario-N/` dirs is a strong candidate for the later C→A pass.