### PR TITLE
chore(python): inventory + allowlist + research markers (Wave 1 / C1)

### DIFF
--- a/.context/plans/python-inventory.md
+++ b/.context/plans/python-inventory.md
@@ -1,0 +1,72 @@
+# C1: authoritative Python and glue inventory
+
+**Status**: Complete (21-07-2026). Source of truth for C2, C2b, and C3.
+**Task**: C1 (Wave 1) of the monorepo tools distribution migration.
+**Allowlist file**: `python-allowlist.txt` (repo root).
+
+## 1. Python by skill, with disposition
+
+Every skill directory containing `.py`, classified per decisions D1 (research) and D5 (validators/generators). Disposition drives C2b (convert or keep) and C3 (delete or preserve).
+
+| Skill | Category | Disposition |
+|-------|----------|-------------|
+| documentation/research/pubmed-search | Research (D1) | Keep (allowlist); marker in C1 |
+| documentation/research/sci-hub-search | Research (D1) | Keep (allowlist); marker in C1 |
+| documentation/research/notebooklm | Research (D1) | Keep (allowlist); marker in C1 |
+| documentation/research/sci-data-extractor | Research (D1) | Keep (allowlist); marker in C1 |
+| documentation/research/google-scholar-search | Research (D1) | Keep (allowlist); marker in C1 |
+| documentation/research/semantic-scholar-search | Research (D1) | Keep (allowlist); marker in C1 |
+| observability/promql/validator | Custom-logic validator (D5 ii) | Keep (allowlist); marker in C2b |
+| ci-cd/gitlab-ci/validator | Custom-logic validator (D5 ii) | Keep (allowlist); marker in C2b |
+| ci-cd/azure-pipelines/validator | Custom-logic validator (D5 ii) | Keep (allowlist); marker in C2b |
+| ci-cd/jenkinsfile/generator | Custom-logic generator (D5 ii) | Keep (allowlist); marker in C2b |
+| ci-cd/fluentbit/generator | Custom-logic generator (D5 ii) | Keep (allowlist); marker in C2b |
+| ci-cd/fluentbit/validator | External-linter wrapper (D5 i) | Convert to bash in C2b; Python deleted in C3 |
+| ci-cd/helm/validator | External-linter wrapper (D5 i) | Convert to bash in C2b; Python deleted in C3 |
+| infrastructure/ansible/validator | External-linter wrapper (D5 i) | Convert to bash in C2b; Python deleted in C3 |
+| infrastructure/k8s/debug | External-linter wrapper (D5 i, shells kubectl) | Convert to bash in C2b; Python deleted in C3 |
+| infrastructure/k8s/yaml-validator | External-linter wrapper (D5 i) | Convert to bash in C2b; Python deleted in C3 |
+| infrastructure/terraform/validator | External-linter wrapper (D5 i) | Convert to bash in C2b; Python deleted in C3 |
+| infrastructure/terragrunt/validator | External-linter wrapper (D5 i) | Convert to bash in C2b; Python deleted in C3 |
+
+Note: fluentbit has both a `generator` (kept) and a `validator` (converted); the paths disambiguate them.
+
+## 2. requirements.txt (8 files)
+
+Tracked skill files:
+- skills/documentation/research/pubmed-search/requirements.txt
+- skills/documentation/research/sci-hub-search/requirements.txt
+- skills/documentation/research/notebooklm/requirements.txt
+- skills/documentation/research/sci-data-extractor/requirements.txt
+- skills/documentation/research/google-scholar-search/requirements.txt
+- skills/documentation/research/semantic-scholar-search/requirements.txt
+
+Vendored copies (carve out of C3 verification; not deleted, not double-counted):
+- .agents/skills/pubmed-search/requirements.txt
+- .agents/skills/sci-hub-search/requirements.txt
+
+All six tracked `requirements.txt` belong to allowlisted research skills, so all are retained by C3. Category-(ii) validators/generators carry `.py` but no `requirements.txt` (stdlib only).
+
+## 3. Inline python3 (not .py files)
+
+- hk.pkl:97 — auditor grade JSON parse.
+- .github/workflows/skill-audit.yml:70-71 — auditor grade + total JSON parse.
+
+Disposition: C2 replaces both with `jq` and pins `jq` in mise.toml (behaviour-preserving).
+
+## 4. CI / dependency surfaces
+
+- .github/dependabot.yml:93 — `package-ecosystem: "pip"` block (globs the research skills). Disposition: C3 narrows to the allowlist (do not delete; retained Python keeps dependency tracking).
+- .github/workflows/codeql.yml:48 — `language: python` matrix entry. Disposition: C3 narrows to the allowlist; A6c handles the `main` code-scanning ruleset change in lockstep (PR #126).
+
+## 5. Vendored .agents copies
+
+`.agents/skills/{pubmed-search,sci-hub-search}/` contain their own `.py` + `requirements.txt` (installed copies of allowlisted research skills). They are gitignored (`.agents/` in .gitignore) but present in the working tree. C3 verification ("zero non-allowlisted `.py`") must carve out `.agents/skills/**`.
+
+## 6. Allowlist summary (11 skills)
+
+- Research (D1): 6 skills, markers applied in C1.
+- Custom-logic validators/generators (D5 ii): 5 skills (promql, gitlab-ci, azure-pipelines validators; jenkinsfile, fluentbit generators), markers applied in C2b.
+- External-linter wrappers (D5 i): 7 skills converted to bash in C2b, Python deleted in C3, NOT on the allowlist.
+
+See `python-allowlist.txt` for the machine-readable list.

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !.context/plans/skill-validator-port-spec.md
 !.context/plans/release-versioning-policy.md
 !.context/plans/skill-distribution.md
+!.context/plans/python-inventory.md
 .cursor/
 .gemini/
 .github/skills/

--- a/python-allowlist.txt
+++ b/python-allowlist.txt
@@ -1,0 +1,24 @@
+# Python allowlist: skills permitted to retain Python after the C3 removal.
+#
+# Source of truth: .context/plans/python-inventory.md (task C1).
+# See the migration plan decisions D1 (research skills) and D5 (custom-logic
+# validators/generators). Each listed skill is (or will be, per C2b) marked
+# with a `python-allowlist` key under `metadata` in its SKILL.md frontmatter.
+#
+# One skill directory per line. Consumed by C3 to narrow the dependabot pip
+# block and the CodeQL python matrix, and to verify no other Python remains.
+
+# --- Research skills (D1); frontmatter markers applied in C1 ---
+skills/documentation/research/pubmed-search
+skills/documentation/research/sci-hub-search
+skills/documentation/research/notebooklm
+skills/documentation/research/sci-data-extractor
+skills/documentation/research/google-scholar-search
+skills/documentation/research/semantic-scholar-search
+
+# --- Custom-logic validators/generators (D5); frontmatter markers applied in C2b ---
+skills/observability/promql/validator
+skills/ci-cd/gitlab-ci/validator
+skills/ci-cd/azure-pipelines/validator
+skills/ci-cd/jenkinsfile/generator
+skills/ci-cd/fluentbit/generator

--- a/skills/documentation/research/google-scholar-search/SKILL.md
+++ b/skills/documentation/research/google-scholar-search/SKILL.md
@@ -2,6 +2,8 @@
 name: google-scholar-search
 description: "Search Google Scholar for academic papers and author profiles. Use when discovering papers to triage — by keyword, author, or year range. Returns titles, authors, abstracts, and links. Triggers: search papers, find papers, google scholar, search scholar, find author, author profile, literature search, paper discovery, search academic literature."
 allowed-tools: Read, Write, Bash
+metadata:
+  python-allowlist: "research"
 ---
 
 # Google Scholar Search

--- a/skills/documentation/research/notebooklm/SKILL.md
+++ b/skills/documentation/research/notebooklm/SKILL.md
@@ -2,6 +2,8 @@
 name: notebooklm
 description: "Query Google NotebookLM notebooks directly for source-grounded, citation-backed answers from your uploaded documents. Includes browser automation, library management, and persistent authentication."
 allowed-tools: [Read, Write, Edit, Bash]
+metadata:
+  python-allowlist: "research"
 ---
 
 # NotebookLM Research Assistant

--- a/skills/documentation/research/pubmed-search/SKILL.md
+++ b/skills/documentation/research/pubmed-search/SKILL.md
@@ -2,6 +2,8 @@
 name: pubmed-search
 description: "Search and analyze biomedical literature from PubMed using the free E-utilities API. Use when researching medical topics, discovering clinical papers, fetching article metadata by PMID, performing deep paper analysis, or downloading open-access PDFs from PubMed Central. Triggers: pubmed search, search biomedical literature, find medical papers, PMID lookup, pubmed metadata, clinical literature search, biomedical research, life sciences papers, PMC download, ncbi search."
 allowed-tools: Read, Write, Bash
+metadata:
+  python-allowlist: "research"
 ---
 
 # PubMed Search

--- a/skills/documentation/research/sci-data-extractor/SKILL.md
+++ b/skills/documentation/research/sci-data-extractor/SKILL.md
@@ -2,6 +2,8 @@
 name: sci-data-extractor
 description: "Extract structured data from scientific literature PDFs using AI-powered OCR and LLM analysis. Supports enzyme kinetics, experimental results, and literature review templates. Use when researchers need to parse tables, charts, or text from paper PDFs into Markdown or CSV. Triggers: extract data from PDF, scientific data extraction, parse paper tables, enzyme kinetics extraction, batch PDF extraction, literature data, research data from paper, OCR scientific paper, convert PDF to structured data."
 allowed-tools: Read, Write, Bash
+metadata:
+  python-allowlist: "research"
 ---
 
 # Sci-Data-Extractor

--- a/skills/documentation/research/sci-hub-search/SKILL.md
+++ b/skills/documentation/research/sci-hub-search/SKILL.md
@@ -2,6 +2,8 @@
 name: sci-hub-search
 description: "Search and download academic papers through Sci-Hub by DOI, title, or keyword. Supports PDF download, metadata extraction, and automatic mirror detection via CrossRef integration. Use when a paper is behind a paywall and you have the DOI or title. Triggers: sci-hub, download paper, fetch paper, academic paper download, paper by DOI, paper access, paywall bypass, retrieve paper, get full text, paper download."
 allowed-tools: Read, Write, Bash
+metadata:
+  python-allowlist: "research"
 ---
 
 # Sci-Hub Search

--- a/skills/documentation/research/semantic-scholar-search/SKILL.md
+++ b/skills/documentation/research/semantic-scholar-search/SKILL.md
@@ -2,6 +2,8 @@
 name: semantic-scholar-search
 description: "Search Semantic Scholar for academic papers, fetch paper details by ID or DOI, retrieve author profiles, and analyse citation graphs. Preferred over google-scholar-search — uses the official API with no scraping. Triggers: search papers, find papers, semantic scholar, paper details, paper by DOI, paper by ID, author profile, citation analysis, references, literature search, paper discovery."
 allowed-tools: Read, Write, Bash
+metadata:
+  python-allowlist: "research"
 ---
 
 # Semantic Scholar Search


### PR DESCRIPTION
Authoritative Python inventory (.context/plans/python-inventory.md), root python-allowlist.txt (6 research + 5 D5 custom-logic skills), and metadata.python-allowlist markers on the 6 research SKILL.md files (validated with skill-validator). Documents inline python3 -> jq (C2), dependabot pip + codeql python -> narrow (C3), and the .agents carve-out.