### PR TITLE
fix(ci): keep Skill Audit gate green on transient comment-API errors

### DIFF
--- a/.github/workflows/skill-audit.yml
+++ b/.github/workflows/skill-audit.yml
@@ -87,9 +87,13 @@ jobs:
             echo "fail=$fail"
           } >> "$GITHUB_OUTPUT"
 
+      # The audit comment is cosmetic. Never let a transient comment-API
+      # failure (e.g. installation-token rate limit) fail the required gate —
+      # the verdict is decided by "Enforce gate" from the grade alone.
       - name: Find existing audit comment
         id: find-comment
         if: steps.dirs.outputs.found == 'true'
+        continue-on-error: true
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -98,6 +102,7 @@ jobs:
 
       - name: Post audit comment
         if: steps.dirs.outputs.found == 'true'
+        continue-on-error: true
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}


### PR DESCRIPTION
The required **Skill Audit** check fails when the cosmetic PR-comment steps hit the installation token's rate limit (`API rate limit exceeded for installation`), even though grading passes (seen on #176, where all six research skills are C+/B). This marks the `find-comment` and `post-comment` steps `continue-on-error` so the gate's verdict comes only from the grade-based `Enforce gate` step. Prevents transient comment-API/rate-limit failures from blocking merges.