### PR TITLE
ci(codeql): per-language change detection + add python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,16 @@
 name: CodeQL
 
-# GitHub-native static analysis (code scanning) for the TypeScript CLI and the
-# Go tooling. Findings surface in the repository Security tab and as PR checks.
+# GitHub-native static analysis (code scanning) for the TypeScript CLI, the Go
+# tooling, and Python scripts. Findings surface in the Security tab and as PR
+# checks.
+#
+# On pull requests, the `changes` job builds a matrix containing only the
+# languages whose files changed, so a workflow-only or docs-only PR does not
+# spin up an unrelated language analysis. Pushes to main and the weekly
+# schedule always run the full matrix.
+#
+# Note: this is the advanced (security) scan only. The separate GitHub Code
+# Quality scan is managed in repo settings and always runs all languages.
 
 on:
   push:
@@ -17,8 +26,78 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed languages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            go:
+              - 'tools/skill-auditor/**'
+              - '**/*.go'
+              - '**/go.mod'
+              - '**/go.sum'
+            js:
+              - 'cli/**'
+              - 'docs/**'
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.js'
+              - '**/*.jsx'
+              - '**/*.cjs'
+              - '**/*.mjs'
+              - 'package.json'
+              - 'bun.lock'
+              - 'cucumber.js'
+            py:
+              - '**/*.py'
+              - '**/requirements*.txt'
+              - '**/pyproject.toml'
+              - '**/setup.py'
+              - '**/setup.cfg'
+            config:
+              - '.github/workflows/codeql.yml'
+
+      # Build the analysis matrix. On push/schedule, scan everything. On a PR,
+      # include a language only when its files (or this workflow) changed. A
+      # change to the workflow itself re-runs all languages so the config is
+      # exercised end to end.
+      - id: set
+        env:
+          EVENT: ${{ github.event_name }}
+          GO: ${{ steps.filter.outputs.go }}
+          JS: ${{ steps.filter.outputs.js }}
+          PY: ${{ steps.filter.outputs.py }}
+          CONFIG: ${{ steps.filter.outputs.config }}
+        run: |
+          set -euo pipefail
+          js='{"language":"javascript-typescript","build-mode":"none"}'
+          go='{"language":"go","build-mode":"manual"}'
+          py='{"language":"python","build-mode":"none"}'
+          if [ "$EVENT" != "pull_request" ]; then
+            matrix="[$js,$go,$py]"
+          else
+            entries=()
+            if [ "$CONFIG" = "true" ] || [ "$JS" = "true" ]; then entries+=("$js"); fi
+            if [ "$CONFIG" = "true" ] || [ "$GO" = "true" ]; then entries+=("$go"); fi
+            if [ "$CONFIG" = "true" ] || [ "$PY" = "true" ]; then entries+=("$py"); fi
+            matrix="[$(IFS=,; echo "${entries[*]:-}")]"
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Computed CodeQL matrix: $matrix"
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: changes
+    if: needs.changes.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,13 +106,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: javascript-typescript
-            build-mode: none
-          - language: go
-            build-mode: manual
+        include: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
         if: matrix.language == 'go'


### PR DESCRIPTION
## Summary

Make the advanced CodeQL (security) scan analyse a language only when that language's files change on a PR, and add `python` to the scan.

- New `changes` job (`dorny/paths-filter`, SHA-pinned) builds the analysis matrix from the languages actually touched.
- A workflow-only or docs-only PR no longer spins up unrelated language analyses.
- Push to `main` and the weekly schedule still run the full matrix (`js-ts`, `go`, `python`).
- A change to `codeql.yml` itself re-runs all languages (so the config is exercised end to end).
- Adds `python` (the repo has ~40 Python skill scripts, previously covered only by the GitHub Code Quality scan).

## Scope note

This only touches the advanced security scan. The separate GitHub **Code Quality** scan is managed in repo settings + the `code_quality` ruleset rule and always runs all languages; it cannot be made change-aware and was left untouched (admin/compliance-governed).

## Residual risk to validate (important)

The `main` ruleset has a `code_scanning` rule. Per GitHub docs, it blocks a PR when a required tool's "analysis is still in progress" or is "not configured". For a PR that changes **neither** Go, JS/TS, nor Python (e.g. a GitHub Actions-only bump), this workflow now runs no security analysis. Those `Analyze (...)` jobs are **not** required status checks (only `Skill Audit` is), so the expected behaviour is that the merge is not blocked, but the docs do not state this unambiguously.

**Validation plan:** this PR itself changes `codeql.yml`, so it exercises the full matrix (all three languages) and confirms the python analysis works. The skip path can only be verified after merge, on the next GitHub Actions-only Dependabot PR. If that PR ends up blocked on code scanning, revert is a single commit.

## Validation so far

- YAML parse + actionlint clean.
- Confirmed 40 Python files exist for the scan to analyse.