### PR TITLE
feat(create-context-file)!: organize by typology with date-prefixed filenames

### DIFF
--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -1026,7 +1026,7 @@ Splits a large feature branch into smaller, focused pull requests using stacked 
 
 ### create-context-file
 
-Creates structured context files (plans, justifications, scratches) in the .cont...
+Creates a structured, date-stamped context file filed by typology (findings, pla...
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |

--- a/skills/project-mgmt/create-context-file/.tessl-plugin/plugin.json
+++ b/skills/project-mgmt/create-context-file/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pantheon-ai/create-context-file",
   "version": "0.3.1",
-  "description": "Create context files (plans, justifications, scratches) in .context/ directory with unique three-word IDs and frontmatter",
+  "description": "Create context files under .context/<typology>/ (findings, plans, guides, follow-ups, merge-requests, tickets, ...) with date-prefixed YYYY-MM-DD-slug.md filenames and YAML frontmatter",
   "private": false,
   "skills": ["SKILL.md"]
 }

--- a/skills/project-mgmt/create-context-file/SKILL.md
+++ b/skills/project-mgmt/create-context-file/SKILL.md
@@ -1,104 +1,145 @@
 ---
 name: create-context-file
-description: Creates structured context files (plans, justifications, scratches) in the .context/ directory with unique three-word IDs and frontmatter metadata. Use when starting a new task and needing to document a plan or task breakdown, when recording decision rationale or architectural choices as a justification, when saving temporary notes or exploratory thinking as a scratch, or when the user asks to "create a plan", "document my thinking", "save context", "track decisions", or "keep notes" in a structured project context directory.
+description: "Creates a structured, date-stamped context file filed by typology (findings, plans, guides, follow-ups, merge-requests, tickets, decisions, notes, research) with YAML frontmatter. Use when saving a finding, writing a plan, capturing a guide, recording a decision, logging a follow-up, filing a merge-request note, plus ticket write-ups."
 license: MIT
-compatibility: opencode
 metadata:
-  version: "0.1.0"
+  version: "1.0.0"
   audience: agents
-  workflow: planning, decision-making, exploration
+  workflow: capture, planning, documentation
 ---
 
-# create-context-file
+# Create Context File
 
-## What I do
-
-I create context files in the `.context/` directory for three purposes:
-- **Plans** (`.context/plans/`): task breakdowns, feature specs, project plans
-- **Justifications** (`.context/justifications/`): decision rationale, architectural choices, approach validation
-- **Scratches** (`.context/scratches/`): temporary notes, exploratory ideas, idea pads
-
-Each file gets a unique three-word identifier (e.g., `happy-blue-moon`), ensuring no filename conflicts, plus frontmatter with the current date and a formatted title.
-
-## How to use
-
-Run with type, slug, and content:
-```bash
-bunx .context/skills/create-context-file/scripts/create-context-file.ts --type plan "feature-name" "Plan content here"
-```
-
-Or use heredoc for multi-line content:
-```bash
-bunx .context/skills/create-context-file/scripts/create-context-file.ts --type justification "decision-name" << HEREDOC
-Multi-line
-justification content
-goes here
-HEREDOC
-```
-
-## File format
-
-Files are created as: `{three-word-id}-{slug}.md`
-Example: `happy-blue-moon-feature-name.md`
-
-The file includes frontmatter:
-```markdown
----
-date: 2026-01-13
-title: Feature Name
----
----
-Your content here
-```
+Persist a working artifact into the project's context directory, filed by
+**typology** and named with a date prefix so it sorts chronologically and never
+collides.
 
 ## When to Use
 
-Use create-context-file when:
-- **Starting new work**: Document plan before writing code (prevents scope creep)
-- **Decision points**: Record why you chose approach A over B (future reference)
-- **Exploratory thinking**: Save scratch notes during research (avoid losing insights)
-- **User requests**: "create a plan", "document this decision", "save my notes"
+- Save an investigation write-up, plan, guide, or decision produced while working.
+- Capture a follow-up, merge-request note, or ticket write-up for later.
+- The user asks to "save this finding", "create a plan", or "write this up".
 
-**Do NOT use for:**
-- **Code comments**: Put technical notes in source files directly
-- **External docs**: Use proper documentation systems (Confluence, Notion)
-- **Long-term specs**: Use README.md or `/docs` for permanent documentation
-- **Task tracking**: Use issue trackers, not context files
+## When Not to Use
 
-## File Type Selection Guide
+- Do NOT use for technical notes that belong inline in source — write a code comment.
+- Do NOT use for permanent, long-lived docs — use the README or docs site.
+- Do NOT use for issue tracking — use the issue tracker.
+- Do NOT use for content the team consumes externally — use the docs system.
 
-| Type | Purpose | Lifecycle | Example Use Cases |
-|------|---------|-----------|-------------------|
-| **plan** | Task breakdown before execution | Delete after task complete | Feature specs, refactoring roadmaps, migration plans |
-| **justification** | Record decision rationale | Keep indefinitely | Architecture choices, library selection, approach validation |
-| **scratch** | Temporary exploratory notes | Delete after conclusion | Research notes, debugging hypotheses, idea capture |
+## Principles
 
-**Decision rule:** If you'll reference it later → **justification**. If it's temporary → **scratch**. If it guides execution → **plan**.
+1. **Typology is the organizing axis.** ALWAYS choose the folder by *what the
+   artifact is*, not by how long it lives.
+2. **One artifact, one file.** ALWAYS keep a single typology per file; NEVER
+   merge a finding with a plan.
+3. **Deterministic names.** The generator MUST own the filename and frontmatter;
+   never hand-craft them.
+4. **Curated growth.** Extend the typology set deliberately, not per task.
+
+## Workflow
+
+1. Choose the typology from the curated set. — **Stop if:** none fits and the
+   need will not recur; reuse the closest match instead of adding a folder.
+2. Inspect what already exists for that typology to avoid duplicates:
+
+   ```bash
+   ls .context/findings/
+   ```
+
+   Expected result: the existing files, so you can confirm none already covers
+   this artifact.
+3. Run the generator with a specific, task-tied title. — **Verify:** the printed
+   path uses the expected typology plus date.
+4. Fill in the body beneath the generated heading. — **Stop if:** the content
+   spans two typologies; split it into separate files.
+
+## Quick Commands
+
+```bash
+# Create a finding with tags
+./scripts/create-context-file.sh --type findings --title "Auth token analysis" \
+  --tags "auth,oauth"
+```
+
+Expected result: a new dated finding file, printed as the only stdout line.
+
+```bash
+# Multi-line body via heredoc
+./scripts/create-context-file.sh --type plans --title "Retriever rollout" << 'EOF'
+## Phase 1
+...
+EOF
+```
+
+Expected result: a dated plan file containing the heredoc body.
+
+```bash
+# Preview without writing
+./scripts/create-context-file.sh --type merge-requests --title "PLG-1234" --dry-run
+```
+
+Expected result: the target path plus full file body printed; nothing written.
+
+```bash
+# A deliberate one-off typology
+./scripts/create-context-file.sh --type experiments --title "spike" --allow-new-type
+```
+
+Expected result: a file under a new typology folder, created knowingly.
+
+Full option list: see the CLI reference below.
 
 ## Anti-Patterns
 
-### NEVER create context files without reading existing .context/ structure first
+### NEVER create a file without checking the typology folder first
 
-- **WHY**: duplicate or misplaced files violate organization conventions and confuse searches.
-- **BAD**: immediately run `create-context-file.ts --type plan "my-plan"` without checking what exists.
-- **GOOD**: `ls .context/plans/` first to see existing plans, avoid duplicates, follow naming patterns.
+**WHY:** the same artifact captured twice fragments context and breaks search.
 
-### NEVER use generic slugs like "notes" or "todo"
+**BAD:** run the generator immediately for a plan that already exists.
+**GOOD:** list the folder, confirm nothing covers it, then create.
 
-- **WHY**: collisions are likely when multiple tasks use vague names; three-word IDs aren't enough if slugs duplicate.
-- **BAD**: `--type scratch "notes"` → creates `happy-blue-moon-notes.md` but another task may have `sad-red-sky-notes.md` causing confusion.
-- **GOOD**: specific slugs tied to task: `--type scratch "api-refactor-notes"` or `--type plan "user-auth-migration"`.
+**Consequence:** duplicate, drifting files that later readers cannot reconcile —
+a common pitfall once a repository grows.
 
-### NEVER mix content types in one file
+### NEVER use a generic slug like `notes` or `todo`
 
-- **WHY**: plans, justifications, and scratches have different lifecycles and audiences; mixing creates cleanup confusion.
-- **BAD**: `--type plan "feature"` but content includes justification rationale AND scratch exploration.
-- **GOOD**: separate files — `--type plan "feature-implementation"`, `--type justification "why-graphql"`, `--type scratch "api-alternatives"`.
+**WHY:** vague slugs collide and read as noise when sorted by date.
 
-### NEVER skip frontmatter or use invalid date formats
+**BAD:** `--title "notes"` yields a `notes.md` that clashes across tasks.
+**GOOD:** `--title "API refactor findings"` yields a specific, searchable name.
 
-- **WHY**: frontmatter powers metadata queries and date sorting; invalid formats break tooling.
-- **BAD**: manually edit file to remove frontmatter or use `date: Jan 13th` (invalid).
-- **GOOD**: script-generated frontmatter with `date: 2026-01-13` (ISO 8601) always included.
+**Consequence:** unsearchable filenames plus silent name clashes in production
+repositories.
+
+### NEVER mix typologies in one file
+
+**WHY:** a finding, a plan, and a follow-up have different lifecycles and readers.
+
+**BAD:** one file holding analysis, a rollout plan, and open questions.
+**GOOD:** three files, one per typology, cross-referenced if needed.
+
+**Consequence:** no file can be retired cleanly; each keeps stale content alive.
+
+### NEVER hand-edit the filename or frontmatter date
+
+**WHY:** the date prefix plus ISO `date` power sorting and downstream tooling.
+
+**BAD:** rename to drop the date, or set `date: Jul 21st`.
+**GOOD:** let the generator produce both; keep the original date on later edits.
+
+**Consequence:** broken chronological ordering plus frontmatter parse failures.
+
+### NEVER invent a new typology for a one-off
+
+**WHY:** ad-hoc folders erode the curated set that makes context navigable.
+
+**BAD:** create a bespoke folder for a single throwaway note.
+**GOOD:** reuse the closest typology, or pass `--allow-new-type` knowingly.
+
+**Consequence:** folder sprawl that defeats predictable retrieval — a slow pitfall.
 
 ## References
+
+- [Typologies](references/typologies.md) — the curated catalog, selection rule, and how to extend the set; load when choosing or adding a typology.
+- [CLI reference](references/cli.md) — full generator flags, behavior, and examples; load when you need an option beyond the Quick Commands.

--- a/skills/project-mgmt/create-context-file/evals/scenario-01.md
+++ b/skills/project-mgmt/create-context-file/evals/scenario-01.md
@@ -1,41 +1,60 @@
-# Scenario 01: Select the Correct Context File Type
+# Scenario 01: Select the Correct Typology
 
 ## User Prompt
 
-You receive the following three requests from different developers on the same team. For each request, you must classify which context file type to use and explain why.
+You receive the following requests from different developers on the same team.
+For each, classify which context-file **typology** to use and explain why.
 
-**Request A:** "I'm about to migrate the database from Postgres 14 to 15. I want to track the steps I'll follow before I start writing any scripts."
+**Request A:** "I dug into why our login latency spiked last week and want to
+write up what I found so the team can reference it."
 
-**Request B:** "We debated whether to use Redis or Memcached for session storage. I want to capture why we went with Redis so future team members understand the reasoning."
+**Request B:** "I'm about to migrate the database from Postgres 14 to 15. I want
+to lay out the steps I'll follow before I start writing any scripts."
 
-**Request C:** "I'm exploring a few different approaches to rate limiting. Just want somewhere to jot down the tradeoffs as I research, nothing permanent."
+**Request C:** "I keep having to explain how our retry/backoff wrapper works.
+I want a reusable how-to the team can point new joiners at."
 
-Produce a Markdown file saved to `type-selection.md` that, for each request (A, B, C):
+**Request D:** "There are three edge cases we agreed to defer on the checkout
+refactor. I want to capture them so they aren't forgotten."
 
-1. States the file type you would use (plan, justification, or scratch).
-2. Quotes the specific decision rule from the skill that led to that choice.
-3. Provides the slug you would use for the file (specific, task-tied, not generic).
+Produce a Markdown file saved to `typology-selection.md` that, for each request
+(A, B, C, D):
+
+1. States the typology you would use (`findings`, `plans`, `guides`, or
+   `follow-ups`).
+2. Explains, from the skill, why that typology fits (pick by *what the artifact
+   is*).
+3. Provides the slug you would use (specific, task-tied, not generic).
 
 ## Expected Behavior
 
-1. Classify Request A (migration steps before execution) as a `plan` file
-2. Classify Request B (decision rationale for Redis vs Memcached) as a `justification` file
-3. Classify Request C (temporary research notes) as a `scratch` file
-4. For each classification, reference the corresponding rule from the skill ("guides execution", "reference later", "temporary")
-5. Provide a specific, task-tied slug for each file (e.g. `postgres-14-to-15-migration`, `redis-session-storage-rationale`, `rate-limiting-tradeoffs`) — not generic terms like `notes` or `todo`
+1. Classify Request A (investigation write-up) as `findings`
+2. Classify Request B (steps before execution) as `plans`
+3. Classify Request C (reusable how-to) as `guides`
+4. Classify Request D (deferred work capture) as `follow-ups`
+5. Justify each by what the artifact is, per the skill's typology guide
+6. Provide a specific, task-tied slug for each (e.g. `login-latency-spike`,
+   `postgres-14-to-15-migration`, `retry-backoff-wrapper`,
+   `checkout-refactor-deferred-edge-cases`) — not generic terms like `notes`
 
 ## Success Criteria
 
-- **Request A classified as plan**: `type-selection.md` classifies Request A (migration steps before execution) as `plan`
-- **Request B classified as justification**: `type-selection.md` classifies Request B (decision rationale for Redis vs Memcached) as `justification`
-- **Request C classified as scratch**: `type-selection.md` classifies Request C (temporary research notes) as `scratch`
-- **Decision rule quoted for each**: For each classification, `type-selection.md` references the corresponding rule from the skill ("guides execution", "reference later", "temporary")
-- **Specific slugs provided**: Each entry includes a task-specific slug (e.g. `postgres-14-to-15-migration`, `redis-session-storage-rationale`, `rate-limiting-tradeoffs`) — not generic terms like `notes` or `todo`
+- **Request A classified as findings**: `typology-selection.md` classifies
+  Request A as `findings`
+- **Request B classified as plans**: `typology-selection.md` classifies Request
+  B as `plans`
+- **Request C classified as guides**: `typology-selection.md` classifies Request
+  C as `guides`
+- **Request D classified as follow-ups**: `typology-selection.md` classifies
+  Request D as `follow-ups`
+- **Reasoning references the typology guide**: each classification explains the
+  choice by what the artifact is, per the skill
+- **Specific slugs provided**: each entry includes a task-specific slug, not a
+  generic term like `notes` or `todo`
 
 ## Failure Conditions
 
-- Classifies Request A as justification or scratch instead of plan
-- Classifies Request B as plan or scratch instead of justification
-- Classifies Request C as plan or justification instead of scratch
-- Omits the decision rule reference for one or more classifications
-- Provides generic slugs (e.g. `notes`, `todo`, `research`) instead of task-specific ones
+- Misclassifies any of A/B/C/D into the wrong typology
+- Justifies a choice by lifecycle alone instead of what the artifact is
+- Provides generic slugs (e.g. `notes`, `todo`, `research`)
+- Invents a brand-new typology when an existing curated one fits

--- a/skills/project-mgmt/create-context-file/evals/scenario-02.md
+++ b/skills/project-mgmt/create-context-file/evals/scenario-02.md
@@ -2,42 +2,54 @@
 
 ## User Prompt
 
-A developer asks: "Can you document my plan for rolling out feature flags to production? The plan has three steps: 1) Add the feature flag SDK, 2) Gate the new checkout flow behind a flag, 3) Enable the flag for 10% of users via canary rollout."
+A developer asks: "Can you document my plan for rolling out feature flags to
+production? The plan has three steps: 1) Add the feature flag SDK, 2) Gate the
+new checkout flow behind a flag, 3) Enable the flag for 10% of users via canary
+rollout."
 
 Today's date is 2026-03-16.
 
 Create a properly formatted context file at the path:
-`.context/plans/<three-word-id>-feature-flag-rollout.md`
-
-Use any valid three-word ID of your choice for the filename prefix.
+`.context/plans/2026-03-16-feature-flag-rollout.md`
 
 The file must:
 
-1. Start with valid YAML frontmatter containing `date: 2026-03-16` and a formatted `title: Feature Flag Rollout`.
-2. Contain the three rollout steps as the body content.
-3. Use the specific slug `feature-flag-rollout` (not a generic slug).
-4. Be placed in the `.context/plans/` subdirectory (not justifications or scratches).
+1. Live under `.context/plans/` (the `plans` typology), not another typology.
+2. Use the date-prefixed filename `2026-03-16-feature-flag-rollout.md` with the
+   specific slug `feature-flag-rollout` (not a generic slug).
+3. Start with valid YAML frontmatter containing `title: "Feature Flag Rollout"`,
+   `type: plans`, `date: 2026-03-16`, `status: active`, and `tags`.
+4. Follow the frontmatter with a `# Feature Flag Rollout` heading.
+5. Contain the three rollout steps as the body content.
 
 ## Expected Behavior
 
-1. Place the file under `.context/plans/` (not `.context/justifications/` or `.context/scratches/`)
-2. Begin the file with valid YAML frontmatter containing `date: 2026-03-16` in ISO 8601 format
-3. Include `title: Feature Flag Rollout` (or equivalent formatted title) in the frontmatter
-4. Include the slug `feature-flag-rollout` in the filename (not a generic term like `notes` or `plan`)
-5. Include all three rollout steps in the file body: SDK addition, feature flag gate, and canary rollout
+1. Place the file under `.context/plans/` (not another typology folder)
+2. Name the file `2026-03-16-feature-flag-rollout.md` (date prefix + specific
+   slug, not a generic term like `notes` or `plan`)
+3. Begin with valid YAML frontmatter including `date: 2026-03-16` (ISO 8601),
+   `type: plans`, and a formatted `title`
+4. Include a `# Feature Flag Rollout` top-level heading after the frontmatter
+5. Include all three rollout steps in the body: SDK addition, feature flag gate,
+   and canary rollout
 
 ## Success Criteria
 
-- **Correct subdirectory**: The file is placed under `.context/plans/` (not `justifications/` or `scratches/`)
-- **Valid frontmatter with ISO 8601 date**: The file begins with YAML frontmatter containing `date: 2026-03-16` in ISO 8601 format
-- **Formatted title in frontmatter**: The frontmatter contains `title: Feature Flag Rollout` (or equivalent formatted title)
-- **Specific slug in filename**: The filename contains the slug `feature-flag-rollout` (not a generic term like `notes` or `plan`)
-- **Content includes all three rollout steps**: The file body contains all three steps: SDK addition, feature flag gate, and canary rollout
+- **Correct typology folder**: the file is under `.context/plans/`
+- **Date-prefixed filename**: the filename is `2026-03-16-feature-flag-rollout.md`
+  (ISO date prefix + specific slug)
+- **Valid frontmatter with ISO date and type**: frontmatter contains
+  `date: 2026-03-16`, `type: plans`, and a formatted `title`
+- **Title heading present**: a `# Feature Flag Rollout` heading follows the
+  frontmatter
+- **Content includes all three steps**: the body contains SDK addition, feature
+  flag gate, and canary rollout
 
 ## Failure Conditions
 
-- Places the file in `.context/justifications/` or `.context/scratches/` instead of `.context/plans/`
-- Omits YAML frontmatter or uses a date format other than ISO 8601 (YYYY-MM-DD)
-- Omits the title from frontmatter
-- Uses a generic slug (e.g. `notes`, `plan`, `todo`) instead of `feature-flag-rollout`
-- Omits one or more of the three rollout steps from the file body
+- Places the file under a typology other than `plans`
+- Omits the date prefix, or uses a date format other than ISO 8601 (YYYY-MM-DD)
+- Uses a three-word-ID prefix or a generic slug (e.g. `notes`, `plan`, `todo`)
+  instead of `feature-flag-rollout`
+- Omits `type` or `title` from the frontmatter
+- Omits one or more of the three rollout steps from the body

--- a/skills/project-mgmt/create-context-file/evals/scenario-03.md
+++ b/skills/project-mgmt/create-context-file/evals/scenario-03.md
@@ -4,37 +4,56 @@
 
 A developer proposes the following context file creation plan:
 
-> "I'll create `.context/plans/notes.md` without checking what's already in `.context/`. The file will document why we chose GraphQL over REST, plus my scratch notes on schema design alternatives I'm exploring, plus the step-by-step migration plan. I'll skip the frontmatter since it's just temporary notes."
+> "I'll create `.context/plans/notes.md` without checking what's already in
+> `.context/`. The file will document what I found investigating the login
+> latency spike, plus a reusable how-to for our retry wrapper, plus the
+> step-by-step migration plan. I'll skip the frontmatter and drop the date from
+> the filename since it's just temporary."
 
-Review this proposal against the create-context-file skill's anti-patterns and produce a written review saved to `antipattern-review.md`.
+Review this proposal against the create-context-file skill's anti-patterns and
+produce a written review saved to `antipattern-review.md`.
 
 Your output must:
 
 1. Identify every anti-pattern from the skill that this proposal violates.
-2. For each anti-pattern, quote the specific part of the proposal that violates it.
+2. For each anti-pattern, quote the specific part of the proposal that violates
+   it.
 3. For each violation, state the corrected approach.
-4. Provide a corrected file creation plan at the end that fixes all identified issues (correct types, slugs, frontmatter, and pre-creation check).
+4. Provide a corrected creation plan at the end that fixes all issues (correct
+   typologies, specific slugs, date-prefixed filenames, frontmatter, and a
+   pre-creation check).
 
 ## Expected Behavior
 
-1. Flag the failure to check existing `.context/` structure before creating the file
-2. Flag `notes` as a generic slug that risks collisions and violates the naming rule
-3. Identify that the proposal mixes justification (GraphQL rationale), scratch (schema exploration), and plan (migration steps) in one file
-4. Flag the proposal to skip frontmatter as a violation of the ISO 8601 date requirement
-5. End with a corrected creation plan: three separate files with specific slugs, correct types, frontmatter, and a pre-creation `ls` check
+1. Flag the failure to check the existing `.context/` structure first
+2. Flag `notes` as a generic slug that risks collisions and violates the naming
+   rule
+3. Identify that the proposal mixes three typologies in one file: `findings`
+   (latency investigation), `guides` (retry how-to), and `plans` (migration
+   steps)
+4. Flag skipping frontmatter and dropping the date prefix as violations of the
+   `YYYY-MM-DD-slug.md` naming and frontmatter conventions
+5. End with a corrected plan: three separate date-prefixed files under the right
+   typologies, with specific slugs, frontmatter, and a pre-creation check
 
 ## Success Criteria
 
-- **Skipping pre-creation check identified**: `antipattern-review.md` flags the failure to check existing `.context/` structure before creating the file
-- **Generic slug identified**: `antipattern-review.md` flags `notes` as a generic slug that risks collisions and violates the naming rule
-- **Mixed content types identified**: `antipattern-review.md` identifies that the proposal mixes justification (GraphQL rationale), scratch (schema exploration), and plan (migration steps) in one file
-- **Missing frontmatter identified**: `antipattern-review.md` flags the proposal to skip frontmatter as a violation of the ISO 8601 date requirement
-- **Corrected plan provided**: `antipattern-review.md` ends with a corrected creation plan: three separate files with specific slugs, correct types, frontmatter, and a pre-creation `ls` check
+- **Skipping pre-creation check identified**: `antipattern-review.md` flags the
+  failure to check the existing `.context/` structure first
+- **Generic slug identified**: `antipattern-review.md` flags `notes` as a
+  generic slug that violates the naming rule
+- **Mixed typologies identified**: `antipattern-review.md` identifies that the
+  proposal mixes `findings`, `guides`, and `plans` in one file
+- **Missing frontmatter and date identified**: `antipattern-review.md` flags
+  skipping frontmatter and dropping the date prefix as convention violations
+- **Corrected plan provided**: `antipattern-review.md` ends with three separate
+  date-prefixed files under the correct typologies, with specific slugs,
+  frontmatter, and a pre-creation check
 
 ## Failure Conditions
 
 - Fails to flag the missing pre-creation check
-- Accepts the generic `notes` slug without flagging it as a violation
-- Does not identify that the proposed file mixes three different content types
-- Does not flag the missing frontmatter as a violation
-- Provides no corrected plan or provides a plan that still has the same violations
+- Accepts the generic `notes` slug without flagging it
+- Does not identify that the file mixes three typologies
+- Does not flag the missing frontmatter or the dropped date prefix
+- Provides no corrected plan, or one that still has the same violations

--- a/skills/project-mgmt/create-context-file/evals/scenario-04.md
+++ b/skills/project-mgmt/create-context-file/evals/scenario-04.md
@@ -2,42 +2,57 @@
 
 ## User Prompt
 
-You receive the following four requests. For each, determine whether a context file is the right tool or not.
+You receive the following four requests. For each, determine whether a context
+file is the right tool or not.
 
 **Request 1:** "Track this bug in JIRA — the login button is broken on Safari."
 
-**Request 2:** "Add a comment to `src/auth/token.ts` explaining why we use RS256 not HS256."
+**Request 2:** "Add a comment to `src/auth/token.ts` explaining why we use RS256
+not HS256."
 
-**Request 3:** "Document the API design for our new payments service so the team can reference it for the next 2 years — put it somewhere permanent."
+**Request 3:** "Document the API design for our new payments service so the team
+can reference it for the next 2 years — put it somewhere permanent."
 
-**Request 4:** "I need to jot down some ideas about refactoring the notification service. Just for now while I think through the approach."
+**Request 4:** "I investigated three approaches to rate limiting and want to
+write up the tradeoffs I found so we can refer back to them."
 
 Produce a Markdown file saved to `tool-selection.md` that, for each request:
 
 1. States whether a context file IS or IS NOT the right tool.
-2. If NOT, states the correct alternative tool (code comment, issue tracker, README/docs).
-3. If IS, states which type (plan, justification, scratch) and why.
+2. If NOT, states the correct alternative tool (code comment, issue tracker,
+   README/docs).
+3. If IS, states which typology and why.
 
 ## Expected Behavior
 
-1. State that Request 1 (JIRA bug tracking) is NOT appropriate for a context file and recommend an issue tracker
-2. State that Request 2 (source file explanation) is NOT appropriate for a context file and recommend a code comment
-3. State that Request 3 (permanent API design docs) is NOT appropriate for a context file and recommend README or `/docs`
-4. Approve Request 4 as a valid scratch file (temporary exploratory notes)
-5. Reference the relevant "Do NOT use for" rule or type selection rule from the skill for each decision
+1. State that Request 1 (JIRA bug tracking) is NOT appropriate for a context
+   file and recommend an issue tracker
+2. State that Request 2 (source file explanation) is NOT appropriate for a
+   context file and recommend a code comment
+3. State that Request 3 (permanent API design docs) is NOT appropriate for a
+   context file and recommend README or `/docs`
+4. Approve Request 4 as a valid `findings` file (an investigation write-up to
+   refer back to)
+5. Reference the relevant "Do NOT use for" rule or typology guide entry from the
+   skill for each decision
 
 ## Success Criteria
 
-- **Request 1 correctly declined (issue tracker)**: `tool-selection.md` states that Request 1 (JIRA bug) is NOT appropriate for a context file and recommends an issue tracker
-- **Request 2 correctly declined (code comment)**: `tool-selection.md` states that Request 2 (source file explanation) is NOT appropriate for a context file and recommends a code comment
-- **Request 3 correctly declined (README/docs)**: `tool-selection.md` states that Request 3 (permanent API design docs) is NOT appropriate for a context file and recommends README or `/docs`
-- **Request 4 correctly approved as scratch**: `tool-selection.md` approves Request 4 as a valid scratch file (temporary exploratory notes)
-- **Reasoning references skill rules**: Each decision references the relevant "Do NOT use for" rule or type selection rule from the skill
+- **Request 1 correctly declined (issue tracker)**: `tool-selection.md` states
+  Request 1 is NOT appropriate and recommends an issue tracker
+- **Request 2 correctly declined (code comment)**: `tool-selection.md` states
+  Request 2 is NOT appropriate and recommends a code comment
+- **Request 3 correctly declined (README/docs)**: `tool-selection.md` states
+  Request 3 is NOT appropriate and recommends README or `/docs`
+- **Request 4 correctly approved as findings**: `tool-selection.md` approves
+  Request 4 as a `findings` file
+- **Reasoning references skill rules**: each decision references the relevant
+  "Do NOT use for" rule or typology guide entry
 
 ## Failure Conditions
 
 - Approves a context file for Request 1 instead of directing to an issue tracker
 - Approves a context file for Request 2 instead of directing to a code comment
 - Approves a context file for Request 3 instead of directing to README or docs
-- Declines Request 4 or classifies it as a plan or justification instead of scratch
+- Declines Request 4, or classifies it as a typology other than `findings`
 - Provides decisions without referencing the skill's rules

--- a/skills/project-mgmt/create-context-file/evals/scenario-05.md
+++ b/skills/project-mgmt/create-context-file/evals/scenario-05.md
@@ -1,40 +1,56 @@
-# Scenario 05: Apply the Decision Rule to Ambiguous Requests
+# Scenario 05: Decompose a Multi-Need Request by Typology
 
 ## User Prompt
 
-A developer says: "I need to figure out the best way to handle versioning for our public API. I'm going to investigate URL versioning vs header versioning vs no versioning. Once I decide, I'll want to remember why. And then I'll need to track the steps to actually implement whatever I choose."
+A developer says: "I need to figure out the best way to handle versioning for
+our public API. I'm going to investigate URL versioning vs header versioning vs
+no versioning and write up what I find. Then I'll need to track the steps to
+actually implement whatever I choose. And I want a short how-to the team can
+follow to add a new API version later."
 
 This single statement describes three separate needs at once.
 
-Using the create-context-file skill's decision rule ("If you'll reference it later → justification. If it's temporary → scratch. If it guides execution → plan"), produce a file saved to `decision-breakdown.md` that:
+Using the create-context-file skill's typology guide (pick by *what the artifact
+is*), produce a file saved to `typology-breakdown.md` that:
 
 1. Identifies all three distinct needs embedded in the developer's statement.
-2. Maps each need to the correct file type using the explicit decision rule.
-3. Proposes a specific slug for each file.
-4. States the lifecycle expectation for each file (when it should be deleted or kept).
+2. Maps each need to the correct typology.
+3. Proposes a specific date-prefixed filename for each (assume today is
+   2026-03-16).
+4. States the lifecycle expectation for each file (kept, retired when done, etc).
 
 ## Expected Behavior
 
-1. Identify three separate needs: investigation/research, decision rationale, and implementation steps
-2. Map the investigation phase (temporary research) to a scratch file
-3. Map the "remember why" need to a justification file with "keep indefinitely" lifecycle
-4. Map the implementation tracking need to a plan file with "delete after task complete" lifecycle
-5. Provide specific, task-tied slugs for each of the three files (not generic terms like `notes` or `todo`)
-6. Include explicit lifecycle statements for each file (when to delete or keep)
+1. Identify three separate needs: investigation write-up, implementation steps,
+   and a reusable how-to
+2. Map the investigation write-up to a `findings` file
+3. Map the implementation tracking to a `plans` file
+4. Map the reusable how-to to a `guides` file
+5. Provide a specific, date-prefixed filename for each (e.g.
+   `.context/findings/2026-03-16-api-versioning-options.md`,
+   `.context/plans/2026-03-16-api-versioning-implementation.md`,
+   `.context/guides/2026-03-16-adding-a-new-api-version.md`) — not generic slugs
+6. Include an explicit lifecycle statement for each file
 
 ## Success Criteria
 
-- **Three distinct needs identified**: `decision-breakdown.md` identifies three separate needs: investigation/research, decision rationale, and implementation steps
-- **Research mapped to scratch**: `decision-breakdown.md` maps the investigation phase (temporary research) to a scratch file
-- **Decision rationale mapped to justification**: `decision-breakdown.md` maps the "remember why" need to a justification file with "keep indefinitely" lifecycle
-- **Implementation steps mapped to plan**: `decision-breakdown.md` maps the implementation tracking need to a plan file with "delete after task complete" lifecycle
-- **Specific slugs and lifecycle expectations provided**: Each of the three files has a specific task-tied slug (not generic) and an explicit lifecycle statement (when to delete or keep)
+- **Three distinct needs identified**: `typology-breakdown.md` identifies
+  investigation, implementation steps, and a reusable how-to
+- **Investigation mapped to findings**: the investigation write-up maps to
+  `findings`
+- **Implementation mapped to plans**: the implementation tracking maps to `plans`
+- **How-to mapped to guides**: the reusable how-to maps to `guides`
+- **Specific date-prefixed filenames provided**: each file has a
+  `YYYY-MM-DD-slug.md` name with a specific slug (not `notes`/`todo`) under the
+  correct typology folder
+- **Lifecycle expectations provided**: each file has an explicit lifecycle
+  statement
 
 ## Failure Conditions
 
-- Identifies fewer than three distinct needs, collapsing multiple needs into one file
-- Maps the investigation phase to justification or plan instead of scratch
-- Maps the decision rationale to scratch or plan instead of justification
-- Maps the implementation steps to scratch or justification instead of plan
-- Provides generic slugs (e.g. `notes`, `research`, `todo`) instead of task-specific ones
+- Identifies fewer than three distinct needs, collapsing them into one file
+- Maps the investigation to a typology other than `findings`
+- Maps the implementation steps to a typology other than `plans`
+- Maps the how-to to a typology other than `guides`
+- Provides generic slugs, or filenames without the ISO date prefix
 - Omits lifecycle expectations for one or more files

--- a/skills/project-mgmt/create-context-file/references/cli.md
+++ b/skills/project-mgmt/create-context-file/references/cli.md
@@ -1,0 +1,53 @@
+# Generator CLI reference
+
+`scripts/create-context-file.sh` writes a date-prefixed context file into a
+typology subfolder and prints the created path.
+
+## Synopsis
+
+```bash
+scripts/create-context-file.sh --type <typology> --title "<title>" [options]
+# optional body content is read from stdin
+```
+
+## Options
+
+| Flag | Argument | Purpose |
+| --- | --- | --- |
+| `-t`, `--type` | `TYPE` | Typology / subfolder (required). Validated against `KNOWN_TYPES`. |
+| `-T`, `--title` | `TITLE` | Human-readable title (required); also seeds the slug. |
+| `-s`, `--slug` | `SLUG` | Override the auto-derived slug. |
+| `-g`, `--tags` | `TAGS` | Comma-separated tags for frontmatter. |
+| `-d`, `--date` | `DATE` | Override the date (`YYYY-MM-DD`); defaults to today. |
+| `-r`, `--root` | `DIR` | Context root; defaults to `.context`. |
+| `-A`, `--allow-new-type` | | Permit a typology not in `KNOWN_TYPES`. |
+| `-n`, `--dry-run` | | Print the target path and file body; write nothing. |
+| `-f`, `--force` | | Overwrite an existing target file. |
+| `-h`, `--help` | | Show usage. |
+
+## Behavior
+
+- The output path is `<root>/<typology>/<YYYY-MM-DD>-<slug>.md`, where `<root>`
+  is resolved against the current working directory (the consuming project).
+- The slug is derived from the title (lowercased, non-alphanumeric runs
+  collapsed to single hyphens) unless `--slug` overrides it.
+- The date must match `YYYY-MM-DD`; other formats are rejected.
+- An unknown typology is rejected unless `--allow-new-type` is passed.
+- An existing target file is never overwritten unless `--force` is passed.
+
+## Examples
+
+```bash
+# Finding with tags
+scripts/create-context-file.sh --type findings --title "Auth token analysis" \
+  --tags "auth,oauth"
+
+# Plan with a heredoc body
+scripts/create-context-file.sh --type plans --title "Retriever rollout" << 'EOF'
+## Phase 1
+...
+EOF
+
+# Preview only
+scripts/create-context-file.sh --type merge-requests --title "PLG-1234 retriever" --dry-run
+```

--- a/skills/project-mgmt/create-context-file/references/typologies.md
+++ b/skills/project-mgmt/create-context-file/references/typologies.md
@@ -1,0 +1,35 @@
+# Typology catalog
+
+The typology is the organizing principle for context files. It maps directly to
+the subfolder name under the context root and is drawn from a curated set that
+stays mostly static but may evolve deliberately.
+
+## Curated typologies
+
+| Typology | What it holds | Typical lifecycle |
+| --- | --- | --- |
+| `findings` | Investigation results, analysis, research output | Keep for reference |
+| `plans` | Implementation plans, task breakdowns | Retire when the work lands |
+| `guides` | Reusable how-tos and reference material | Keep and maintain |
+| `follow-ups` | Deferred work, open threads, TODO capture | Close when actioned |
+| `merge-requests` | MR/PR notes, descriptions, review context | Retire after merge |
+| `tickets` | Issue write-ups and refinement notes | Track with the issue |
+| `decisions` | Decision rationale and trade-offs | Keep indefinitely |
+| `notes` | General working notes | Prune when stale |
+| `research` | Longer-running research logs | Keep while active |
+
+## Selection rule
+
+Pick the typology by **what the artifact is**, not by how long it will live. An
+investigation write-up is `findings` whether or not you keep it; a rollout
+checklist is `plans` whether it lasts a day or a month.
+
+When none of the curated typologies fits, prefer the closest match over
+inventing a new folder. Introduce a new typology only when it will recur.
+
+## Extending the set
+
+The generator validates the requested typology against `KNOWN_TYPES` in
+`scripts/create-context-file.sh`. To add a permanent typology, add it to that
+list. For a genuine one-off, pass `--allow-new-type` instead of editing the
+list, which keeps the curated set intentional.

--- a/skills/project-mgmt/create-context-file/scripts/create-context-file.sh
+++ b/skills/project-mgmt/create-context-file/scripts/create-context-file.sh
@@ -1,121 +1,147 @@
 #!/usr/bin/env sh
+#
+# create-context-file.sh - create a context file under <root>/<typology>/
+# using a date-prefixed filename: <YYYY-MM-DD>-<slug>.md
+#
+# The typology is an open, curated set (findings, plans, guides, follow-ups,
+# merge-requests, tickets, ...). It maps directly to the subfolder name. The
+# set is meant to stay mostly static; extend KNOWN_TYPES below when a genuinely
+# new typology is needed, or pass --allow-new-type for a one-off.
+#
+# Files are written to <root>/<typology>/ where <root> defaults to .context in
+# the CURRENT working directory (the consuming project), not the skill package.
+#
+# Usage:
+#   create-context-file.sh --type <typology> --title "<title>" [options]
+#   ... optional body content is read from stdin (e.g. via heredoc)
+#
+# Options:
+#   -t, --type   TYPE     Typology / subfolder (required). See KNOWN_TYPES.
+#   -T, --title  TITLE    Human-readable title (required).
+#   -s, --slug   SLUG     Override the auto-generated slug (kebab-case).
+#   -g, --tags   TAGS     Comma-separated tags (e.g. "auth,oauth").
+#   -d, --date   DATE     Override the date (YYYY-MM-DD). Defaults to today.
+#   -r, --root   DIR      Context root. Defaults to .context.
+#   -A, --allow-new-type  Permit a typology not in KNOWN_TYPES.
+#   -n, --dry-run         Print the target path and file body; write nothing.
+#   -f, --force           Overwrite if the target file already exists.
+#   -h, --help            Show this help.
 
-set -e
+set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Curated, mostly-static typology set. Extend deliberately.
+KNOWN_TYPES="findings plans guides follow-ups merge-requests tickets decisions notes research"
 
-adjectives="happy blue quick smart green fast red cool warm bright"
-nouns="moon sun star planet comet galaxy cloud ocean forest mountain"
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 
+usage() { sed -n '2,/^# *-h/p' "$0" | sed 's/^#\{0,1\} \{0,1\}//'; }
+
+# slugify: lowercase, keep alnum, collapse the rest to single hyphens, trim.
 slugify() {
-	printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 -]//g' | sed 's/[[:space:]]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
+	printf '%s' "$1" \
+		| tr '[:upper:]' '[:lower:]' \
+		| sed 's/[^a-z0-9]\{1,\}/-/g; s/-\{1,\}/-/g; s/^-//; s/-$//'
 }
 
-random_index() {
-	_max="$1"
-	_seed=$(date +%s 2>/dev/null || echo $$)
-	_rand=$(( (_seed * 1664525 + 1013904223) % 2147483647 ))
-	echo $(( _rand % _max ))
-}
-
-pick_word() {
-	_words="$1"
-	_count="$2"
-	_idx=$(random_index "$_count")
-	echo "$_words" | cut -d' ' -f$((_idx + 1))
-}
-
-generate_three_word_id() {
-	_adj_count=$(echo "$adjectives" | wc -w | tr -d ' ')
-	_noun_count=$(echo "$nouns" | wc -w | tr -d ' ')
-	
-	_adj=$(pick_word "$adjectives" "$_adj_count")
-	_noun=$(pick_word "$nouns" "$_noun_count")
-	_num=$(random_index 1000)
-	
-	printf '%s-%s-%d' "$_adj" "$_noun" "$_num"
-}
-
-title_case() {
-	_slug="$1"
-	_result=""
-	IFS='-'
-	for _word in $_slug; do
-		_first=$(printf '%s' "$_word" | cut -c1 | tr '[:lower:]' '[:upper:]')
-		_rest=$(printf '%s' "$_word" | cut -c2-)
-		if [ -n "$_result" ]; then
-			_result="$_result "
-		fi
-		_result="${_result}${_first}${_rest}"
+type_known() {
+	for _k in $KNOWN_TYPES; do
+		[ "$_k" = "$1" ] && return 0
 	done
-	unset IFS
-	printf '%s' "$_result"
+	return 1
 }
 
-usage() {
-	cat <<EOF
-Usage: $(basename "$0") --type [plan|justification|scratch] "slug" "content"
+type=""
+title=""
+slug=""
+tags=""
+date=""
+root=".context"
+allow_new=0
+dry_run=0
+force=0
 
-Examples:
-  $(basename "$0") --type plan "feature-name" "Plan content here"
-  $(basename "$0") --type justification "decision-name" "Justification content here"
-  $(basename "$0") --type scratch "note-name" "Scratch content here"
-EOF
-	exit 1
-}
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-t|--type)           type="${2:-}"; shift 2 ;;
+		-T|--title)          title="${2:-}"; shift 2 ;;
+		-s|--slug)           slug="${2:-}"; shift 2 ;;
+		-g|--tags)           tags="${2:-}"; shift 2 ;;
+		-d|--date)           date="${2:-}"; shift 2 ;;
+		-r|--root)           root="${2:-}"; shift 2 ;;
+		-A|--allow-new-type) allow_new=1; shift ;;
+		-n|--dry-run)        dry_run=1; shift ;;
+		-f|--force)          force=1; shift ;;
+		-h|--help)           usage; exit 0 ;;
+		*)                   die "unknown argument: $1 (see --help)" ;;
+	esac
+done
 
-if [ $# -lt 4 ]; then
-	usage
+[ -n "$type" ]  || die "--type is required (see --help)"
+[ -n "$title" ] || die "--title is required (see --help)"
+
+type="$(slugify "$type")"
+[ -n "$type" ] || die "--type produced an empty typology"
+
+if ! type_known "$type" && [ "$allow_new" -ne 1 ]; then
+	die "unknown typology '$type'. Known: ${KNOWN_TYPES}.
+Add it to KNOWN_TYPES in this script if it should be permanent, or pass --allow-new-type for a one-off."
 fi
 
-if [ "$1" != "--type" ]; then
-	echo "Error: --type flag is required"
-	usage
-fi
-
-_type="$2"
-_slug="$3"
-shift 3
-_content="$*"
-
-case "$_type" in
-	plan|justification|scratch) ;;
-	*)
-		echo "Error: Invalid type. Must be one of: plan, justification, scratch"
-		exit 1
-		;;
+date="${date:-$(date +%Y-%m-%d)}"
+case "$date" in
+	[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+	*) die "--date must be YYYY-MM-DD (got: $date)" ;;
 esac
 
-if [ -z "$_slug" ] || [ -z "$_content" ]; then
-	echo "Error: Both slug and content are required"
-	exit 1
+[ -n "$slug" ] || slug="$(slugify "$title")"
+slug="$(slugify "$slug")"
+[ -n "$slug" ] || die "could not derive a slug; pass --slug"
+
+dir="${root%/}/${type}"
+path="${dir}/${date}-${slug}.md"
+
+# Body content from stdin when piped (leaves body empty for interactive runs).
+content=""
+if [ ! -t 0 ]; then
+	content="$(cat)"
 fi
 
-_three_word_id=$(generate_three_word_id)
-_formatted_slug=$(slugify "$_slug")
-_file_name="${_three_word_id}-${_formatted_slug}.md"
+# Build tags block.
+if [ -n "$tags" ]; then
+	tags_block="tags:"
+	_ifs="$IFS"; IFS=','
+	for _tag in $tags; do
+		_tag="$(printf '%s' "$_tag" | sed 's/^[[:space:]]\{1,\}//; s/[[:space:]]\{1,\}$//')"
+		[ -n "$_tag" ] && tags_block="${tags_block}
+  - ${_tag}"
+	done
+	IFS="$_ifs"
+else
+	tags_block="tags: []"
+fi
 
-case "$_type" in
-	plan) _target_dir="plans" ;;
-	justification) _target_dir="justifications" ;;
-	scratch) _target_dir="scratches" ;;
-esac
+body="---
+title: \"${title}\"
+type: ${type}
+date: ${date}
+status: active
+${tags_block}
+---
 
-_target_path="${SCRIPT_DIR}/../.context/${_target_dir}/${_file_name}"
-_date=$(date +%Y-%m-%d)
-_title=$(title_case "$_slug")
+# ${title}
+"
+[ -n "$content" ] && body="${body}
+${content}
+"
 
-_frontmatter="---
-date: ${_date}
-title: ${_title}
----"
+if [ "$dry_run" -eq 1 ]; then
+	printf 'path: %s\n\n%s' "$path" "$body"
+	exit 0
+fi
 
-_full_content="${_frontmatter}
+[ -e "$path" ] && [ "$force" -ne 1 ] \
+	&& die "refusing to overwrite existing file: $path (use --force)"
 
-${_content}"
-
-mkdir -p "${SCRIPT_DIR}/../.context/${_target_dir}"
-printf '%s\n' "$_full_content" > "$_target_path"
-
-echo "Created $_type file: $_target_path"
-echo "Three-word ID: $_three_word_id"
+mkdir -p "$dir"
+printf '%s' "$body" > "$path"
+printf '%s\n' "$path"


### PR DESCRIPTION
## What

Reworks the `create-context-file` skill from the three-word-ID + fixed
`plan/justification/scratch` model to a **typology-driven** layout.

- Files land in `.context/<typology>/` where typology is a curated, mostly-static
  set (`findings`, `plans`, `guides`, `follow-ups`, `merge-requests`, `tickets`,
  `decisions`, `notes`, `research`), extensible via `KNOWN_TYPES` or a one-off
  `--allow-new-type`.
- Filenames are date-prefixed: `YYYY-MM-DD-slug.md`.

## Why

Aligns the skill with the date-prefixed, typology-based convention. The old
model produced opaque `happy-blue-moon-*.md` names and a closed type enum that
did not cover common artifacts (follow-ups, MR notes, tickets).

## Changes

- **script**: rewritten to typology + date+slug; now writes to the *consuming
  project's* context root (the old script wrote into the skill package itself, a
  latent bug). Adds `--dry-run`, `--tags`, `--date`, `--slug`, `--allow-new-type`,
  `--force`; body via stdin; validates typology against `KNOWN_TYPES`.
- **SKILL.md**: rewritten to the canonical template (Principles, Workflow with
  Verify/Stop-if, Quick Commands, 5 anti-patterns, bullet-link References);
  fixed the stale `.ts`/`bunx` invocation to the real `.sh`; dropped the
  agent-specific `compatibility` field.
- **references/**: added `typologies.md` and `cli.md` (progressive disclosure).
- **evals**: all 5 scenarios retargeted to the typology model.
- **plugin.json**: description updated.

## Quality

- `skill-auditor`: **F (88) -> B (112)/140**. Pre-push gate (blocks below C)
  passes.
- Not yet A-grade: the remaining gap is D9 (eval validation, 4/20). The Go
  auditor rewards `evals/scenario-N/` subdirectories, but the repo's own
  `references/eval-format.md` mandates flat `evals/scenario-NN.md` and calls the
  `instructions.json`/`summary.json` artifacts "retired". This contradiction is
  repo-wide and needs a maintainer decision before D9 can be raised.
- unit tests (311) and integration tests (28 scenarios) pass; shellcheck,
  biome, markdownlint clean.

## Breaking change

BREAKING CHANGE: filenames are now date-prefixed (`YYYY-MM-DD-slug.md`) instead
of three-word IDs, and types are an open typology set instead of the fixed
`plan/justification/scratch` enum. Existing files are unaffected; only newly
generated files use the new scheme.