### PR TITLE
ci(dependabot): group pip updates by dependency across skills

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -110,6 +110,9 @@ updates:
       include: "scope"
     groups:
       pip-minor-patch:
+        # Collapse the same dependency across all research-skill directories
+        # into one PR (e.g. a single `requests` bump instead of one per skill).
+        group-by: dependency-name
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
## What

Adds `group-by: dependency-name` to the `pip-minor-patch` group in `.github/dependabot.yml`.

## Why

The pip config covers six research-skill directories via a glob (`/skills/documentation/research/*`). Dependabot groups **per directory**, so a dependency shared across skills (e.g. `requests` appears in five of them) currently opens a **separate PR per directory** - the burst of ~13 pip PRs (#142-#155) seen after enabling pip coverage.

`group-by: dependency-name` collapses each dependency into a **single PR across all directories**, so one `requests` bump touches all five skills at once.

## Behaviour

- Version updates only (per Dependabot; security updates and cooldown are unaffected).
- Majors still raised individually (`update-types` stays `minor`/`patch`), matching the repo's existing strategy.
- Skipped if a dependency has incompatible version constraints across directories - those fall back to separate PRs.

## Follow-up

Existing open pip PRs (#142-#155) were opened under the old grouping; they will not retroactively merge. Once this lands, Dependabot will reconcile on its next run - recreating them under the new grouping. Simplest path is to let the new grouped PRs supersede, then close the stale singletons (or `@dependabot recreate`).