### PR TITLE
chore(ci): use App client-id in pr-auto-rebase

### DIFF
--- a/.github/workflows/pr-auto-rebase.yml
+++ b/.github/workflows/pr-auto-rebase.yml
@@ -29,8 +29,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          # App IDs are public identifiers, not secrets. 3181784 = pantheon-ai-bot.
-          app-id: "3181784"
+          # Client ID for the pantheon-ai-bot App (public identifier, not a secret).
+          client-id: "Iv23ligzn16vkDCWfHgc"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Rebase behind, non-draft PRs


### PR DESCRIPTION
## Summary

`actions/create-github-app-token` deprecated the `app-id` input in favour of `client-id`. Switch the `pr-auto-rebase` workflow to the pantheon-ai-bot **Client ID** (`Iv23ligzn16vkDCWfHgc`, a public identifier) to clear the deprecation warning. Behaviour is unchanged; `secrets.GH_APP_PRIVATE_KEY` is untouched.

## Validation (live)

Dispatched the branch via `workflow_dispatch`:
- Run succeeded.
- Token minted correctly with the client ID (all open PRs queried and reported up to date).
- The `app-id ... deprecated` warning no longer appears in the logs.