### PR TITLE
fix(ci): Skill Audit gate must report on non-skill PRs

### DIFF
--- a/.github/workflows/skill-audit.yml
+++ b/.github/workflows/skill-audit.yml
@@ -1,11 +1,14 @@
 name: Skill Audit Gate
 
+# Runs on every PR to main (no path filter) so the required "Skill Audit"
+# status check always reports a conclusion. PRs that change no skills are
+# detected early and pass immediately without building the Go tools — a path
+# filter here would leave the required check unreported and block non-skill
+# PRs forever.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
-    paths:
-      - "skills/**"
 
 permissions:
   contents: read
@@ -22,15 +25,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # skill-auditor combines its own D1-D9 scoring with skill-validator's structural checks.
-      - name: Install skill-validator
-        run: |
-          go install github.com/agent-ecosystem/skill-validator/cmd/skill-validator@latest
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
-
-      - name: Build skill-auditor
-        run: cd tools/skill-auditor && go build -o ../../bin/skill-auditor .
-
       - name: Find changed skill dirs
         id: dirs
         run: |
@@ -40,6 +34,22 @@ jobs:
             | xargs -I{} dirname {} | sort -u | tr '\n' ' ')
           echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
           [ -n "$DIRS" ] && echo "found=true" >> "$GITHUB_OUTPUT" || echo "found=false" >> "$GITHUB_OUTPUT"
+
+      - name: No skills changed
+        if: steps.dirs.outputs.found == 'false'
+        run: echo "No SKILL.md changed — nothing to audit. Skill Audit passes."
+
+      # skill-auditor combines its own D1-D9 scoring with skill-validator's structural checks.
+      # Only build the Go tools when there are skills to audit.
+      - name: Install skill-validator
+        if: steps.dirs.outputs.found == 'true'
+        run: |
+          go install github.com/agent-ecosystem/skill-validator/cmd/skill-validator@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Build skill-auditor
+        if: steps.dirs.outputs.found == 'true'
+        run: cd tools/skill-auditor && go build -o ../../bin/skill-auditor .
 
       - name: Audit changed skills
         id: audit
@@ -99,7 +109,3 @@ jobs:
         run: |
           echo "::error::One or more changed skills scored below C (D/F) or could not be audited. Raise them to at least grade C to pass; grade A for a green pass."
           exit 1
-
-      - name: No skills changed
-        if: steps.dirs.outputs.found == 'false'
-        run: echo "No SKILL.md changed — nothing to audit."


### PR DESCRIPTION
## Problem

The `main` ruleset requires the **Skill Audit** status check. But `skill-audit.yml` had `on.pull_request.paths: [skills/**]`, so any PR that changes no skills (CLI, CI, docs) never triggered the workflow. GitHub then waits forever for a required context that never posts → the PR sits at **BLOCKED** despite all other checks passing. This is currently blocking #116 and #117.

## Fix

- Remove the `paths` filter so the gate runs on every PR to main and always reports a conclusion.
- The job already no-ops when no `SKILL.md` changed (`found == false`); move the change-detection step ahead of the Go tool builds and gate `go install`/`go build` on `found == true`, so non-skill PRs finish in seconds (checkout → detect → pass).

Skill-changing PRs behave exactly as before (audit, PR comment, D/F gate).

## Rollout note

This PR is itself a non-skill change, so it hits the same bug and needs one admin-merge to break the chicken-and-egg. Once merged, re-triggering #116/#117 (they run the workflow from `main`) will let their Skill Audit report and clear the block.