### PR TITLE
ci(plumber): authorize the repo's trusted action sources

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -616,6 +616,11 @@ github:
         - docker/build-push-action
         - ossf/scorecard-action
         - anchore/scan-action
+        - googleapis/release-please-action # Release automation (release-please.yml)
+        - oven-sh/setup-bun # Bun runtime setup (CLI, docs, skill-check workflows)
+        - peter-evans/find-comment # PR comment lookup (skill-check workflows)
+        - peter-evans/create-or-update-comment # PR comment upserts (skill-check workflows)
+        - tesslio/setup-tessl # Tessl registry tooling (publish-skills.yml)
 
     # ===========================================
     # Container images must not use forbidden tags


### PR DESCRIPTION
## What

Adds the five third-party action sources the workflows already use to the `githubActionMustComeFromAuthorizedSources.trustedGithubActions` allowlist in `.plumber.yaml`:

| Source | Used by | Owner |
| --- | --- | --- |
| `googleapis/release-please-action` | release-please.yml | Google (official) |
| `oven-sh/setup-bun` | CLI / docs / skill-check workflows | Bun (official) |
| `peter-evans/find-comment` | skill-check workflows | peter-evans |
| `peter-evans/create-or-update-comment` | skill-check + Plumber comment | peter-evans |
| `tesslio/setup-tessl` | publish-skills.yml | Tessl (registry this repo publishes to) |

All are already pinned by commit SHA in the workflows.

## Effect (verified by local scan of this branch)

- **Plumber Score: D (40/100) -> B (85/100)**
- Clears all **15 `ISSUE-713`** "unauthorized source" findings.
- Remaining: **1x `ISSUE-505`** (branch protection not compliant) - a repo-governance matter, out of scope here.

## Notes

- This is an allowlist of *sources*, not a bypass: SHA-pinning, archived-action, and known-CVE checks still apply to every entry.
- Decision-support: these owners were vetted as the actions actually in use; a maintainer should confirm the trust boundary is acceptable before merging.