### PR TITLE
feat(distribution): opt-in live-global skill install hook (Phase 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules/
 skills-lock.json
 .env.keys
 /bin/
+lefthook-local.yml

--- a/lefthook-local.example.yml
+++ b/lefthook-local.example.yml
@@ -1,0 +1,30 @@
+# Personal, machine-local git hooks (Phase 4: live-global skill distribution).
+#
+# lefthook automatically merges `lefthook-local.yml` (git-ignored) over the
+# committed `lefthook.yml`. This file is a committed *example* — it is not
+# active. To enable live-global distribution on your machine:
+#
+#   cp lefthook-local.example.yml lefthook-local.yml
+#   bun cli/index.ts install --global --agent claude-code opencode   # first-time link
+#
+# How it works
+# ------------
+# `tekhne install --global` symlinks every skill in this repo into the global
+# skill directories of the named agents (Claude Code: ~/.claude/skills,
+# OpenCode: ~/.config/opencode/skills). Because the installs are symlinks into
+# this working tree, skill *edits* are live immediately — no hook needed.
+#
+# The hook below only handles the add/remove case: after `git pull`/`git merge`
+# brings newly merged skills to your checkout, it creates links for the new
+# skills. It is idempotent (already-linked skills are skipped) and never
+# clobbers non-tekhne skills (real files/dirs are left untouched).
+#
+# This is opt-in and kept out of the committed `lefthook.yml` on purpose: a
+# shared hook would write ~130 symlinks into the home directory of anyone who
+# clones or pulls the repo (and could fire in CI). Distribution to a personal
+# machine is a personal-machine concern.
+
+post-merge:
+  commands:
+    refresh-global-skills:
+      run: bun cli/index.ts install --global --agent claude-code opencode


### PR DESCRIPTION
## What

Phase 4 distribution wiring. Adds `lefthook-local.example.yml` documenting the live-global mechanism and git-ignores `lefthook-local.yml`.

## Mechanism

`tekhne install --global --agent claude-code opencode` symlinks every skill into:
- Claude Code: `~/.claude/skills`
- OpenCode: `~/.config/opencode/skills`

Because installs are **symlinks into the working tree**, skill edits are live immediately with no watcher. The `post-merge` hook only links **newly merged** skills after a pull; it is idempotent (already-linked skipped) and never clobbers non-tekhne skills.

## Why opt-in (local, not committed lefthook.yml)

A shared hook would write ~130 symlinks into the home directory of anyone who clones or pulls tekhne, and could fire in CI. Distributing to a personal machine is a personal-machine concern, so it lives in a git-ignored `lefthook-local.yml` that each owner enables with `cp lefthook-local.example.yml lefthook-local.yml`.

## Depends on

Correct Claude Code links require #116 (symlink-through-symlinked-parent fix); before that, `~/.claude` -> `~/.config/claude` makes the Claude rail dangle. Merge #116 first.