### PR TITLE
fix(deps): patch python-dotenv CVE and add pip Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,29 @@ updates:
           - "minor"
           - "patch"
 
+  # Python research skills (requirements.txt under skills/documentation/research)
+  - package-ecosystem: "pip"
+    directories:
+      - "/skills/documentation/research/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   # GitHub Actions (keeps the SHA pins in .github/workflows current)
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Wait 7 days after a release before opening an update PR, so a yanked or
+    # compromised release has time to surface before we adopt it.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "npm"
@@ -41,6 +45,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Wait 7 days after a release before opening an update PR, so a yanked or
+    # compromised release has time to surface before we adopt it.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "docs"
@@ -63,6 +71,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Wait 7 days after a release before opening an update PR, so a yanked or
+    # compromised release has time to surface before we adopt it.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "go"
@@ -85,6 +97,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Wait 7 days after a release before opening an update PR, so a yanked or
+    # compromised release has time to surface before we adopt it.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "python"
@@ -107,6 +123,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Wait 7 days after a release before opening an update PR, so a yanked or
+    # compromised release has time to surface before we adopt it.
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"

--- a/skills/documentation/research/notebooklm/requirements.txt
+++ b/skills/documentation/research/notebooklm/requirements.txt
@@ -7,4 +7,4 @@
 patchright==1.55.2
 
 # Environment management
-python-dotenv==1.0.0
+python-dotenv==1.2.2


### PR DESCRIPTION
## What

Resolves open Dependabot alert #1 (medium), closes the gap that let it go un-PRed, and adds a release cooldown.

### 1. Patch the vulnerability
- **Package:** `python-dotenv` (pip), `skills/documentation/research/notebooklm/requirements.txt`
- **Advisory:** [GHSA-mf9w-mj56-hr94](https://github.com/advisories/GHSA-mf9w-mj56-hr94) - symlink following in `set_key` allows arbitrary file overwrite via a cross-device rename fallback
- **Vulnerable:** `< 1.2.2` -> bumped `1.0.0` to `1.2.2` (first patched release, and current latest)

### 2. Add pip coverage to Dependabot
The pip ecosystem was not in `.github/dependabot.yml` (only npm, gomod, github-actions), so Dependabot flagged the vuln but never opened a version-update PR. Added a `pip` entry covering `skills/documentation/research/*/requirements.txt` (six skills) with the same weekly-grouped strategy as the other ecosystems. Also created the `python` repo label (Python-blue, matching the other language labels).

### 3. Add a 7-day release cooldown
Added `cooldown.default-days: 7` to every ecosystem (npm x2, gomod, pip, github-actions). Dependabot now waits a week after a release before opening an update PR, so a yanked or compromised release has time to surface before adoption.

## Verification
- `dependabot.yml` parses; ecosystems: npm, npm, gomod, pip, github-actions, each with `cooldown.default-days: 7`
- `python-dotenv==1.2.2` requires Python >=3.10 (fine for the skill venv)