### PR TITLE
feat(skill-validator-rs): standalone validator CLI binary + distribution (A5b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
 name = "skill-validator-rs"
 version = "0.0.0"
 dependencies = [
+ "clap",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "skill-validator-rs"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "regex",

--- a/crates/skill-validator-rs/Cargo.toml
+++ b/crates/skill-validator-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skill-validator-rs"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/skill-validator-rs/Cargo.toml
+++ b/crates/skill-validator-rs/Cargo.toml
@@ -8,18 +8,31 @@ rust-version.workspace = true
 publish = false
 description = "Deterministic, offline skill validation (structure, content, token counts) for the tekhne auditor."
 
+# Opt this crate into cargo-dist: workspace policy sets `publish = false`, which
+# otherwise hides the binary from dist. skill-validator-rs is the offline
+# validator gate consumed by the git hooks and CI (A5b). It ships no bundled
+# skill and has no `skill install` subcommand: it is a gate tool, not a skill
+# installer.
+[package.metadata.dist]
+dist = true
+
 [lib]
 name = "skill_validator_rs"
 path = "src/lib.rs"
 
-# The CLI/binary target is deferred to A5b (D3). Until then this crate is a
-# pure library, so `clap` (and the currently unused `common`) are not declared.
+# The standalone validator gate binary (A5b). Wraps the lib API with a clap CLI,
+# report rendering (text/json/markdown/annotations), and exit-code logic.
+[[bin]]
+name = "skill-validator-rs"
+path = "src/main.rs"
+
 [dependencies]
 tiktoken-rs = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
+clap = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/skill-validator-rs/src/main.rs
+++ b/crates/skill-validator-rs/src/main.rs
@@ -1,0 +1,183 @@
+//! `skill-validator-rs`: the standalone offline validator gate (A5b). Wraps the
+//! library's deterministic validation surface with a clap CLI, report rendering
+//! (text/json/markdown plus GitHub Actions annotations), and the Go tool's
+//! exit-code contract (`cmd/exitcode.go`): `0` clean, `1` error, `2` warning,
+//! `3` CLI usage error; `--strict` promotes warnings to `1`.
+//!
+//! Hook-parity invocations (see `hk.pkl`, repointed by A6):
+//! - pre-commit: `skill-validator-rs validate structure --allow-dirs=evals <dir>`
+//!   (orphan checks run: `--skip-orphans` defaults false).
+//! - pre-push:   `skill-validator-rs check --allow-dirs=evals --per-file <dir>`.
+
+mod model;
+mod render;
+mod run;
+
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+use skill_validator_rs::Options;
+
+use model::{exit_code, CliReport, OutputFormat};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Parser)]
+#[command(
+    name = "skill-validator-rs",
+    version = VERSION,
+    about = "Deterministic, offline skill validation gate",
+    long_about = "skill-validator-rs runs the offline, deterministic skill checks (structure, \
+internal links, content, contamination) and exits 0 (clean), 1 (error), 2 (warning) or 3 (CLI \
+usage error). It is the gate consumed by the git hooks and CI."
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+
+    /// Directory names accepted without warning (comma-separated, repeatable).
+    #[arg(long, global = true, value_delimiter = ',', value_name = "CSV")]
+    allow_dirs: Vec<String>,
+
+    /// Analyse each reference file individually (`check` only).
+    #[arg(long, global = true)]
+    per_file: bool,
+
+    /// Skip the orphan-file reachability checks.
+    #[arg(long, global = true)]
+    skip_orphans: bool,
+
+    /// Promote warnings to a failing exit code (exit 1 instead of 2).
+    #[arg(long, global = true)]
+    strict: bool,
+
+    /// Treat root-level text files as standard content (flat skills).
+    #[arg(long, global = true)]
+    allow_flat_layouts: bool,
+
+    /// Do not warn about unrecognised frontmatter fields.
+    #[arg(long, global = true)]
+    allow_extra_frontmatter: bool,
+
+    /// Output format.
+    #[arg(short = 'o', long, global = true, value_enum, default_value_t = OutputFormat::Text)]
+    output: OutputFormat,
+
+    /// Also emit GitHub Actions `::error`/`::warning` annotation lines.
+    #[arg(long, global = true)]
+    emit_annotations: bool,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Validate a skill (subgroups select the check group).
+    Validate {
+        #[command(subcommand)]
+        group: ValidateGroup,
+    },
+    /// Run every group (structure, links, content, contamination) on a skill.
+    Check {
+        /// The skill directory.
+        dir: String,
+    },
+    /// Analyse a skill without validating (subgroups select the analysis).
+    Analyze {
+        #[command(subcommand)]
+        group: AnalyzeGroup,
+    },
+}
+
+#[derive(Subcommand)]
+enum ValidateGroup {
+    /// Validate directory layout, frontmatter, tokens, markdown, links, orphans.
+    Structure {
+        /// The skill directory.
+        dir: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum AnalyzeGroup {
+    /// Report content-quality metrics for SKILL.md.
+    Content {
+        /// The skill directory.
+        dir: String,
+    },
+}
+
+impl Cli {
+    fn options(&self) -> Options {
+        Options {
+            skip_orphans: self.skip_orphans,
+            allow_extra_frontmatter: self.allow_extra_frontmatter,
+            allow_flat_layouts: self.allow_flat_layouts,
+            allow_dirs: self.allow_dirs.clone(),
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    // Parse manually so clap usage errors map to exit code 3 while `--help` and
+    // `--version` still exit 0 (the Go tool's `cmd/exitcode.go` contract).
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(err) => return handle_parse_error(err),
+    };
+
+    match dispatch(&cli) {
+        Ok((report, gated)) => finish(&cli, &report, gated),
+        Err(message) => {
+            eprintln!("error: {message}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+/// Run the selected command. The bool is whether the exit code is gated on the
+/// report's findings (`false` for pure analysis, which is always exit 0).
+fn dispatch(cli: &Cli) -> Result<(CliReport, bool), String> {
+    match &cli.command {
+        Command::Validate {
+            group: ValidateGroup::Structure { dir },
+        } => Ok((run::validate_structure(dir, &cli.options()), true)),
+        Command::Check { dir } => Ok((run::check(dir, &cli.options(), cli.per_file), true)),
+        Command::Analyze {
+            group: AnalyzeGroup::Content { dir },
+        } => Ok((run::analyze_content_cmd(dir)?, false)),
+    }
+}
+
+/// Print the rendered report (and any annotations) and return the exit code.
+fn finish(cli: &Cli, report: &CliReport, gated: bool) -> ExitCode {
+    if cli.emit_annotations {
+        let annotations = render::render_annotations(report);
+        if !annotations.is_empty() {
+            // Keep stdout valid for machine consumers when emitting JSON.
+            if cli.output == OutputFormat::Json {
+                eprint!("{annotations}");
+            } else {
+                print!("{annotations}");
+            }
+        }
+    }
+
+    print!("{}", render::render(report, cli.output));
+
+    if !gated {
+        return ExitCode::SUCCESS;
+    }
+    ExitCode::from(exit_code(report.errors, report.warnings, cli.strict) as u8)
+}
+
+/// Map a clap parse outcome to an exit code: `--help`/`--version` exit 0,
+/// everything else (unknown flag, missing arg, bad subcommand) exits 3.
+fn handle_parse_error(err: clap::Error) -> ExitCode {
+    use clap::error::ErrorKind;
+    let _ = err.print();
+    match err.kind() {
+        ErrorKind::DisplayHelp
+        | ErrorKind::DisplayVersion
+        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => ExitCode::SUCCESS,
+        _ => ExitCode::from(3),
+    }
+}

--- a/crates/skill-validator-rs/src/model.rs
+++ b/crates/skill-validator-rs/src/model.rs
@@ -1,0 +1,107 @@
+//! Shared CLI data types: the aggregated per-run report the command runners
+//! build and the renderers consume, plus the output-format enum and the
+//! exit-code helper. Kept binary-local (not part of the library surface).
+
+use clap::ValueEnum;
+use serde::Serialize;
+
+use skill_validator_rs::{ContaminationReport, ContentReport, TokenCount, ValidationResult};
+
+/// The report shape produced by every command and handed to the renderers.
+///
+/// `results`/`token_counts`/`other_token_counts` come from the structure
+/// validator; `content`/`contamination`/`reference_reports` are populated only
+/// by `check` and `analyze content`. Empty collections and absent reports are
+/// omitted from JSON so each command yields a focused document.
+#[derive(Debug, Default, Serialize)]
+pub struct CliReport {
+    /// The validated skill directory, exactly as supplied on the command line.
+    pub skill_dir: String,
+    /// All findings, in emission order (Level/Category/Message/File/Line).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub results: Vec<ValidationResult>,
+    /// Token counts for standard files (SKILL.md body, references, assets).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub token_counts: Vec<TokenCount>,
+    /// Token counts for non-standard ("other") files.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub other_token_counts: Vec<TokenCount>,
+    /// Content analysis for SKILL.md (check / analyze content only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<ContentReport>,
+    /// Contamination analysis for SKILL.md (check only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contamination: Option<ContaminationReport>,
+    /// Per-reference-file analysis (check --per-file only).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reference_reports: Vec<ReferenceReport>,
+    /// Count of error-level results.
+    pub errors: usize,
+    /// Count of warning-level results.
+    pub warnings: usize,
+}
+
+/// Per-reference-file analysis emitted under `check --per-file`.
+#[derive(Debug, Serialize)]
+pub struct ReferenceReport {
+    /// Reference path relative to the skill directory, e.g. `references/x.md`.
+    pub file: String,
+    /// Content analysis for the file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<ContentReport>,
+    /// Contamination analysis for the file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contamination: Option<ContaminationReport>,
+}
+
+/// How the report is rendered to stdout (`-o/--output`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum OutputFormat {
+    /// Human-readable text (the default).
+    Text,
+    /// Stable, machine-parseable JSON.
+    Json,
+    /// A Markdown report with a results table.
+    Markdown,
+}
+
+/// Process exit code, matching the Go tool's `cmd/exitcode.go` contract:
+/// `0` clean, `1` any error (or, under `--strict`, any warning), `2` warnings
+/// only. CLI usage errors (`3`) are handled at parse time, not here.
+pub fn exit_code(errors: usize, warnings: usize, strict: bool) -> i32 {
+    if errors > 0 {
+        1
+    } else if warnings > 0 {
+        if strict {
+            1
+        } else {
+            2
+        }
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::exit_code;
+
+    #[test]
+    fn clean_is_zero() {
+        assert_eq!(exit_code(0, 0, false), 0);
+        assert_eq!(exit_code(0, 0, true), 0);
+    }
+
+    #[test]
+    fn error_is_one() {
+        assert_eq!(exit_code(1, 0, false), 1);
+        assert_eq!(exit_code(2, 5, false), 1);
+    }
+
+    #[test]
+    fn warning_is_two_unless_strict() {
+        assert_eq!(exit_code(0, 1, false), 2);
+        assert_eq!(exit_code(0, 3, true), 1);
+    }
+}

--- a/crates/skill-validator-rs/src/render.rs
+++ b/crates/skill-validator-rs/src/render.rs
@@ -1,0 +1,239 @@
+//! Report renderers: `text` (human-readable, default), `json` (stable and
+//! machine-parseable), `markdown` (a results table), plus GitHub Actions
+//! annotation lines (`--emit-annotations`). Renderers never decide the exit
+//! code; they only present the [`CliReport`] built by the runners.
+
+use skill_validator_rs::{ContaminationReport, ContentReport, Level, ValidationResult};
+
+use crate::model::{CliReport, OutputFormat};
+
+/// Render `report` in the requested `format` and return the string to print to
+/// stdout. Pass results are omitted from text and markdown to keep the gate
+/// output focused on findings.
+pub fn render(report: &CliReport, format: OutputFormat) -> String {
+    match format {
+        OutputFormat::Text => render_text(report),
+        OutputFormat::Json => render_json(report),
+        OutputFormat::Markdown => render_markdown(report),
+    }
+}
+
+fn render_json(report: &CliReport) -> String {
+    serde_json::to_string_pretty(report).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
+}
+
+fn render_text(report: &CliReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("Skill: {}\n", report.skill_dir));
+
+    let findings: Vec<&ValidationResult> = report
+        .results
+        .iter()
+        .filter(|r| r.level != Level::Pass)
+        .collect();
+
+    if findings.is_empty() && report.results.is_empty() {
+        // No structure group ran (e.g. `analyze content`).
+    } else if findings.is_empty() {
+        out.push_str("  No issues found.\n");
+    } else {
+        for r in findings {
+            out.push_str(&format!("  {}\n", text_line(r)));
+        }
+    }
+
+    if let Some(content) = &report.content {
+        out.push_str(&render_content_text("Content metrics", content));
+    }
+    if let Some(contamination) = &report.contamination {
+        out.push_str(&render_contamination_text(contamination));
+    }
+    for rr in &report.reference_reports {
+        if let Some(content) = &rr.content {
+            out.push_str(&render_content_text(
+                &format!("Content ({})", rr.file),
+                content,
+            ));
+        }
+    }
+
+    if !report.results.is_empty() {
+        out.push_str(&format!(
+            "Summary: {} error{}, {} warning{}\n",
+            report.errors,
+            plural(report.errors),
+            report.warnings,
+            plural(report.warnings),
+        ));
+    }
+    out
+}
+
+fn text_line(r: &ValidationResult) -> String {
+    let level = r.level.as_str().to_uppercase();
+    let location = location(&r.file, r.line);
+    if location.is_empty() {
+        format!("[{level}] {}: {}", r.category, r.message)
+    } else {
+        format!("[{level}] {}: {} ({location})", r.category, r.message)
+    }
+}
+
+fn render_content_text(title: &str, c: &ContentReport) -> String {
+    format!(
+        "{title}:\n  words={} code_blocks={} sentences={} imperative={} \
+         sections={} list_items={}\n  code_block_ratio={:.4} imperative_ratio={:.4} \
+         information_density={:.4} instruction_specificity={:.4}\n  code_languages={:?}\n",
+        c.word_count,
+        c.code_block_count,
+        c.sentence_count,
+        c.imperative_count,
+        c.section_count,
+        c.list_item_count,
+        c.code_block_ratio,
+        c.imperative_ratio,
+        c.information_density,
+        c.instruction_specificity,
+        c.code_languages,
+    )
+}
+
+fn render_contamination_text(c: &ContaminationReport) -> String {
+    format!(
+        "Contamination:\n  level={} score={:.4} scope_breadth={} language_mismatch={}\n  \
+         primary_category={} mismatched_categories={:?}\n",
+        c.contamination_level,
+        c.contamination_score,
+        c.scope_breadth,
+        c.language_mismatch,
+        c.primary_category,
+        c.mismatched_categories,
+    )
+}
+
+fn render_markdown(report: &CliReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# Validation report: `{}`\n\n", report.skill_dir));
+
+    let findings: Vec<&ValidationResult> = report
+        .results
+        .iter()
+        .filter(|r| r.level != Level::Pass)
+        .collect();
+
+    if !report.results.is_empty() {
+        if findings.is_empty() {
+            out.push_str("No issues found.\n\n");
+        } else {
+            out.push_str("| Level | Category | Message | Location |\n");
+            out.push_str("| ----- | -------- | ------- | -------- |\n");
+            for r in findings {
+                out.push_str(&format!(
+                    "| {} | {} | {} | {} |\n",
+                    r.level.as_str(),
+                    escape_pipes(&r.category),
+                    escape_pipes(&r.message),
+                    escape_pipes(&location(&r.file, r.line)),
+                ));
+            }
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "**{} error{}, {} warning{}**\n",
+            report.errors,
+            plural(report.errors),
+            report.warnings,
+            plural(report.warnings),
+        ));
+    }
+
+    if let Some(content) = &report.content {
+        out.push_str(&markdown_content(content));
+    }
+    out
+}
+
+fn markdown_content(c: &ContentReport) -> String {
+    format!(
+        "\n## Content metrics\n\n\
+         - Words: {}\n- Code blocks: {}\n- Sentences: {}\n- Imperative sentences: {}\n\
+         - Sections: {}\n- List items: {}\n- Code-block ratio: {:.4}\n\
+         - Imperative ratio: {:.4}\n- Information density: {:.4}\n\
+         - Instruction specificity: {:.4}\n",
+        c.word_count,
+        c.code_block_count,
+        c.sentence_count,
+        c.imperative_count,
+        c.section_count,
+        c.list_item_count,
+        c.code_block_ratio,
+        c.imperative_ratio,
+        c.information_density,
+        c.instruction_specificity,
+    )
+}
+
+/// GitHub Actions annotation lines for every error and warning finding
+/// (`::error` / `::warning`). Pass/Info results are not annotated.
+pub fn render_annotations(report: &CliReport) -> String {
+    let mut out = String::new();
+    for r in &report.results {
+        let command = match r.level {
+            Level::Error => "error",
+            Level::Warning => "warning",
+            _ => continue,
+        };
+        let props = annotation_props(&report.skill_dir, &r.file, r.line);
+        let message = escape_annotation_data(&format!("{}: {}", r.category, r.message));
+        out.push_str(&format!("::{command}{props}::{message}\n"));
+    }
+    out
+}
+
+/// The `file=...,line=...` property block, joining the skill directory to the
+/// result's relative file. Empty when the result carries no file.
+fn annotation_props(skill_dir: &str, file: &str, line: usize) -> String {
+    if file.is_empty() {
+        return String::new();
+    }
+    let path = escape_annotation_prop(&format!("{skill_dir}/{file}"));
+    if line > 0 {
+        format!(" file={path},line={line}")
+    } else {
+        format!(" file={path}")
+    }
+}
+
+fn location(file: &str, line: usize) -> String {
+    match (file.is_empty(), line) {
+        (true, _) => String::new(),
+        (false, 0) => file.to_string(),
+        (false, n) => format!("{file}:{n}"),
+    }
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+fn escape_pipes(s: &str) -> String {
+    s.replace('|', "\\|").replace('\n', " ")
+}
+
+/// Escape a workflow-command data segment (GitHub Actions message escaping).
+fn escape_annotation_data(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+}
+
+/// Escape a workflow-command property value (additionally escapes `,` and `:`).
+fn escape_annotation_prop(s: &str) -> String {
+    escape_annotation_data(s)
+        .replace(',', "%2C")
+        .replace(':', "%3A")
+}

--- a/crates/skill-validator-rs/src/run.rs
+++ b/crates/skill-validator-rs/src/run.rs
@@ -1,0 +1,93 @@
+//! Command runners: translate parsed CLI arguments into library calls and
+//! build a [`CliReport`]. `validate structure` runs the structure group;
+//! `check` additionally runs the content and contamination groups (per-file
+//! when requested); `analyze content` runs the content group alone.
+
+use std::path::Path;
+
+use skill_validator_rs::structure::fsutil::read_dir_sorted;
+use skill_validator_rs::{analyze_contamination, analyze_content, validate, Options, Skill};
+
+use crate::model::{CliReport, ReferenceReport};
+
+/// Run `validate structure <dir>`: the structure group only.
+pub fn validate_structure(dir: &str, opts: &Options) -> CliReport {
+    let report = validate(Path::new(dir), opts);
+    CliReport {
+        skill_dir: dir.to_string(),
+        results: report.results,
+        token_counts: report.token_counts,
+        other_token_counts: report.other_token_counts,
+        errors: report.errors,
+        warnings: report.warnings,
+        ..CliReport::default()
+    }
+}
+
+/// Run `check <dir>`: the structure group plus content and contamination
+/// analysis of SKILL.md, and (when `per_file`) of each reference file.
+pub fn check(dir: &str, opts: &Options, per_file: bool) -> CliReport {
+    let mut cli = validate_structure(dir, opts);
+
+    // Content and contamination are metrics groups: they enrich the report but
+    // never add findings, so the exit code stays driven by the structure group.
+    let path = Path::new(dir);
+    if let Ok(skill) = Skill::load(path) {
+        let content = analyze_content(&skill.raw_content);
+        let contamination = analyze_contamination(
+            &skill_name(path),
+            &skill.raw_content,
+            &content.code_languages,
+        );
+        cli.content = Some(content);
+        cli.contamination = Some(contamination);
+    }
+
+    if per_file {
+        cli.reference_reports = analyze_reference_files(path);
+    }
+
+    cli
+}
+
+/// Run `analyze content <dir>`: the content group over SKILL.md only.
+pub fn analyze_content_cmd(dir: &str) -> Result<CliReport, String> {
+    let skill = Skill::load(Path::new(dir))?;
+    Ok(CliReport {
+        skill_dir: dir.to_string(),
+        content: Some(analyze_content(&skill.raw_content)),
+        ..CliReport::default()
+    })
+}
+
+/// The skill name used for contamination (the directory basename), matching the
+/// Go tool's use of the skill identity for multi-interface-tool detection.
+fn skill_name(dir: &Path) -> String {
+    dir.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// Analyse every readable file directly under `references/` (sorted, hidden and
+/// nested entries skipped), mirroring the token counter's reference walk.
+fn analyze_reference_files(dir: &Path) -> Vec<ReferenceReport> {
+    let refs_dir = dir.join("references");
+    let name = skill_name(dir);
+    let mut reports = Vec::new();
+    for entry in read_dir_sorted(&refs_dir) {
+        if entry.is_dir || entry.name.starts_with('.') {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&entry.path) else {
+            continue;
+        };
+        let content = analyze_content(&text);
+        let contamination = analyze_contamination(&name, &text, &content.code_languages);
+        reports.push(ReferenceReport {
+            file: format!("references/{}", entry.name),
+            content: Some(content),
+            contamination: Some(contamination),
+        });
+    }
+    reports
+}

--- a/crates/skill-validator-rs/tests/cli.rs
+++ b/crates/skill-validator-rs/tests/cli.rs
@@ -1,0 +1,174 @@
+//! CLI integration tests for the standalone validator gate (A5b).
+//!
+//! These assert the exact exit-code contract from the Go tool's
+//! `cmd/exitcode.go` (`0` clean, `1` error, `2` warning, `3` CLI usage error;
+//! `--strict` promotes warnings to `1`) and the hook-parity invocations
+//! (`validate structure --allow-dirs=evals` and `check --per-file`) against the
+//! frozen golden-corpus fixtures. The binary is located via the
+//! `CARGO_BIN_EXE_<name>` variable Cargo sets for integration tests.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+/// Absolute path to a golden-corpus testdata fixture directory.
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/golden-corpus/fixtures/testdata")
+        .join(name)
+}
+
+/// Run the built binary with `args` and return its output.
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_skill-validator-rs"))
+        .args(args)
+        .output()
+        .expect("spawn skill-validator-rs")
+}
+
+/// The process exit code (tests never trigger signals).
+fn code(output: &Output) -> i32 {
+    output.status.code().expect("exit code")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn clean_skill_exits_zero() {
+    let dir = fixture("valid-skill");
+    let out = run(&["validate", "structure", dir.to_str().unwrap()]);
+    assert_eq!(code(&out), 0, "stdout: {}", stdout(&out));
+}
+
+#[test]
+fn error_skill_exits_one() {
+    let dir = fixture("invalid-skill");
+    let out = run(&["validate", "structure", dir.to_str().unwrap()]);
+    assert_eq!(code(&out), 1, "stdout: {}", stdout(&out));
+}
+
+#[test]
+fn warning_only_skill_exits_two() {
+    let dir = fixture("warnings-only-skill");
+    let out = run(&["validate", "structure", dir.to_str().unwrap()]);
+    assert_eq!(code(&out), 2, "stdout: {}", stdout(&out));
+}
+
+#[test]
+fn warning_only_skill_exits_one_under_strict() {
+    let dir = fixture("warnings-only-skill");
+    let out = run(&["validate", "structure", "--strict", dir.to_str().unwrap()]);
+    assert_eq!(code(&out), 1, "stdout: {}", stdout(&out));
+}
+
+#[test]
+fn cli_misuse_exits_three() {
+    // Missing the required <dir> positional.
+    assert_eq!(code(&run(&["validate", "structure"])), 3);
+    // Unknown flag.
+    let dir = fixture("valid-skill");
+    assert_eq!(
+        code(&run(&[
+            "validate",
+            "structure",
+            "--no-such-flag",
+            dir.to_str().unwrap()
+        ])),
+        3
+    );
+    // Unknown subcommand.
+    assert_eq!(code(&run(&["totally-bogus"])), 3);
+}
+
+#[test]
+fn help_and_version_exit_zero() {
+    assert_eq!(code(&run(&["--help"])), 0);
+    assert_eq!(code(&run(&["--version"])), 0);
+}
+
+#[test]
+fn validate_structure_allow_dirs_suppresses_the_named_dir() {
+    // The pre-commit hook parity invocation.
+    let dir = fixture("allowed-dirs-skill");
+    let path = dir.to_str().unwrap();
+
+    let without = run(&["validate", "structure", path]);
+    assert!(
+        stdout(&without).contains("evals/"),
+        "expected an unknown-dir warning for evals/ without the flag; stdout: {}",
+        stdout(&without)
+    );
+
+    let with = run(&["validate", "structure", "--allow-dirs=evals", path]);
+    assert!(
+        !stdout(&with).contains("unknown directory: evals/"),
+        "--allow-dirs=evals should suppress the evals/ warning; stdout: {}",
+        stdout(&with)
+    );
+    // The fixture still has an unrecognised `testing/` directory, so the run is
+    // still gated on a warning (exit 2), proving the flag is scoped to evals.
+    assert_eq!(code(&with), 2, "stdout: {}", stdout(&with));
+}
+
+#[test]
+fn check_per_file_runs_all_groups_on_a_clean_skill() {
+    // The pre-push hook parity invocation.
+    let dir = fixture("valid-skill");
+    let out = run(&[
+        "check",
+        "--allow-dirs=evals",
+        "--per-file",
+        "-o",
+        "json",
+        dir.to_str().unwrap(),
+    ]);
+    assert_eq!(code(&out), 0, "stdout: {}", stdout(&out));
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout(&out)).expect("check --per-file emits valid JSON");
+    assert!(parsed.get("content").is_some(), "content group ran");
+    assert!(
+        parsed.get("contamination").is_some(),
+        "contamination group ran"
+    );
+    assert!(
+        parsed
+            .get("reference_reports")
+            .and_then(|v| v.as_array())
+            .is_some_and(|a| !a.is_empty()),
+        "per-file reference analysis present: {}",
+        stdout(&out)
+    );
+}
+
+#[test]
+fn json_output_is_stable_and_parseable() {
+    let dir = fixture("invalid-skill");
+    let out = run(&["validate", "structure", "-o", "json", dir.to_str().unwrap()]);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout(&out)).expect("valid JSON on stdout");
+    assert!(parsed.get("errors").and_then(|v| v.as_u64()).unwrap() > 0);
+    assert!(parsed.get("results").and_then(|v| v.as_array()).is_some());
+}
+
+#[test]
+fn annotations_do_not_pollute_json_stdout() {
+    let dir = fixture("invalid-skill");
+    let out = run(&[
+        "validate",
+        "structure",
+        "-o",
+        "json",
+        "--emit-annotations",
+        dir.to_str().unwrap(),
+    ]);
+    // Annotations go to stderr under JSON so stdout stays machine-parseable.
+    serde_json::from_str::<serde_json::Value>(&stdout(&out))
+        .expect("stdout is pure JSON even with --emit-annotations");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("::error"),
+        "annotations emitted to stderr: {err}"
+    );
+}


### PR DESCRIPTION
## Wave 6 / A5b: standalone skill-validator-rs CLI (unblocks A6/B5)

Adds the offline validator gate binary on top of the A4a lib, so the hooks/CI can drop the Go `skill-validator`.

- **Binary `skill-validator-rs`**: `validate structure <dir>`, `check <dir>` (structure + links + content + contamination), `analyze content <dir>`. Flags `--allow-dirs --per-file --skip-orphans --strict --allow-flat-layouts --allow-extra-frontmatter -o/--output <text|json|markdown> --emit-annotations`.
- **Exit codes** matching the Go validator: 0 clean / 1 error / 2 warning / 3 usage; `--strict` promotes warnings to 1. Hook-parity verified for `validate structure --allow-dirs=evals <dir>` and `check --per-file <dir>`.
- Renderers: text / json (Go-shaped `results[]` + tallies) / markdown / GitHub annotations.
- `dist = true` + bumped to `0.1.0` so `tool/skill-validator-rs-v0.1.0` releases via the existing (version-agnostic) `tool-release.yml`. No bundled skill, no `skill install` (gate tool).
- 10 new CLI integration tests; token-parity and golden-parity unaffected. Gates green.

Hooks/CI are **not** repointed here (that is A6, using build-from-source).