### PR TITLE
ci: add concurrency guards to PR-triggered workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Supersede an in-flight run when the ref updates (e.g. a rebase), so
+  # stale runs are cancelled instead of piling onto the shared API quota.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -27,6 +27,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Supersede an in-flight run when the ref updates (e.g. a rebase), so
+  # stale runs are cancelled instead of piling onto the shared API quota.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   plumber:
     name: Plumber Score

--- a/.github/workflows/pr-cli-tests.yml
+++ b/.github/workflows/pr-cli-tests.yml
@@ -12,6 +12,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Supersede an in-flight run when the ref updates (e.g. a rebase), so
+  # stale runs are cancelled instead of piling onto the shared API quota.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/pr-skill-checks.yml
+++ b/.github/workflows/pr-skill-checks.yml
@@ -13,6 +13,12 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  # Supersede an in-flight run when the ref updates (e.g. a rebase), so
+  # stale runs are cancelled instead of piling onto the shared API quota.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tessl-lint:
     name: Tessl Plugin Lint

--- a/.github/workflows/skill-audit.yml
+++ b/.github/workflows/skill-audit.yml
@@ -14,6 +14,12 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  # Supersede an in-flight run when the ref updates (e.g. a rebase), so
+  # stale runs are cancelled instead of piling onto the shared API quota.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   skill-audit:
     name: Skill Audit
@@ -102,7 +108,10 @@ jobs:
 
             ${{ steps.audit.outputs.table }}
 
-            **Gate:** ✅ pass = A / A+ (≥126) · ⚠️ warning = C – B+ (98–125, non-blocking) · ❌ fail = D / F (<98, blocks merge)
+            **Gate:** 
+            - ✅ pass = A / A+ (≥126)
+            - ⚠️ warning = C – B+ (98–125, non-blocking)
+            - ❌ fail = D / F (<98, blocks merge)
 
       - name: Enforce gate (fail on D/F)
         if: steps.dirs.outputs.found == 'true' && steps.audit.outputs.fail == '1'

--- a/.github/workflows/skill-validate.yml
+++ b/.github/workflows/skill-validate.yml
@@ -14,6 +14,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Supersede an in-flight run when the ref updates (e.g. a rebase), so
+  # stale runs are cancelled instead of piling onto the shared API quota.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   skill-validator:
     name: Skill Validator


### PR DESCRIPTION
## What

Adds a `concurrency` group to the six PR-triggered workflows (codeql, plumber, pr-cli-tests, pr-skill-checks, skill-audit, skill-validate):

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Why

Every merge to `main` triggers the auto-rebase workflow, which rebases all open PR branches and re-fires their checks. With ~16 open PRs that is a large, repeated burst of concurrent runs on the shared installation API quota - which is what exhausted the rate limit and blocked Plumber's SLSA attestation check.

`cancel-in-progress` supersedes an older run when the ref updates again (e.g. a second rebase), so stale runs stop consuming quota instead of piling up.

## Notes

- Per-`{workflow, ref}` group: independent PRs never cancel each other; only a newer commit on the *same* ref cancels its own older run.
- Required checks (Skill Audit, CodeQL) still complete on the final commit, since the superseding push re-runs them.
- Paired with draining the Dependabot backlog (in progress separately) to cut the churn at its source.