### PR TITLE
ci(codeql): upgrade to Node 24 actions + fix Go cache warning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,16 +48,19 @@ jobs:
           - language: python
             build-mode: none
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
         if: matrix.language == 'go'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: tools/skill-auditor/go.mod
+          # The Go module lives in a subdirectory, so point the build cache at
+          # its lockfile; otherwise setup-go warns it cannot find go.mod at root.
+          cache-dependency-path: tools/skill-auditor/go.sum
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -70,6 +73,6 @@ jobs:
         working-directory: tools/skill-auditor
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Addresses the annotation warnings surfaced on CodeQL Analyze runs (seen on #158, but ambient - they appear on every PR because they originate in `codeql.yml`, not in #158's change):

| Warning | Fix |
| --- | --- |
| `Node.js 20 is deprecated` for `actions/checkout` | checkout v4 (Node 20) -> **v7.0.0** (Node 24), the SHA already used elsewhere in the repo |
| `CodeQL Action v3 will be deprecated in December 2026` | `github/codeql-action` init + analyze v3 (Node 20) -> **v4.37.0** (Node 24) |
| `Restore cache failed: Dependencies file is not found ... go.mod` | add `cache-dependency-path: tools/skill-auditor/go.sum` to `setup-go`, since the module lives in a subdirectory |

All pins remain SHA-pinned (Plumber's `actionsMustBePinnedByCommitSha` still satisfied). Note the codeql-action v4.37.0 SHA `99df26d4…` is the same version Plumber already uses internally for SARIF upload.

## Not addressed (by design)

The `Plumber Score is below the configured gate ... soft-fail is enabled` warning is intentional - that is the advisory scan reporting the accepted `ISSUE-505`, not failing the job. Documented in `.github/BRANCH_PROTECTION.md`.

## Scope note

This also supersedes the CodeQL v3->v4 bump that was in the closed Dependabot PR #128, done here directly with a pinned SHA and the accompanying Node 24 / cache fixes.