### PR TITLE
fix(install): resolve symlink target through symlinked parent dirs

### DIFF
--- a/cli/lib/install/create-symlink.test.ts
+++ b/cli/lib/install/create-symlink.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSymlink } from "./create-symlink";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = realpathSync.native(
+    mkdtempSync(join(tmpdir(), "create-symlink-test-")),
+  );
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+const makeSource = (): string => {
+  const source = join(tmp, "src", "my-skill");
+  mkdirSync(source, { recursive: true });
+  writeFileSync(join(source, "SKILL.md"), "# skill");
+  return source;
+};
+
+describe("createSymlink", () => {
+  test("creates a link that resolves to the source", () => {
+    const source = makeSource();
+    const targetDir = join(tmp, "skills");
+    mkdirSync(targetDir);
+    const target = join(targetDir, "my-skill");
+
+    expect(createSymlink(source, target, false)).toBe(true);
+    expect(existsSync(target)).toBe(true);
+    expect(realpathSync.native(target)).toBe(source);
+  });
+
+  test("resolves correctly when the target dir is reached via a symlinked parent", () => {
+    // Reproduces ~/.claude -> ~/.config/claude: the target's parent is a symlink,
+    // so a relative link computed from the logical path would dangle.
+    const source = makeSource();
+    const realParent = join(tmp, "config", "claude");
+    mkdirSync(join(realParent, "skills"), { recursive: true });
+    const logicalParent = join(tmp, ".claude");
+    symlinkSync(realParent, logicalParent, "dir");
+
+    const target = join(logicalParent, "skills", "my-skill");
+    expect(createSymlink(source, target, false)).toBe(true);
+
+    // The link must resolve to the source through the symlinked parent.
+    expect(existsSync(target)).toBe(true);
+    expect(realpathSync.native(target)).toBe(source);
+    // And it must be stored relative (portable), not absolute.
+    expect(readlinkSync(target).startsWith("/")).toBe(false);
+  });
+
+  test("is idempotent: a second call skips an already-correct link", () => {
+    const source = makeSource();
+    const targetDir = join(tmp, "skills");
+    mkdirSync(targetDir);
+    const target = join(targetDir, "my-skill");
+
+    expect(createSymlink(source, target, false)).toBe(true);
+    expect(createSymlink(source, target, false)).toBe(false);
+  });
+
+  test("self-heals a broken/dangling symlink", () => {
+    const source = makeSource();
+    const targetDir = join(tmp, "skills");
+    mkdirSync(targetDir);
+    const target = join(targetDir, "my-skill");
+    symlinkSync(join(tmp, "does-not-exist"), target, "dir");
+    expect(existsSync(target)).toBe(false); // dangling
+
+    expect(createSymlink(source, target, false)).toBe(true);
+    expect(realpathSync.native(target)).toBe(source);
+  });
+
+  test("replaces a symlink that points somewhere else", () => {
+    const source = makeSource();
+    const other = join(tmp, "other");
+    mkdirSync(other);
+    const targetDir = join(tmp, "skills");
+    mkdirSync(targetDir);
+    const target = join(targetDir, "my-skill");
+    symlinkSync(other, target, "dir");
+
+    expect(createSymlink(source, target, false)).toBe(true);
+    expect(realpathSync.native(target)).toBe(source);
+  });
+
+  test("never clobbers a real (non-symlink) directory", () => {
+    const source = makeSource();
+    const targetDir = join(tmp, "skills");
+    mkdirSync(targetDir);
+    const target = join(targetDir, "my-skill");
+    mkdirSync(target); // a real dir, e.g. a frozen external skill
+    writeFileSync(join(target, "SKILL.md"), "# external");
+
+    expect(createSymlink(source, target, false)).toBe(false);
+    expect(lstatSync(target).isSymbolicLink()).toBe(false);
+    expect(existsSync(join(target, "SKILL.md"))).toBe(true);
+  });
+
+  test("dry run reports without writing", () => {
+    const source = makeSource();
+    const targetDir = join(tmp, "skills");
+    mkdirSync(targetDir);
+    const target = join(targetDir, "my-skill");
+
+    expect(createSymlink(source, target, true)).toBe(true);
+    expect(existsSync(target)).toBe(false);
+  });
+});

--- a/cli/lib/install/create-symlink.ts
+++ b/cli/lib/install/create-symlink.ts
@@ -1,5 +1,5 @@
 import {
-  existsSync,
+  lstatSync,
   readlinkSync,
   realpathSync,
   symlinkSync,
@@ -14,33 +14,57 @@ export const createSymlink = (
   dryRun: boolean,
 ): boolean => {
   const resolvedSource = realpathSync.native(resolve(source));
-  const relativeSource = relative(dirname(target), resolvedSource);
+  // Resolve the target directory through any symlinked parents (e.g.
+  // ~/.claude -> ~/.config/claude). The link is physically stored in the real
+  // directory, so the relative link text must be computed from there or it
+  // dangles when the parent is a symlink. Fall back to the logical path when
+  // the directory does not exist yet (e.g. dry-run, which skips mkdir).
+  const rawTargetDir = dirname(target);
+  let targetDir: string;
+  try {
+    targetDir = realpathSync.native(rawTargetDir);
+  } catch {
+    targetDir = rawTargetDir;
+  }
+  const relativeSource = relative(targetDir, resolvedSource);
 
-  if (existsSync(target)) {
-    try {
-      const existing = readlinkSync(target);
-      // Resolve existing (may be relative or absolute) and canonicalize
-      // with realpathSync to handle platform symlinks (e.g. macOS /tmp → /private/tmp)
-      const resolvedExisting = realpathSync.native(
-        resolve(dirname(target), existing),
-      );
+  // lstat (not existsSync) so we detect broken/dangling symlinks too.
+  let stat: ReturnType<typeof lstatSync> | null = null;
+  try {
+    stat = lstatSync(target);
+  } catch {
+    stat = null;
+  }
 
-      if (resolvedExisting === resolvedSource) {
-        logger.debug(`Already linked: ${target}`);
-        return false;
-      }
-
-      if (dryRun) {
-        logger.warning(`Would replace symlink: ${target} -> ${relativeSource}`);
-        return true;
-      }
-
-      unlinkSync(target);
-      logger.info(`Removed old symlink: ${target}`);
-    } catch {
+  if (stat) {
+    if (!stat.isSymbolicLink()) {
+      // Merge-not-clobber: never remove a real file or directory (e.g. a
+      // frozen external skill installed independently).
       logger.warning(`Path exists but is not a symlink: ${target}`);
       return false;
     }
+
+    const existing = readlinkSync(target);
+    let resolvedExisting: string | null = null;
+    try {
+      resolvedExisting = realpathSync.native(resolve(targetDir, existing));
+    } catch {
+      // Dangling link — fall through to replace it.
+      resolvedExisting = null;
+    }
+
+    if (resolvedExisting === resolvedSource) {
+      logger.debug(`Already linked: ${target}`);
+      return false;
+    }
+
+    if (dryRun) {
+      logger.warning(`Would replace symlink: ${target} -> ${relativeSource}`);
+      return true;
+    }
+
+    unlinkSync(target);
+    logger.info(`Removed old symlink: ${target}`);
   }
 
   if (dryRun) {


### PR DESCRIPTION
## Problem

`tekhne install --global` produced **130 broken symlinks** in the Claude Code rail while OpenCode worked. Root cause: `~/.claude` is a symlink to `~/.config/claude`. `createSymlink` computed the relative link text from the *logical* target dir (`~/.claude/skills`), but the link is physically stored in the *real* dir (`~/.config/claude/skills`), one level deeper. So it wrote `../../` where `../../../` was needed, and every link dangled.

## Fix

- Compute the relative base from `realpathSync(dirname(target))` so links are correct through symlinked parents, with a fallback to the logical path when the dir does not exist yet (dry-run).
- Apply the same realpath base to the existing-link comparison so idempotent re-runs are detected correctly.
- Switch `existsSync` -> `lstat`, so **broken links self-heal** on reinstall, while **real (non-symlink) files/dirs are never clobbered** (merge-not-clobber preserved).

## Tests

New `create-symlink.test.ts` (7 cases): symlinked-parent resolution, idempotency, self-heal of dangling links, replace-divergent, no-clobber of real dirs, dry-run. Full CLI suite: 311 pass, 0 fail.

## Verified locally

After the fix, `install --global --agent claude-code opencode` yields 130 valid links each, **0 broken**, existing global skills untouched, and re-run is fully idempotent (Skipped 130).