### PR TITLE
chore: narrow Python to the allowlist + add guardrail (C3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,10 +64,18 @@ updates:
           - "minor"
           - "patch"
 
-  # Python research skills (requirements.txt under skills/documentation/research)
+  # Python research skills (requirements.txt under skills/documentation/research).
+  # Scoped to exactly the allowlisted research skills that ship a requirements.txt
+  # (python-allowlist.txt). The allowlisted validator/generator skills carry .py
+  # but no requirements.txt (stdlib only), so they are not listed here.
   - package-ecosystem: "pip"
     directories:
-      - "/skills/documentation/research/*"
+      - "/skills/documentation/research/google-scholar-search"
+      - "/skills/documentation/research/notebooklm"
+      - "/skills/documentation/research/pubmed-search"
+      - "/skills/documentation/research/sci-data-extractor"
+      - "/skills/documentation/research/sci-hub-search"
+      - "/skills/documentation/research/semantic-scholar-search"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/hk.pkl
+++ b/hk.pkl
@@ -30,6 +30,13 @@ local preCommit = new Mapping<String, Step> {
     ["skill-artifacts"] {
         check = "./skills/agentic-harness/skill-quality-auditor/scripts/validate-skill-artifacts.sh {{files}}"
     }
+    // Guardrail: no .py may live outside a directory listed in
+    // python-allowlist.txt. Python is retained only for the allowlisted skills,
+    // so a stray .py is a mis-placed script or an allowlist gap. Glob-less so it
+    // scans the whole tree on every commit; offline and deterministic.
+    ["python-allowlist"] {
+        check = "./scripts/check-python-allowlist.sh"
+    }
     // Regenerates README.md + docs tiles from skills and audit data, staging
     // them. Fix-only: `--dry-run` exits 0 even when out of sync, which would
     // let hk's check-first skip the regeneration, so there is no `check`

--- a/scripts/check-python-allowlist.sh
+++ b/scripts/check-python-allowlist.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# check-python-allowlist.sh
+#
+# Guardrail: fail if any .py file lives outside a directory listed in
+# python-allowlist.txt. Python is retained only for the allowlisted skills, so
+# a .py appearing anywhere else is either a mis-placed skill script or an
+# allowlist gap and must be reviewed before it lands. Deterministic, offline,
+# no network or build steps.
+#
+# Carve-outs (not skill Python; mirror the linter exclusions already in hk.pkl):
+#   - target/, node_modules/, .git/   build output, dependencies, VCS metadata
+#   - .agents/                        vendored installed-skill copies (gitignored)
+#   - */tests/golden-corpus/*         skill-validator-rs / skill-auditor fixtures
+#
+# Usage: ./scripts/check-python-allowlist.sh
+# Exit:  0 = all .py under an allowlisted directory; 1 = violation(s) found.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+allowlist_file="python-allowlist.txt"
+if [ ! -f "$allowlist_file" ]; then
+  echo "error: $allowlist_file not found at repo root ($repo_root)" >&2
+  exit 1
+fi
+
+# Normalise the allowlist to a temp file: drop comments and blank lines, trim
+# surrounding whitespace and any trailing carriage returns.
+normalised_allowlist="$(mktemp)"
+trap 'rm -f "$normalised_allowlist"' EXIT
+sed -e 's/#.*$//' -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' "$allowlist_file" \
+  | tr -d '\r' \
+  | grep -v '^$' > "$normalised_allowlist"
+
+py_total=0
+violations=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  f="${f#./}"
+  py_total=$((py_total + 1))
+  matched=0
+  while IFS= read -r d; do
+    [ -z "$d" ] && continue
+    case "$f" in
+      "$d"/*) matched=1; break ;;
+    esac
+  done < "$normalised_allowlist"
+  if [ "$matched" -eq 0 ]; then
+    if [ "$violations" -eq 0 ]; then
+      echo "python-allowlist guardrail FAILED: .py file(s) not under an allowlisted directory (see python-allowlist.txt):" >&2
+    fi
+    echo "  $f" >&2
+    violations=$((violations + 1))
+  fi
+done < <(
+  find . -type f -name '*.py' \
+    -not -path './target/*' \
+    -not -path '*/node_modules/*' \
+    -not -path './.agents/*' \
+    -not -path './.git/*' \
+    -not -path '*/tests/golden-corpus/*' \
+  | sort
+)
+
+if [ "$violations" -gt 0 ]; then
+  {
+    echo ""
+    echo "Move each script under an allowlisted skill, or add its skill directory"
+    echo "to python-allowlist.txt after Compliance and plan review."
+  } >&2
+  exit 1
+fi
+
+echo "python-allowlist guardrail OK: ${py_total} .py file(s), all under allowlisted directories."


### PR DESCRIPTION
## Wave 7 / C3: finalise the Python footprint to the allowlist

Python is **retained** (18 allowlisted skills); this narrows + guards it, no deletions.

- **Verified:** all 38 `.py` files (excluding `target/`, `node_modules/`, `.agents/skills/**`, and the golden-corpus test fixtures) live under an allowlisted directory from `python-allowlist.txt` (6 research + 12 validator/generator skills). No stray `python3`/`python` invocation outside the allowlist.
- **Dependabot `pip`** narrowed from the `research/*` glob to the six exact research-skill dirs that ship a `requirements.txt` (the validator/generator skills are stdlib-only, no `requirements.txt`).
- **Guardrail:** `scripts/check-python-allowlist.sh` + a `python-allowlist` pre-commit step (`hk.pkl`) fails if any future non-allowlisted `.py` appears. Passes on the current tree; negative-tested.
- **CodeQL `python` untouched** — Python stays scanned (retained), so no language-retirement / "configuration not found" transition (unlike `go`).

Follow-ups (non-blocking): the guardrail is pre-commit only (a CI step could enforce on `main` later); the C1 inventory doc still has stale "delete validator Python in C3" wording superseded by the authoritative `python-allowlist.txt`.