### PR TITLE
ci(dist): pin release runners to ubuntu-22.04 (ubuntu-20.04 retired)

### DIFF
--- a/.github/workflows/tool-release.yml
+++ b/.github/workflows/tool-release.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -167,7 +167,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -217,7 +217,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -281,7 +281,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -37,3 +37,11 @@ tag-namespace = "tool"
 # releases only ever happen on a 'tool/*-v*' tag push, so the PR dry-run adds
 # noise without value; skip it so PRs settle to CLEAN.
 pr-run-mode = "skip"
+
+# Runner overrides. cargo-dist 0.28's default `ubuntu-20.04` runner was retired
+# by GitHub, so the release jobs queued forever. Pin the global jobs and the
+# Linux build targets to `ubuntu-22.04` (macOS targets use the macOS runners).
+[dist.github-custom-runners]
+global = "ubuntu-22.04"
+aarch64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"


### PR DESCRIPTION
The first release tag (tool/skill-auditor-v0.1.0) queued forever: cargo-dist 0.28's default ubuntu-20.04 runner was retired by GitHub. Adds [dist.github-custom-runners] (global + linux targets = ubuntu-22.04) and regenerates tool-release.yml. macOS targets use the macOS runners. Verified: dist plan valid, no ubuntu-20.04 remains.