### PR TITLE
feat(rust): skill-install crate — 42-agent detection (Wave 3 / A3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,10 @@ dependencies = [
 [[package]]
 name = "skill-install"
 version = "0.0.0"
+dependencies = [
+ "common",
+ "tempfile",
+]
 
 [[package]]
 name = "skill-validator-rs"

--- a/crates/skill-install/Cargo.toml
+++ b/crates/skill-install/Cargo.toml
@@ -9,3 +9,7 @@ publish = false
 description = "Agent-directory detection and bundled-skill installation for tekhne tool CLIs."
 
 [dependencies]
+common = { path = "../common" }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/skill-install/src/agents.rs
+++ b/crates/skill-install/src/agents.rs
@@ -1,0 +1,550 @@
+//! The agent table ported from `cli/lib/types/agents.ts`.
+//!
+//! Each [`AgentConfig`] captures an agent's project-relative skills directory,
+//! its global-skills-directory resolution, and the `detectInstalled` probe
+//! paths. Directory and detection logic is expressed as data resolved against
+//! an [`Environment`], mirroring the `join(...)`/`existsSync(...)` expressions
+//! in the TypeScript source.
+
+use std::path::{Path, PathBuf};
+
+use crate::env::{open_claw_global_skills_dir, Environment};
+
+/// A base directory an agent path is resolved relative to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Base {
+    /// `os.homedir()`.
+    Home,
+    /// `XDG_CONFIG_HOME` or `~/.config` (`configHome`).
+    ConfigHome,
+    /// `CODEX_HOME` or `~/.codex` (`codexHome`).
+    CodexHome,
+    /// `CLAUDE_CONFIG_DIR` or `~/.claude` (`claudeHome`).
+    ClaudeHome,
+    /// `process.cwd()`.
+    Cwd,
+    /// An absolute path that ignores every base directory (e.g. `/etc/codex`).
+    Absolute,
+}
+
+impl Base {
+    /// Resolve `base` + `rel` against `env`. An empty `rel` yields the base
+    /// directory itself; [`Base::Absolute`] yields `rel` verbatim.
+    fn resolve(self, rel: &str, env: &Environment) -> PathBuf {
+        if self == Base::Absolute {
+            return PathBuf::from(rel);
+        }
+        let root: &Path = match self {
+            Base::Home => &env.home,
+            Base::ConfigHome => &env.config_home,
+            Base::CodexHome => &env.codex_home,
+            Base::ClaudeHome => &env.claude_home,
+            Base::Cwd => &env.cwd,
+            Base::Absolute => unreachable!(),
+        };
+        if rel.is_empty() {
+            root.to_path_buf()
+        } else {
+            root.join(rel)
+        }
+    }
+}
+
+/// A single `existsSync` probe used by an agent's detection logic.
+#[derive(Debug, Clone, Copy)]
+pub struct DetectPath {
+    /// The base directory the probe is relative to.
+    pub base: Base,
+    /// The path relative to `base` (empty means the base directory itself).
+    pub rel: &'static str,
+}
+
+/// How an agent's global skills directory is resolved.
+#[derive(Debug, Clone, Copy)]
+pub enum GlobalDir {
+    /// A fixed `base` + `rel` location.
+    Fixed {
+        /// The base directory.
+        base: Base,
+        /// The path relative to `base`.
+        rel: &'static str,
+    },
+    /// OpenClaw's dynamic resolution (see [`open_claw_global_skills_dir`]).
+    OpenClaw,
+}
+
+/// A single agent's install and detection configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct AgentConfig {
+    /// The stable agent slug (matches the `AgentType` union in `types.ts`).
+    pub name: &'static str,
+    /// The human-readable display name.
+    pub display_name: &'static str,
+    /// The project-relative skills directory.
+    pub skills_dir: &'static str,
+    /// How the global skills directory is resolved.
+    pub global: GlobalDir,
+    /// The `existsSync` probes; any hit means the agent is installed.
+    pub detect: &'static [DetectPath],
+    /// Whether the agent appears in the universal agents list.
+    pub show_in_universal_list: bool,
+}
+
+impl AgentConfig {
+    /// Resolve the agent's global skills directory against `env`.
+    ///
+    /// `exists` backs OpenClaw's dynamic probing; other agents ignore it.
+    pub fn global_skills_dir(&self, env: &Environment, exists: &dyn Fn(&Path) -> bool) -> PathBuf {
+        match self.global {
+            GlobalDir::Fixed { base, rel } => base.resolve(rel, env),
+            GlobalDir::OpenClaw => open_claw_global_skills_dir(&env.home, exists),
+        }
+    }
+
+    /// The resolved `existsSync` probe paths for this agent, in source order.
+    pub fn detect_paths(&self, env: &Environment) -> Vec<PathBuf> {
+        self.detect
+            .iter()
+            .map(|d| d.base.resolve(d.rel, env))
+            .collect()
+    }
+
+    /// Whether the agent is installed: true when any probe path exists.
+    pub fn detect_installed(&self, env: &Environment, exists: &dyn Fn(&Path) -> bool) -> bool {
+        self.detect_paths(env).iter().any(|p| exists(p))
+    }
+}
+
+const fn probe(base: Base, rel: &'static str) -> DetectPath {
+    DetectPath { base, rel }
+}
+
+const fn fixed(base: Base, rel: &'static str) -> GlobalDir {
+    GlobalDir::Fixed { base, rel }
+}
+
+/// The full agent table, ported one-for-one from `agents.ts`.
+pub static AGENTS: &[AgentConfig] = &[
+    AgentConfig {
+        name: "amp",
+        display_name: "Amp",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::ConfigHome, "agents/skills"),
+        detect: &[probe(Base::ConfigHome, "amp")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "antigravity",
+        display_name: "Antigravity",
+        skills_dir: ".agent/skills",
+        global: fixed(Base::Home, ".gemini/antigravity/skills"),
+        detect: &[probe(Base::Home, ".gemini/antigravity")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "augment",
+        display_name: "Augment",
+        skills_dir: ".augment/skills",
+        global: fixed(Base::Home, ".augment/skills"),
+        detect: &[probe(Base::Home, ".augment")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "claude-code",
+        display_name: "Claude Code",
+        skills_dir: ".claude/skills",
+        global: fixed(Base::ClaudeHome, "skills"),
+        detect: &[probe(Base::ClaudeHome, "")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "openclaw",
+        display_name: "OpenClaw",
+        skills_dir: "skills",
+        global: GlobalDir::OpenClaw,
+        detect: &[
+            probe(Base::Home, ".openclaw"),
+            probe(Base::Home, ".clawdbot"),
+            probe(Base::Home, ".moltbot"),
+        ],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "cline",
+        display_name: "Cline",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::Home, ".agents/skills"),
+        detect: &[probe(Base::Home, ".cline")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "codebuddy",
+        display_name: "CodeBuddy",
+        skills_dir: ".codebuddy/skills",
+        global: fixed(Base::Home, ".codebuddy/skills"),
+        detect: &[
+            probe(Base::Cwd, ".codebuddy"),
+            probe(Base::Home, ".codebuddy"),
+        ],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "codex",
+        display_name: "Codex",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::CodexHome, "skills"),
+        detect: &[
+            probe(Base::CodexHome, ""),
+            probe(Base::Absolute, "/etc/codex"),
+        ],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "command-code",
+        display_name: "Command Code",
+        skills_dir: ".commandcode/skills",
+        global: fixed(Base::Home, ".commandcode/skills"),
+        detect: &[probe(Base::Home, ".commandcode")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "continue",
+        display_name: "Continue",
+        skills_dir: ".continue/skills",
+        global: fixed(Base::Home, ".continue/skills"),
+        detect: &[
+            probe(Base::Cwd, ".continue"),
+            probe(Base::Home, ".continue"),
+        ],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "cortex",
+        display_name: "Cortex Code",
+        skills_dir: ".cortex/skills",
+        global: fixed(Base::Home, ".snowflake/cortex/skills"),
+        detect: &[probe(Base::Home, ".snowflake/cortex")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "crush",
+        display_name: "Crush",
+        skills_dir: ".crush/skills",
+        global: fixed(Base::Home, ".config/crush/skills"),
+        detect: &[probe(Base::Home, ".config/crush")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "cursor",
+        display_name: "Cursor",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::Home, ".cursor/skills"),
+        detect: &[probe(Base::Home, ".cursor")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "droid",
+        display_name: "Droid",
+        skills_dir: ".factory/skills",
+        global: fixed(Base::Home, ".factory/skills"),
+        detect: &[probe(Base::Home, ".factory")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "gemini-cli",
+        display_name: "Gemini CLI",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::Home, ".gemini/skills"),
+        detect: &[probe(Base::Home, ".gemini")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "github-copilot",
+        display_name: "GitHub Copilot",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::Home, ".copilot/skills"),
+        detect: &[probe(Base::Home, ".copilot")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "goose",
+        display_name: "Goose",
+        skills_dir: ".goose/skills",
+        global: fixed(Base::ConfigHome, "goose/skills"),
+        detect: &[probe(Base::ConfigHome, "goose")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "junie",
+        display_name: "Junie",
+        skills_dir: ".junie/skills",
+        global: fixed(Base::Home, ".junie/skills"),
+        detect: &[probe(Base::Home, ".junie")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "iflow-cli",
+        display_name: "iFlow CLI",
+        skills_dir: ".iflow/skills",
+        global: fixed(Base::Home, ".iflow/skills"),
+        detect: &[probe(Base::Home, ".iflow")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "kilo",
+        display_name: "Kilo Code",
+        skills_dir: ".kilocode/skills",
+        global: fixed(Base::Home, ".kilocode/skills"),
+        detect: &[probe(Base::Home, ".kilocode")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "kimi-cli",
+        display_name: "Kimi Code CLI",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::Home, ".config/agents/skills"),
+        detect: &[probe(Base::Home, ".kimi")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "kiro-cli",
+        display_name: "Kiro CLI",
+        skills_dir: ".kiro/skills",
+        global: fixed(Base::Home, ".kiro/skills"),
+        detect: &[probe(Base::Home, ".kiro")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "kode",
+        display_name: "Kode",
+        skills_dir: ".kode/skills",
+        global: fixed(Base::Home, ".kode/skills"),
+        detect: &[probe(Base::Home, ".kode")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "mcpjam",
+        display_name: "MCPJam",
+        skills_dir: ".mcpjam/skills",
+        global: fixed(Base::Home, ".mcpjam/skills"),
+        detect: &[probe(Base::Home, ".mcpjam")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "mistral-vibe",
+        display_name: "Mistral Vibe",
+        skills_dir: ".vibe/skills",
+        global: fixed(Base::Home, ".vibe/skills"),
+        detect: &[probe(Base::Home, ".vibe")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "mux",
+        display_name: "Mux",
+        skills_dir: ".mux/skills",
+        global: fixed(Base::Home, ".mux/skills"),
+        detect: &[probe(Base::Home, ".mux")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "opencode",
+        display_name: "OpenCode",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::ConfigHome, "opencode/skills"),
+        detect: &[probe(Base::ConfigHome, "opencode")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "openhands",
+        display_name: "OpenHands",
+        skills_dir: ".openhands/skills",
+        global: fixed(Base::Home, ".openhands/skills"),
+        detect: &[probe(Base::Home, ".openhands")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "pi",
+        display_name: "Pi",
+        skills_dir: ".pi/skills",
+        global: fixed(Base::Home, ".pi/agent/skills"),
+        detect: &[probe(Base::Home, ".pi/agent")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "qoder",
+        display_name: "Qoder",
+        skills_dir: ".qoder/skills",
+        global: fixed(Base::Home, ".qoder/skills"),
+        detect: &[probe(Base::Home, ".qoder")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "qwen-code",
+        display_name: "Qwen Code",
+        skills_dir: ".qwen/skills",
+        global: fixed(Base::Home, ".qwen/skills"),
+        detect: &[probe(Base::Home, ".qwen")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "replit",
+        display_name: "Replit",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::ConfigHome, "agents/skills"),
+        detect: &[probe(Base::Cwd, ".replit")],
+        show_in_universal_list: false,
+    },
+    AgentConfig {
+        name: "roo",
+        display_name: "Roo Code",
+        skills_dir: ".roo/skills",
+        global: fixed(Base::Home, ".roo/skills"),
+        detect: &[probe(Base::Home, ".roo")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "trae",
+        display_name: "Trae",
+        skills_dir: ".trae/skills",
+        global: fixed(Base::Home, ".trae/skills"),
+        detect: &[probe(Base::Home, ".trae")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "trae-cn",
+        display_name: "Trae CN",
+        skills_dir: ".trae/skills",
+        global: fixed(Base::Home, ".trae-cn/skills"),
+        detect: &[probe(Base::Home, ".trae-cn")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "warp",
+        display_name: "Warp",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::Home, ".agents/skills"),
+        detect: &[probe(Base::Home, ".warp")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "windsurf",
+        display_name: "Windsurf",
+        skills_dir: ".windsurf/skills",
+        global: fixed(Base::Home, ".codeium/windsurf/skills"),
+        detect: &[probe(Base::Home, ".codeium/windsurf")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "zencoder",
+        display_name: "Zencoder",
+        skills_dir: ".zencoder/skills",
+        global: fixed(Base::Home, ".zencoder/skills"),
+        detect: &[probe(Base::Home, ".zencoder")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "neovate",
+        display_name: "Neovate",
+        skills_dir: ".neovate/skills",
+        global: fixed(Base::Home, ".neovate/skills"),
+        detect: &[probe(Base::Home, ".neovate")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "pochi",
+        display_name: "Pochi",
+        skills_dir: ".pochi/skills",
+        global: fixed(Base::Home, ".pochi/skills"),
+        detect: &[probe(Base::Home, ".pochi")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "adal",
+        display_name: "AdaL",
+        skills_dir: ".adal/skills",
+        global: fixed(Base::Home, ".adal/skills"),
+        detect: &[probe(Base::Home, ".adal")],
+        show_in_universal_list: true,
+    },
+    AgentConfig {
+        name: "universal",
+        display_name: "Universal",
+        skills_dir: ".agents/skills",
+        global: fixed(Base::ConfigHome, "agents/skills"),
+        detect: &[],
+        show_in_universal_list: false,
+    },
+];
+
+/// Every agent configuration in source order.
+pub fn all() -> &'static [AgentConfig] {
+    AGENTS
+}
+
+/// Look up an agent by its slug.
+pub fn by_name(name: &str) -> Option<&'static AgentConfig> {
+    AGENTS.iter().find(|a| a.name == name)
+}
+
+/// Every agent slug in source order.
+pub fn slugs() -> Vec<&'static str> {
+    AGENTS.iter().map(|a| a.name).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env() -> Environment {
+        Environment::resolve(
+            PathBuf::from("/home/user"),
+            PathBuf::from("/work/project"),
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn table_has_forty_two_unique_agents() {
+        assert_eq!(AGENTS.len(), 42);
+        let mut names = slugs();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), 42);
+    }
+
+    #[test]
+    fn claude_code_detects_home_itself() {
+        let claude = by_name("claude-code").unwrap();
+        assert_eq!(claude.detect_paths(&env()), vec![env().claude_home.clone()]);
+    }
+
+    #[test]
+    fn codex_detects_absolute_etc_path() {
+        let codex = by_name("codex").unwrap();
+        let paths = codex.detect_paths(&env());
+        assert_eq!(paths[0], env().codex_home);
+        assert_eq!(paths[1], PathBuf::from("/etc/codex"));
+    }
+
+    #[test]
+    fn openclaw_global_dir_is_dynamic() {
+        let openclaw = by_name("openclaw").unwrap();
+        let dir = openclaw.global_skills_dir(&env(), &|p: &Path| p.ends_with(".moltbot"));
+        assert_eq!(dir, PathBuf::from("/home/user/.moltbot/skills"));
+    }
+
+    #[test]
+    fn universal_is_never_detected() {
+        let universal = by_name("universal").unwrap();
+        assert!(!universal.detect_installed(&env(), &|_| true));
+    }
+
+    #[test]
+    fn detect_installed_matches_any_probe() {
+        let codebuddy = by_name("codebuddy").unwrap();
+        let target = env().cwd.join(".codebuddy");
+        assert!(codebuddy.detect_installed(&env(), &|p: &Path| p == target));
+    }
+}

--- a/crates/skill-install/src/env.rs
+++ b/crates/skill-install/src/env.rs
@@ -1,0 +1,184 @@
+//! Base-directory resolution for agent detection.
+//!
+//! Ports the module-level path constants from `cli/lib/types/agents.ts`
+//! (`home`, `configHome`, `codexHome`, `claudeHome`) plus the
+//! `getOpenClawGlobalSkillsDir` helper. Resolution is expressed as pure
+//! functions so the environment-override and XDG semantics can be unit-tested
+//! without touching the process environment.
+
+use std::path::{Path, PathBuf};
+
+use common::{Error, Result};
+
+/// The resolved base directories an agent's install paths are computed from.
+///
+/// Mirrors the module-level constants in `agents.ts`. `cwd` backs the
+/// `process.cwd()` checks a few agents perform in `detectInstalled`.
+#[derive(Debug, Clone)]
+pub struct Environment {
+    /// The user's home directory (`os.homedir()`).
+    pub home: PathBuf,
+    /// The XDG config home (`XDG_CONFIG_HOME` or `~/.config`).
+    pub config_home: PathBuf,
+    /// The Codex home (`CODEX_HOME` or `~/.codex`).
+    pub codex_home: PathBuf,
+    /// The Claude Code home (`CLAUDE_CONFIG_DIR` or `~/.claude`).
+    pub claude_home: PathBuf,
+    /// The current working directory (`process.cwd()`).
+    pub cwd: PathBuf,
+}
+
+impl Environment {
+    /// Resolve every base directory from the live process environment.
+    ///
+    /// Reads `XDG_CONFIG_HOME`, `CODEX_HOME`, and `CLAUDE_CONFIG_DIR`, matching
+    /// the override precedence in `agents.ts`.
+    pub fn from_env() -> Result<Self> {
+        let home = std::env::home_dir()
+            .filter(|p| !p.as_os_str().is_empty())
+            .ok_or_else(|| Error::Config("could not determine home directory".into()))?;
+        let cwd = std::env::current_dir().map_err(|source| Error::io(".", source))?;
+        Ok(Self::resolve(
+            home,
+            cwd,
+            std::env::var("XDG_CONFIG_HOME").ok().as_deref(),
+            std::env::var("CODEX_HOME").ok().as_deref(),
+            std::env::var("CLAUDE_CONFIG_DIR").ok().as_deref(),
+        ))
+    }
+
+    /// Resolve base directories from explicit inputs (used by `from_env` and
+    /// exercised directly in tests).
+    pub fn resolve(
+        home: PathBuf,
+        cwd: PathBuf,
+        xdg_config_home: Option<&str>,
+        codex_home: Option<&str>,
+        claude_config_dir: Option<&str>,
+    ) -> Self {
+        let config_home = resolve_config_home(&home, xdg_config_home);
+        let codex_home = resolve_home_override(&home, codex_home, ".codex");
+        let claude_home = resolve_home_override(&home, claude_config_dir, ".claude");
+        Self {
+            home,
+            config_home,
+            codex_home,
+            claude_home,
+            cwd,
+        }
+    }
+}
+
+/// Resolve the XDG config home.
+///
+/// Matches `xdgConfig ?? join(home, ".config")` where `xdgConfig` itself is
+/// `XDG_CONFIG_HOME || join(home, ".config")`: an unset or empty value falls
+/// back to `~/.config`, and (unlike the trimmed overrides) the value is used
+/// verbatim otherwise.
+pub fn resolve_config_home(home: &Path, xdg_config_home: Option<&str>) -> PathBuf {
+    match xdg_config_home {
+        Some(value) if !value.is_empty() => PathBuf::from(value),
+        _ => home.join(".config"),
+    }
+}
+
+/// Resolve a trimmed home override such as `CODEX_HOME` or `CLAUDE_CONFIG_DIR`.
+///
+/// Matches `process.env.VAR?.trim() || join(home, fallback)`: the value is
+/// trimmed, and an unset or whitespace-only value falls back to
+/// `home/<fallback>`.
+pub fn resolve_home_override(home: &Path, raw: Option<&str>, fallback: &str) -> PathBuf {
+    match raw.map(str::trim).filter(|v| !v.is_empty()) {
+        Some(value) => PathBuf::from(value),
+        None => home.join(fallback),
+    }
+}
+
+/// Resolve OpenClaw's global skills directory.
+///
+/// Ports `getOpenClawGlobalSkillsDir`: prefer `.openclaw`, then `.clawdbot`,
+/// then `.moltbot` if present, otherwise fall back to `.openclaw/skills`.
+pub fn open_claw_global_skills_dir(home: &Path, exists: &dyn Fn(&Path) -> bool) -> PathBuf {
+    for name in [".openclaw", ".clawdbot", ".moltbot"] {
+        if exists(&home.join(name)) {
+            return home.join(name).join("skills");
+        }
+    }
+    home.join(".openclaw").join("skills")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn home() -> PathBuf {
+        PathBuf::from("/home/user")
+    }
+
+    #[test]
+    fn config_home_defaults_to_dot_config() {
+        assert_eq!(resolve_config_home(&home(), None), home().join(".config"));
+    }
+
+    #[test]
+    fn config_home_uses_xdg_when_set() {
+        assert_eq!(
+            resolve_config_home(&home(), Some("/xdg/cfg")),
+            PathBuf::from("/xdg/cfg")
+        );
+    }
+
+    #[test]
+    fn config_home_empty_xdg_falls_back() {
+        assert_eq!(
+            resolve_config_home(&home(), Some("")),
+            home().join(".config")
+        );
+    }
+
+    #[test]
+    fn home_override_defaults_to_fallback() {
+        assert_eq!(
+            resolve_home_override(&home(), None, ".codex"),
+            home().join(".codex")
+        );
+    }
+
+    #[test]
+    fn home_override_uses_and_trims_value() {
+        assert_eq!(
+            resolve_home_override(&home(), Some("  /custom/codex  "), ".codex"),
+            PathBuf::from("/custom/codex")
+        );
+    }
+
+    #[test]
+    fn home_override_whitespace_only_falls_back() {
+        assert_eq!(
+            resolve_home_override(&home(), Some("   "), ".claude"),
+            home().join(".claude")
+        );
+    }
+
+    #[test]
+    fn open_claw_prefers_clawdbot_when_present() {
+        let dir = open_claw_global_skills_dir(&home(), &|p: &Path| p.ends_with(".clawdbot"));
+        assert_eq!(dir, home().join(".clawdbot").join("skills"));
+    }
+
+    #[test]
+    fn open_claw_falls_back_to_openclaw() {
+        let dir = open_claw_global_skills_dir(&home(), &|_: &Path| false);
+        assert_eq!(dir, home().join(".openclaw").join("skills"));
+    }
+
+    #[test]
+    fn resolve_wires_up_all_bases() {
+        let env =
+            Environment::resolve(home(), PathBuf::from("/work"), None, Some("/x/codex"), None);
+        assert_eq!(env.config_home, home().join(".config"));
+        assert_eq!(env.codex_home, PathBuf::from("/x/codex"));
+        assert_eq!(env.claude_home, home().join(".claude"));
+        assert_eq!(env.cwd, PathBuf::from("/work"));
+    }
+}

--- a/crates/skill-install/src/install.rs
+++ b/crates/skill-install/src/install.rs
@@ -1,0 +1,214 @@
+//! Installing a bundled skill into a detected agent directory.
+//!
+//! Ports the install action from `cli/lib/install`: resolve the target
+//! directory for an agent (`resolveTargetDir`), then either symlink the source
+//! skill into it (`createSymlink`, using relative link text) or copy it
+//! recursively.
+
+use std::path::{Component, Path, PathBuf};
+
+use common::{Error, Result};
+
+use crate::agents::AgentConfig;
+use crate::env::Environment;
+
+/// How a bundled skill is placed into a target directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallMode {
+    /// Recursively copy the skill directory.
+    Copy,
+    /// Create a symlink pointing at the source skill directory.
+    Symlink,
+}
+
+/// Resolve the directory an agent's skills install into.
+///
+/// Ports `resolveTargetDir`: when `global` is true, use the agent's global
+/// skills directory (falling back to the project-relative directory under
+/// `cwd`); otherwise use `cwd/<skillsDir>`.
+pub fn resolve_target_dir(
+    agent: &AgentConfig,
+    global: bool,
+    env: &Environment,
+    exists: &dyn Fn(&Path) -> bool,
+) -> PathBuf {
+    if global {
+        agent.global_skills_dir(env, exists)
+    } else {
+        env.cwd.join(agent.skills_dir)
+    }
+}
+
+/// Install the skill at `source` into `target_dir` using `mode`.
+///
+/// The skill lands at `target_dir/<source-dir-name>`. Parent directories are
+/// created as needed. Returns the installed path.
+pub fn install_skill(source: &Path, target_dir: &Path, mode: InstallMode) -> Result<PathBuf> {
+    let name = source.file_name().ok_or_else(|| {
+        Error::Config(format!(
+            "source has no directory name: {}",
+            source.display()
+        ))
+    })?;
+    let target = target_dir.join(name);
+    std::fs::create_dir_all(target_dir).map_err(|source| Error::io(target_dir, source))?;
+    match mode {
+        InstallMode::Copy => copy_dir_all(source, &target)?,
+        InstallMode::Symlink => symlink_skill(source, target_dir, &target)?,
+    }
+    Ok(target)
+}
+
+/// Recursively copy `src` into `dst`, creating `dst` and any parents.
+fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst).map_err(|e| Error::io(dst, e))?;
+    let entries = std::fs::read_dir(src).map_err(|e| Error::io(src, e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| Error::io(src, e))?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|e| Error::io(&from, e))?;
+        if file_type.is_dir() {
+            copy_dir_all(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to).map_err(|e| Error::io(&from, e))?;
+        }
+    }
+    Ok(())
+}
+
+/// Symlink `source` into `target`, using relative link text computed from the
+/// real (canonicalized) target directory, matching `createSymlink`.
+fn symlink_skill(source: &Path, target_dir: &Path, target: &Path) -> Result<()> {
+    let resolved_source = source.canonicalize().map_err(|e| Error::io(source, e))?;
+    let resolved_target_dir = target_dir
+        .canonicalize()
+        .unwrap_or_else(|_| target_dir.to_path_buf());
+    let link_text = relative_path(&resolved_target_dir, &resolved_source);
+    create_dir_symlink(&link_text, target)
+}
+
+/// Compute a relative path from directory `from` to `to`, both assumed
+/// absolute and normalized (equivalent to Node's `path.relative`).
+fn relative_path(from: &Path, to: &Path) -> PathBuf {
+    let from: Vec<Component> = from.components().collect();
+    let to: Vec<Component> = to.components().collect();
+    let common = from
+        .iter()
+        .zip(to.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let mut result = PathBuf::new();
+    for _ in common..from.len() {
+        result.push("..");
+    }
+    for component in &to[common..] {
+        result.push(component.as_os_str());
+    }
+    result
+}
+
+#[cfg(unix)]
+fn create_dir_symlink(link_text: &Path, target: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(link_text, target).map_err(|e| Error::io(target, e))
+}
+
+#[cfg(windows)]
+fn create_dir_symlink(link_text: &Path, target: &Path) -> Result<()> {
+    std::os::windows::fs::symlink_dir(link_text, target).map_err(|e| Error::io(target, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::by_name;
+
+    fn env_at(cwd: &Path) -> Environment {
+        Environment::resolve(
+            PathBuf::from("/home/user"),
+            cwd.to_path_buf(),
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn make_skill(root: &Path) -> PathBuf {
+        let skill = root.join("my-skill");
+        std::fs::create_dir_all(skill.join("references")).unwrap();
+        std::fs::write(skill.join("SKILL.md"), "# skill").unwrap();
+        std::fs::write(skill.join("references/ref.md"), "ref").unwrap();
+        skill
+    }
+
+    #[test]
+    fn resolve_target_dir_local_uses_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = env_at(tmp.path());
+        let claude = by_name("claude-code").unwrap();
+        let dir = resolve_target_dir(claude, false, &env, &|_| false);
+        assert_eq!(dir, tmp.path().join(".claude/skills"));
+    }
+
+    #[test]
+    fn resolve_target_dir_global_uses_global_dir() {
+        let env = env_at(Path::new("/work"));
+        let claude = by_name("claude-code").unwrap();
+        let dir = resolve_target_dir(claude, true, &env, &|_| false);
+        assert_eq!(dir, PathBuf::from("/home/user/.claude/skills"));
+    }
+
+    #[test]
+    fn copy_mode_duplicates_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill = make_skill(&tmp.path().join("bundle"));
+        let target_dir = tmp.path().join("dest/skills");
+
+        let installed = install_skill(&skill, &target_dir, InstallMode::Copy).unwrap();
+
+        assert_eq!(installed, target_dir.join("my-skill"));
+        assert!(!installed
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            std::fs::read_to_string(installed.join("SKILL.md")).unwrap(),
+            "# skill"
+        );
+        assert_eq!(
+            std::fs::read_to_string(installed.join("references/ref.md")).unwrap(),
+            "ref"
+        );
+    }
+
+    #[test]
+    fn symlink_mode_links_to_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill = make_skill(&tmp.path().join("bundle"));
+        let target_dir = tmp.path().join("dest/skills");
+
+        let installed = install_skill(&skill, &target_dir, InstallMode::Symlink).unwrap();
+
+        assert!(installed
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        // The link resolves back to the source skill's content.
+        assert_eq!(
+            std::fs::read_to_string(installed.join("SKILL.md")).unwrap(),
+            "# skill"
+        );
+        assert_eq!(
+            installed.canonicalize().unwrap(),
+            skill.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn relative_path_walks_up_and_down() {
+        let rel = relative_path(Path::new("/a/b/dest"), Path::new("/a/b/src/skill"));
+        assert_eq!(rel, PathBuf::from("../src/skill"));
+    }
+}

--- a/crates/skill-install/src/lib.rs
+++ b/crates/skill-install/src/lib.rs
@@ -1,5 +1,22 @@
 //! `skill-install`: agent-directory detection and bundled-skill installation
 //! for the tekhne tool CLIs.
 //!
-//! Populated in Wave 3 (A3), porting the agent detection table from
-//! `cli/lib/types/agents.ts`. This scaffold exposes no public API yet.
+//! Ported from `cli/lib/types/agents.ts` and `cli/lib/install`. The crate
+//! exposes three concerns, one per module:
+//!
+//! - [`env`]: base-directory resolution (`home`, `configHome`, `codexHome`,
+//!   `claudeHome`) including environment overrides and XDG semantics.
+//! - [`agents`]: the 42-agent table, each with its skills directory, global
+//!   directory resolution, and `detectInstalled` probe paths.
+//! - [`install`]: resolving an agent's target directory and copying or
+//!   symlinking a bundled skill into it.
+
+pub mod agents;
+pub mod env;
+pub mod install;
+
+pub use agents::{all, by_name, slugs, AgentConfig, Base, DetectPath, GlobalDir, AGENTS};
+pub use env::{
+    open_claw_global_skills_dir, resolve_config_home, resolve_home_override, Environment,
+};
+pub use install::{install_skill, resolve_target_dir, InstallMode};

--- a/crates/skill-install/tests/parity.rs
+++ b/crates/skill-install/tests/parity.rs
@@ -1,0 +1,264 @@
+//! Table-parity test: proves the Rust agent table reproduces the TypeScript
+//! source of truth (`cli/lib/types/agents.ts` and `types.ts`).
+//!
+//! The TypeScript is embedded at compile time and parsed here. Expected values
+//! are derived from the TS `join(...)`/`existsSync(...)` expressions and
+//! compared against the Rust table resolved under an identical synthetic
+//! environment, so the two cannot silently drift.
+
+use std::path::{Path, PathBuf};
+
+use skill_install::{agents, Environment};
+
+const AGENTS_TS: &str = include_str!("../../../cli/lib/types/agents.ts");
+const TYPES_TS: &str = include_str!("../../../cli/lib/types/types.ts");
+
+// Synthetic base directories used on both sides of the comparison.
+const HOME: &str = "/home/user";
+const CONFIG: &str = "/home/user/.config";
+const CODEX: &str = "/home/user/.codex";
+const CLAUDE: &str = "/home/user/.claude";
+const CWD: &str = "/work/project";
+
+fn synthetic_env() -> Environment {
+    Environment::resolve(PathBuf::from(HOME), PathBuf::from(CWD), None, None, None)
+}
+
+/// Return the content between the outer parentheses whose `(` is at `open_idx`.
+fn balanced(s: &str, open_idx: usize) -> &str {
+    let bytes = s.as_bytes();
+    let mut depth = 0usize;
+    for i in open_idx..s.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &s[open_idx + 1..i];
+                }
+            }
+            _ => {}
+        }
+    }
+    &s[open_idx + 1..]
+}
+
+/// Split on commas that sit at parenthesis depth zero.
+fn split_top_commas(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut cur = String::new();
+    for c in s.chars() {
+        match c {
+            '(' => {
+                depth += 1;
+                cur.push(c);
+            }
+            ')' => {
+                depth -= 1;
+                cur.push(c);
+            }
+            ',' if depth == 0 => {
+                parts.push(cur.trim().to_string());
+                cur.clear();
+            }
+            other => cur.push(other),
+        }
+    }
+    if !cur.trim().is_empty() {
+        parts.push(cur.trim().to_string());
+    }
+    parts
+}
+
+fn unquote(s: &str) -> String {
+    s.trim().trim_matches('"').to_string()
+}
+
+/// Resolve a single `join` argument (a variable, `process.cwd()`, or literal).
+fn eval_piece(piece: &str) -> String {
+    let p = piece.trim();
+    match p {
+        "home" => HOME.to_string(),
+        "configHome" => CONFIG.to_string(),
+        "codexHome" => CODEX.to_string(),
+        "claudeHome" => CLAUDE.to_string(),
+        "process.cwd()" => CWD.to_string(),
+        _ if p.starts_with('"') => unquote(p),
+        _ => panic!("unhandled join piece: {p}"),
+    }
+}
+
+/// Resolve a TS path expression (a `join(...)`, a bare base variable, a string
+/// literal, or the OpenClaw helper) using the synthetic environment.
+fn eval_expr(expr: &str) -> String {
+    let e = expr.trim().trim_end_matches(',').trim();
+    match e {
+        "claudeHome" => return CLAUDE.to_string(),
+        "codexHome" => return CODEX.to_string(),
+        // No .openclaw/.clawdbot/.moltbot exist in the synthetic env, so the
+        // helper falls back to its default branch.
+        "getOpenClawGlobalSkillsDir()" => return format!("{HOME}/.openclaw/skills"),
+        _ => {}
+    }
+    if e.starts_with('"') {
+        return unquote(e);
+    }
+    if let Some(idx) = e.find('(') {
+        if e[..idx].trim() == "join" {
+            let inner = balanced(e, idx);
+            let parts: Vec<String> = split_top_commas(inner)
+                .iter()
+                .map(|p| eval_piece(p))
+                .collect();
+            return parts.join("/");
+        }
+    }
+    panic!("unhandled path expression: {e}");
+}
+
+/// The TS object literal for one agent, from its `name:` line to the next one.
+fn agent_block(slug: &str) -> String {
+    let needle = format!("name: \"{slug}\",");
+    let start = AGENTS_TS
+        .find(&needle)
+        .unwrap_or_else(|| panic!("no block found for agent {slug}"));
+    let after = start + needle.len();
+    let end = AGENTS_TS[after..]
+        .find("name: \"")
+        .map(|i| after + i)
+        .unwrap_or(AGENTS_TS.len());
+    AGENTS_TS[start..end].to_string()
+}
+
+fn field_string(block: &str, field: &str) -> String {
+    let key = format!("{field}: \"");
+    let i = block
+        .find(&key)
+        .unwrap_or_else(|| panic!("missing field {field}"));
+    let rest = &block[i + key.len()..];
+    let end = rest.find('"').unwrap();
+    rest[..end].to_string()
+}
+
+fn global_expr(block: &str) -> String {
+    let key = "globalSkillsDir:";
+    let i = block.find(key).expect("missing globalSkillsDir");
+    let rest = &block[i + key.len()..];
+    let end = rest.find('\n').unwrap();
+    rest[..end].trim().trim_end_matches(',').trim().to_string()
+}
+
+/// Every `existsSync(<expr>)` argument in the block, in source order.
+fn exists_args(block: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut search = 0usize;
+    while let Some(rel) = block[search..].find("existsSync(") {
+        let paren = search + rel + "existsSync".len();
+        out.push(balanced(block, paren).trim().to_string());
+        search = paren + 1;
+    }
+    out
+}
+
+/// Collect every double-quoted string in `s`.
+fn quoted_strings(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            if let Some(rel) = s[i + 1..].find('"') {
+                out.push(s[i + 1..i + 1 + rel].to_string());
+                i = i + 1 + rel + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+fn union_slugs() -> Vec<String> {
+    let start = TYPES_TS
+        .find("export type AgentType =")
+        .expect("AgentType union not found");
+    let rest = &TYPES_TS[start..];
+    let end = rest.find(';').expect("union terminator not found");
+    let mut slugs = quoted_strings(&rest[..end]);
+    slugs.sort();
+    slugs
+}
+
+fn sorted(mut v: Vec<String>) -> Vec<String> {
+    v.sort();
+    v
+}
+
+fn path_strings(paths: &[PathBuf]) -> Vec<String> {
+    paths
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect()
+}
+
+#[test]
+fn slug_union_matches_table_exactly() {
+    let ts_slugs = union_slugs();
+    assert_eq!(ts_slugs.len(), 42, "AgentType union should list 42 agents");
+
+    let rust_slugs = sorted(agents::slugs().iter().map(|s| s.to_string()).collect());
+    assert_eq!(rust_slugs, ts_slugs, "Rust slugs must match the TS union");
+    assert_eq!(agents::all().len(), 42, "Rust table should hold 42 agents");
+}
+
+#[test]
+fn every_agent_directory_and_detection_matches_typescript() {
+    let env = synthetic_env();
+    let never_exists = |_: &Path| false;
+
+    let mut checked = 0;
+    for agent in agents::all() {
+        let block = agent_block(agent.name);
+
+        // Project-relative skills directory.
+        assert_eq!(
+            field_string(&block, "skillsDir"),
+            agent.skills_dir,
+            "skillsDir mismatch for {}",
+            agent.name
+        );
+
+        // Global skills directory.
+        let expected_global = eval_expr(&global_expr(&block));
+        let actual_global = agent
+            .global_skills_dir(&env, &never_exists)
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            actual_global, expected_global,
+            "globalSkillsDir mismatch for {}",
+            agent.name
+        );
+
+        // detectInstalled probe paths (order-independent).
+        let expected_detect = sorted(exists_args(&block).iter().map(|e| eval_expr(e)).collect());
+        let actual_detect = sorted(path_strings(&agent.detect_paths(&env)));
+        assert_eq!(
+            actual_detect, expected_detect,
+            "detectInstalled mismatch for {}",
+            agent.name
+        );
+
+        // showInUniversalList: false only when explicitly set in the TS.
+        let ts_hidden = block.contains("showInUniversalList: false");
+        assert_eq!(
+            !agent.show_in_universal_list, ts_hidden,
+            "showInUniversalList mismatch for {}",
+            agent.name
+        );
+
+        checked += 1;
+    }
+    assert_eq!(checked, 42, "expected to check all 42 agents");
+}


### PR DESCRIPTION
Wave 3 / A3. Implements the `skill-install` crate: ports the 42-agent detection table, env overrides (CLAUDE_CONFIG_DIR/CODEX_HOME), and XDG/OpenClaw base-dir resolution from `cli/lib/types/agents.ts`, plus copy/symlink install of a bundled skill. Built on the `common` crate.

- **env.rs** — XDG + home-override resolution (`resolve_config_home`, `resolve_home_override`, `open_claw_global_skills_dir`).
- **agents.rs** — the 42-agent table as data (`AgentConfig` + `Base`/`GlobalDir`/`DetectPath`), `detect_installed`, `all()/by_name()/slugs()`.
- **install.rs** — `resolve_target_dir` + `install_skill` (Copy / Symlink, unix+windows).

**Parity: 42/42** — a test parses `agents.ts`/`types.ts` directly and asserts the Rust table matches per-agent (skillsDir, globalSkillsDir, detect probes, universal-list) + slug-set equality. 33 tests total; `cargo fmt/clippy(-D warnings)/build --locked/test` all green.