### PR TITLE
ci(release-please): cut releases weekly, refresh PR on push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,10 +3,22 @@ name: Release Please
 on:
   push:
     branches: [main]
+  schedule:
+    # Weekly release cut: Mondays 08:07 UTC (09:07 BST). Off-peak minute lowers
+    # the chance of GitHub dropping the scheduled run under load.
+    - cron: "7 8 * * 1"
+  workflow_dispatch: {}
 
 permissions:
   contents: write
   pull-requests: write
+
+# Serialise runs so a push-triggered PR refresh and the weekly release cut do
+# not race to update the release-please branch. Never cancel an in-flight run:
+# cancelling mid tag/GitHub-Release creation could leave a half-cut release.
+concurrency:
+  group: release-please
+  cancel-in-progress: false
 
 jobs:
   release-please:
@@ -15,8 +27,13 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
-          # RELEASE_PLEASE_TOKEN: optional PAT for orgs that restrict GITHUB_TOKEN
-          # permissions. A human merging the release PR still triggers publish-skills.yml.
+          # Optional PAT for orgs that restrict the default GITHUB_TOKEN.
+          # Falls back to GITHUB_TOKEN when the PAT secret is absent.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Cadence control. On push we only refresh the rolling release PR
+          # (skip the tag/GitHub Release), so it stays current and mergeable
+          # against the strict up-to-date branch ruleset. The release itself is
+          # cut only on the weekly schedule, or on demand via workflow_dispatch.
+          skip-github-release: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## What

Split the Release Please cadence so a real release (git tags + GitHub Releases) is cut **only on a weekly schedule** (Mondays) or on demand, while the rolling release PR (e.g. #110) keeps refreshing on every push to `main`.

## Why

The release PR was re-running the release action on every push. The goal is a genuine **weekly release** cadence. A naive schedule-only trigger would leave the release PR stale and unmergeable between runs (the `main` ruleset enforces strict "branches must be up to date"), and risks GitHub's 60-day auto-disable of scheduled workflows. Keeping the push trigger avoids both.

## How

- Added `schedule` (`cron: "7 8 * * 1"`, Mondays 08:07 UTC / 09:07 BST) and `workflow_dispatch`; kept `push`.
- `skip-github-release: ${{ github.event_name == 'push' }}` so pushes only refresh the release PR (no tag/release); the release is cut on the weekly run or via manual dispatch.
- Added a non-cancelling concurrency guard (`group: release-please`) so a push refresh and the weekly cut cannot race on the release branch.
- Corrected a misleading token comment.

## Behaviour

- **Push to main:** release PR refreshed/force-pushed as before, stays mergeable. No release cut.
- **Mondays / manual dispatch:** pending release is cut.

Because push still force-pushes the release branch, the `pr-auto-rebase.yml` exclusion comment stays accurate; no change needed there.

## Notes

- To cut tags immediately after merging the release PR mid-week, trigger the workflow via `workflow_dispatch`; otherwise tags appear at the next weekly run.
- Publishing is unaffected: `publish-skills.yml` keys off `plugin.json` version diffs, not release tags.
- Validated with `actionlint`.

## Decision-support

This changes release cadence and governance for a regulated project. Final sign-off on the weekly day/time and merge procedure rests with the repo owner.