### PR TITLE
ci: tessl currency pass, part 1 (publish pipeline + review wiring)

### DIFF
--- a/.github/workflows/pr-skill-checks.yml
+++ b/.github/workflows/pr-skill-checks.yml
@@ -132,7 +132,7 @@ jobs:
         run: exit 1
 
   tessl-review:
-    name: Tessl Skill Review
+    name: Tessl Review
     # Advisory, opt-in LLM/hosted review (mirrors skill-quality-auditor ADR-007 Tier 2).
     # Runs ONLY when a PR carries the 'run-eval' label (or via workflow_dispatch), never on every PR,
     # and never blocks the PR (see the advisory step below). The required, deterministic gate is the
@@ -168,7 +168,7 @@ jobs:
         if: steps.token-check.outputs.present == 'true'
         run: bun install
 
-      - name: Run tessl skill review
+      - name: Run tessl review
         id: review
         if: steps.token-check.outputs.present == 'true'
         env:
@@ -215,7 +215,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
-          body-includes: "## Tessl Skill Review"
+          body-includes: "## Tessl Review"
 
       - name: Post review results as PR comment
         if: always()
@@ -225,7 +225,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
           body: |
-            ## Tessl Skill Review
+            ## Tessl Review
 
             ${{ steps.review.conclusion == 'skipped' && '> ⏭️ Skipped — `TESSL_TOKEN` is not configured (fork PR or missing secret)' || '' }}
 
@@ -241,7 +241,7 @@ jobs:
       - name: Advisory notice if review reported issues
         if: steps.review.conclusion != 'skipped' && steps.review.outputs.exit_code != '0'
         run: |
-          echo "::warning::Tessl skill review reported issues or could not authenticate (advisory only, does not block this PR). See the 'Tessl Skill Review' comment. The required structural gate is the Skill Validator check."
+          echo "::warning::Tessl review reported issues or could not authenticate (advisory only, does not block this PR). See the 'Tessl Review' comment. The required structural gate is the Skill Validator check."
 
   request-eval-scenarios:
     name: Request Eval Scenarios from Copilot

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -1,4 +1,4 @@
-name: Publish Skills to Tessl
+name: Publish Plugins to Tessl
 
 on:
   push:
@@ -10,40 +10,40 @@ permissions:
   contents: read
 
 jobs:
-  detect-tiles:
-    name: Detect Changed Tiles
+  detect-plugins:
+    name: Detect Changed Plugins
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.tiles.outputs.matrix }}
-      has-tiles: ${{ steps.tiles.outputs.has-tiles }}
+      matrix: ${{ steps.plugins.outputs.matrix }}
+      has-plugins: ${{ steps.plugins.outputs.has-plugins }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
 
-      - name: Find changed tile directories
-        id: tiles
+      - name: Find changed plugin directories
+        id: plugins
         run: |
           CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'skills/**' 2>/dev/null || true)
 
           if [ -z "$CHANGED" ]; then
-            echo "has-tiles=false" >> "$GITHUB_OUTPUT"
-            echo 'matrix={"tile":[]}' >> "$GITHUB_OUTPUT"
+            echo "has-plugins=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"plugin":[]}' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # For each changed file, walk up the directory tree to find the nearest tile.json
-          TILE_DIRS=""
+          # For each changed file, walk up to the nearest plugin root (dir containing .tessl-plugin/plugin.json).
+          PLUGIN_DIRS=""
           while IFS= read -r file; do
             dir="$(dirname "$file")"
             while [ "$dir" != "." ] && [ "$dir" != "skills" ]; do
-              if [ -f "$dir/tile.json" ]; then
-                # Only publish if the tile.json version actually changed —
+              if [ -f "$dir/.tessl-plugin/plugin.json" ]; then
+                # Only publish if the plugin version actually changed —
                 # prevents republishing an already-published version on non-version pushes.
-                OLD_VERSION=$(git show HEAD~1:"$dir/tile.json" 2>/dev/null | jq -r '.version' 2>/dev/null || echo "")
-                NEW_VERSION=$(jq -r '.version' "$dir/tile.json" 2>/dev/null || echo "")
+                OLD_VERSION=$(git show HEAD~1:"$dir/.tessl-plugin/plugin.json" 2>/dev/null | jq -r '.version' 2>/dev/null || echo "")
+                NEW_VERSION=$(jq -r '.version' "$dir/.tessl-plugin/plugin.json" 2>/dev/null || echo "")
                 if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-                  TILE_DIRS="${TILE_DIRS}${dir}\n"
+                  PLUGIN_DIRS="${PLUGIN_DIRS}${dir}\n"
                 fi
                 break
               fi
@@ -51,24 +51,24 @@ jobs:
             done
           done <<< "$CHANGED"
 
-          UNIQUE_DIRS=$(printf '%b' "$TILE_DIRS" | sort -u | grep -v '^$' || true)
+          UNIQUE_DIRS=$(printf '%b' "$PLUGIN_DIRS" | sort -u | grep -v '^$' || true)
 
           if [ -z "$UNIQUE_DIRS" ]; then
-            echo "has-tiles=false" >> "$GITHUB_OUTPUT"
-            echo 'matrix={"tile":[]}' >> "$GITHUB_OUTPUT"
+            echo "has-plugins=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"plugin":[]}' >> "$GITHUB_OUTPUT"
           else
-            MATRIX=$(printf '%s\n' "$UNIQUE_DIRS" | jq -R . | jq -sc '{tile: .}')
-            echo "has-tiles=true" >> "$GITHUB_OUTPUT"
+            MATRIX=$(printf '%s\n' "$UNIQUE_DIRS" | jq -R . | jq -sc '{plugin: .}')
+            echo "has-plugins=true" >> "$GITHUB_OUTPUT"
             echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           fi
 
   publish:
-    name: Publish ${{ matrix.tile }}
-    needs: detect-tiles
-    if: needs.detect-tiles.outputs.has-tiles == 'true'
+    name: Publish ${{ matrix.plugin }}
+    needs: detect-plugins
+    if: needs.detect-plugins.outputs.has-plugins == 'true'
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJson(needs.detect-tiles.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.detect-plugins.outputs.matrix) }}
       fail-fast: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -77,10 +77,10 @@ jobs:
         with:
           token: ${{ secrets.TESSL_TOKEN }}
 
-      - name: Lint tile
-        run: tessl tile lint
-        working-directory: ${{ matrix.tile }}
+      - name: Lint plugin
+        run: tessl plugin lint
+        working-directory: ${{ matrix.plugin }}
 
-      - name: Publish tile
-        run: tessl tile publish
-        working-directory: ${{ matrix.tile }}
+      - name: Publish plugin
+        run: tessl plugin publish
+        working-directory: ${{ matrix.plugin }}

--- a/cli/lib/tessl/review-skill.ts
+++ b/cli/lib/tessl/review-skill.ts
@@ -11,12 +11,14 @@ export const reviewSkill = async (
 
   const manifest = await readManifest(skillPath);
   if (manifest && manifest.skills.length > 1) {
-    logger.info(`Multi-skill tile detected (${manifest.skills.length} skills)`);
+    logger.info(
+      `Multi-skill plugin detected (${manifest.skills.length} skills)`,
+    );
     for (const skillPathRel of manifest.skills) {
       const skillFullPath = join(skillPath, dirname(skillPathRel));
       logger.info(`Reviewing skill: ${skillPathRel}`);
       const { exitCode, stderr } = await exec(
-        `tessl skill review ${skillFullPath}`,
+        `tessl review run ${skillFullPath}`,
       );
       if (exitCode !== 0) {
         logger.error(`Review failed for ${skillPathRel}: ${stderr}`);
@@ -27,7 +29,7 @@ export const reviewSkill = async (
     return true;
   }
 
-  const { exitCode, stderr } = await exec(`tessl skill review ${skillPath}`);
+  const { exitCode, stderr } = await exec(`tessl review run ${skillPath}`);
   if (exitCode !== 0) {
     logger.error(`Review failed: ${stderr}`);
     return false;

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "tessl:manage": "bun cli/index.ts tessl manage",
     "tessl:publish-check": "bun cli/index.ts tessl publish-check",
     "tessl:import": "tessl skill import",
-    "tessl:lint": "tessl skill lint",
-    "tessl:publish": "tessl skill publish",
-    "tessl:review": "tessl skill review",
+    "tessl:lint": "tessl plugin lint",
+    "tessl:publish": "tessl plugin publish",
+    "tessl:review": "tessl review run",
     "test": "bun test cli/",
     "test:integration": "cucumber-js",
     "build:skill-auditor": "cd tools/skill-auditor && go build -o ../../bin/skill-auditor ."
@@ -43,7 +43,7 @@
     "@types/js-yaml": "^4.0.9",
     "lefthook": "^2.1.1",
     "markdownlint-cli2": "^0.21.0",
-    "tessl": "^0.68.0",
+    "tessl": "^0.90.0",
     "tsx": "^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
## What

First part of the Tessl currency pass (see the Journal drift assessment). Brings the dead/tile-era tooling onto the current plugin model.

- **`publish-skills.yml`** — rewritten from **tiles to plugins**: detects changed `.tessl-plugin/plugin.json` packages (version-changed only) and runs `tessl plugin lint` + `tessl plugin publish`. Previously it ran `tessl tile lint`/`tessl tile publish` against `tile.json`, which no longer exists — so **the publish pipeline was a dead no-op**.
- **`package.json`** — `tessl:lint`/`tessl:publish` → `tessl plugin …`; `tessl:review` → `tessl review run`; `tessl` devDep `^0.68.0` → `^0.90.0`.
- **`cli/lib/tessl/review-skill.ts`** — `tessl skill review` → `tessl review run` (Skill Review is deprecated, removed after July 2026).
- **`pr-skill-checks.yml`** — rename the review job/comments `Tessl Skill Review` → `Tessl Review`.

## Why

Restores the plugin publish pipeline (Phase 4 distribution depends on it) and completes the command-level Skill Review → Tessl Review migration.

## Deferred to part 2

- Make the `tessl-lint` job advisory + plugin-based (activating `tessl plugin lint` naively would reintroduce a token/hard-fail 401 gate, like the review job we already made advisory). It currently no-ops on the absent `tile.json`, so it is harmless meanwhile.
- Clean stale `tessl.json` deps: `tessl/cli-setup` and `tessl-labs/skill-review-optimizer` have **no published versions** (per `tessl outdated`); `tile-creator` is tile-era. This touches vendored `.tessl/plugins`, so it is a separate, careful change.