### PR TITLE
feat(rust): implement common crate (Wave 2 / A2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,163 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "common"
 version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "skill-install"
@@ -13,3 +168,74 @@ version = "0.0.0"
 [[package]]
 name = "skill-validator-rs"
 version = "0.0.0"
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,13 @@ license = "ISC"
 repository = "https://github.com/pantheon-org/tekhne"
 rust-version = "1.96"
 
-# Shared dependencies are introduced by later waves (A2 common, A3
-# skill-install, A4a skill-validator-rs). Kept empty here so the scaffold
-# builds with no third-party dependencies.
+# Shared dependencies for the tekhne tool crates. Added as each wave needs
+# them (A2 introduces the foundational set below).
 [workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tempfile = "3"
 
 [profile.release]
 lto = "thin"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,3 +9,9 @@ publish = false
 description = "Shared configuration, error types, structured output, and filesystem helpers for the tekhne tool crates."
 
 [dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1,0 +1,77 @@
+//! Configuration loading and environment overrides.
+
+use std::path::Path;
+
+use serde::de::DeserializeOwned;
+
+use crate::error::{Error, Result};
+use crate::fs::read_to_string;
+
+/// Load a JSON config file and deserialize it into `T`.
+///
+/// Returns [`Error::NotFound`] when the file is absent and [`Error::Json`]
+/// when the contents fail to parse.
+pub fn load_json<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Err(Error::NotFound(path.to_path_buf()));
+    }
+    let text = read_to_string(path)?;
+    serde_json::from_str(&text).map_err(|source| Error::json(path.display().to_string(), source))
+}
+
+/// Read an environment variable, treating unset or empty as absent.
+///
+/// Tool crates use this for env overrides (e.g. `CLAUDE_CONFIG_DIR`).
+pub fn env_override(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Cfg {
+        name: String,
+        count: u32,
+    }
+
+    #[test]
+    fn load_json_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("cfg.json");
+        std::fs::write(&path, r#"{"name":"tekhne","count":3}"#).unwrap();
+        let cfg: Cfg = load_json(&path).unwrap();
+        assert_eq!(
+            cfg,
+            Cfg {
+                name: "tekhne".into(),
+                count: 3
+            }
+        );
+    }
+
+    #[test]
+    fn load_json_missing_is_not_found() {
+        let err = load_json::<Cfg>("/no/such/cfg.json").unwrap_err();
+        assert!(matches!(err, Error::NotFound(_)));
+    }
+
+    #[test]
+    fn load_json_invalid_is_json_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("bad.json");
+        std::fs::write(&path, "{ not json").unwrap();
+        let err = load_json::<Cfg>(&path).unwrap_err();
+        assert!(matches!(err, Error::Json { .. }));
+    }
+
+    #[test]
+    fn env_override_ignores_empty() {
+        // A name unlikely to be set in the environment.
+        let key = "TEKHNE_COMMON_TEST_ENV_UNSET";
+        assert_eq!(env_override(key), None);
+    }
+}

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,0 +1,76 @@
+//! Shared error type for the tekhne tool crates.
+
+use std::path::{Path, PathBuf};
+
+/// Errors shared across the tekhne tool crates.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An i/o operation failed; carries the path for context.
+    #[error("i/o error at {path}: {source}")]
+    Io {
+        /// The path the operation targeted.
+        path: PathBuf,
+        /// The underlying i/o error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A JSON (de)serialization failed; `context` names what was being processed.
+    #[error("json error in {context}: {source}")]
+    Json {
+        /// A human-readable description of what was being (de)serialized.
+        context: String,
+        /// The underlying serde_json error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// A required path did not exist.
+    #[error("not found: {0}")]
+    NotFound(PathBuf),
+
+    /// A configuration value was invalid or missing.
+    #[error("config error: {0}")]
+    Config(String),
+}
+
+impl Error {
+    /// Build an [`Error::Io`] from a path and the underlying i/o error.
+    pub fn io(path: impl AsRef<Path>, source: std::io::Error) -> Self {
+        Error::Io {
+            path: path.as_ref().to_path_buf(),
+            source,
+        }
+    }
+
+    /// Build an [`Error::Json`] from a context label and the underlying error.
+    pub fn json(context: impl Into<String>, source: serde_json::Error) -> Self {
+        Error::Json {
+            context: context.into(),
+            source,
+        }
+    }
+}
+
+/// Convenience result alias used throughout the tool crates.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_error_includes_path() {
+        let src = std::io::Error::new(std::io::ErrorKind::NotFound, "nope");
+        let err = Error::io("/tmp/x", src);
+        assert!(err.to_string().contains("/tmp/x"));
+    }
+
+    #[test]
+    fn config_error_message() {
+        assert_eq!(
+            Error::Config("bad value".into()).to_string(),
+            "config error: bad value"
+        );
+    }
+}

--- a/crates/common/src/fs.rs
+++ b/crates/common/src/fs.rs
@@ -1,0 +1,86 @@
+//! Filesystem helpers with path-aware errors and skill discovery.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+
+/// Read a file to a string, attaching the path to any i/o error.
+pub fn read_to_string(path: impl AsRef<Path>) -> Result<String> {
+    let path = path.as_ref();
+    std::fs::read_to_string(path).map_err(|source| Error::io(path, source))
+}
+
+/// The conventional entry-point filename for a skill.
+pub const SKILL_FILE: &str = "SKILL.md";
+
+/// Recursively find every skill directory under `root`.
+///
+/// A skill directory is any directory that directly contains a `SKILL.md`.
+/// Hidden directories (those whose name begins with `.`) are skipped, and the
+/// result is sorted for deterministic output. The search recurses into skill
+/// directories too, so nested (toolkit) skills are discovered.
+pub fn find_skill_dirs(root: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    collect_skill_dirs(root.as_ref(), &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+fn collect_skill_dirs(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let read = std::fs::read_dir(dir).map_err(|source| Error::io(dir, source))?;
+    let mut has_skill = false;
+    let mut subdirs = Vec::new();
+    for entry in read {
+        let entry = entry.map_err(|source| Error::io(dir, source))?;
+        let path = entry.path();
+        if path.is_dir() {
+            let hidden = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with('.'));
+            if !hidden {
+                subdirs.push(path);
+            }
+        } else if path.file_name().and_then(|n| n.to_str()) == Some(SKILL_FILE) {
+            has_skill = true;
+        }
+    }
+    if has_skill {
+        out.push(dir.to_path_buf());
+    }
+    for sub in subdirs {
+        collect_skill_dirs(&sub, out)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_to_string_missing_file_reports_path() {
+        let err = read_to_string("/definitely/missing/file.txt").unwrap_err();
+        assert!(matches!(err, Error::Io { .. }));
+        assert!(err.to_string().contains("/definitely/missing/file.txt"));
+    }
+
+    #[test]
+    fn find_skill_dirs_discovers_flat_and_nested() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // flat skill: <root>/a/SKILL.md
+        std::fs::create_dir_all(root.join("a")).unwrap();
+        std::fs::write(root.join("a/SKILL.md"), "x").unwrap();
+        // nested (toolkit) skill: <root>/kit/sub/SKILL.md
+        std::fs::create_dir_all(root.join("kit/sub")).unwrap();
+        std::fs::write(root.join("kit/sub/SKILL.md"), "x").unwrap();
+        // non-skill dir and a hidden dir are ignored
+        std::fs::create_dir_all(root.join("a/references")).unwrap();
+        std::fs::create_dir_all(root.join(".hidden")).unwrap();
+        std::fs::write(root.join(".hidden/SKILL.md"), "x").unwrap();
+
+        let found = find_skill_dirs(root).unwrap();
+        assert_eq!(found, vec![root.join("a"), root.join("kit/sub")]);
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,5 +1,14 @@
 //! `common`: shared configuration, error types, structured output, and
-//! filesystem helpers for the tekhne tool crates.
+//! filesystem helpers for the tekhne tool crates (skill-validator-rs,
+//! skill-auditor, skill-install).
 //!
-//! Populated in Wave 2 (A2). This scaffold intentionally exposes no public
-//! API yet; it exists so the workspace builds end to end from A1 onward.
+//! Populated in Wave 2 (A2). The public surface is intentionally small and
+//! dependency-light so the tool crates can share it without pulling in each
+//! other's concerns.
+
+pub mod config;
+pub mod error;
+pub mod fs;
+pub mod output;
+
+pub use error::{Error, Result};

--- a/crates/common/src/output.rs
+++ b/crates/common/src/output.rs
@@ -1,0 +1,76 @@
+//! Structured output helpers for tool results.
+
+use serde::Serialize;
+
+use crate::error::{Error, Result};
+
+/// The output format a tool should emit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Format {
+    /// Human-readable text (the default for interactive use).
+    #[default]
+    Text,
+    /// Machine-readable JSON (for `--json` / CI consumers).
+    Json,
+}
+
+impl Format {
+    /// Parse a format from a CLI flag value, defaulting to [`Format::Text`].
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "text" => Ok(Format::Text),
+            "json" => Ok(Format::Json),
+            other => Err(Error::Config(format!("unknown output format: {other}"))),
+        }
+    }
+}
+
+/// Serialize a value to a compact JSON string.
+pub fn to_json<T: Serialize>(value: &T) -> Result<String> {
+    serde_json::to_string(value).map_err(|source| Error::json("output", source))
+}
+
+/// Serialize a value to a pretty (2-space indented) JSON string.
+pub fn to_json_pretty<T: Serialize>(value: &T) -> Result<String> {
+    serde_json::to_string_pretty(value).map_err(|source| Error::json("output", source))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Result_ {
+        grade: &'static str,
+        total: u32,
+    }
+
+    #[test]
+    fn json_is_compact() {
+        let out = to_json(&Result_ {
+            grade: "B",
+            total: 112,
+        })
+        .unwrap();
+        assert_eq!(out, r#"{"grade":"B","total":112}"#);
+    }
+
+    #[test]
+    fn json_pretty_is_indented() {
+        let out = to_json_pretty(&Result_ {
+            grade: "B",
+            total: 112,
+        })
+        .unwrap();
+        assert!(out.contains("\n  \"grade\""));
+    }
+
+    #[test]
+    fn format_parse_and_default() {
+        assert_eq!(Format::parse("json").unwrap(), Format::Json);
+        assert_eq!(Format::parse("TEXT").unwrap(), Format::Text);
+        assert_eq!(Format::default(), Format::Text);
+        assert!(Format::parse("xml").is_err());
+    }
+}


### PR DESCRIPTION
Wave 2 / A2. Populates the shared `common` crate that the Wave 3 tool crates depend on:

- **error** — shared `Error` enum (io / json / not-found / config) with a `Result` alias
- **config** — JSON config loading + `env_override` helper
- **output** — `Format` enum + compact/pretty JSON serialization
- **fs** — path-aware `read_to_string` + recursive skill-directory discovery

11 unit tests; `cargo fmt --check`, `clippy -D warnings`, `build`, and `test` all green locally.