### PR TITLE
feat(skill-auditor): audit tooling — prune-audits + plan-aggregation (Wave 3)

### DIFF
--- a/crates/skill-auditor/src/aggregation.rs
+++ b/crates/skill-auditor/src/aggregation.rs
@@ -1,0 +1,368 @@
+//! Aggregation planning for a skill "family" (skills sharing a name prefix).
+//!
+//! Ports `plan-aggregation.sh`. Two deliberate deviations from the shell:
+//! - **Layout fix**: the shell scanned only the immediate children of each
+//!   root (`skills/*`), so on this repo's nested `skills/<domain>/<skill>/`
+//!   layout it matched nothing. This recurses and matches a skill by its
+//!   directory name at any depth.
+//! - **Engine reuse**: the average-duplication metric is computed with the
+//!   shared [`crate::duplication`] line-overlap engine rather than the shell's
+//!   bespoke ">10-char, lowercased, unique" normalisation, so there is one
+//!   similarity implementation. The exact percentage therefore differs from the
+//!   shell's, but it drives the same advisory thresholds.
+
+use std::path::{Path, PathBuf};
+
+use crate::duplication;
+
+/// A skill belonging to the requested family.
+#[derive(Debug, Clone)]
+pub struct FamilySkill {
+    /// Directory name (e.g. `bdd-testing`).
+    pub name: String,
+    /// Path to the skill's SKILL.md.
+    pub path: PathBuf,
+    /// Line count of SKILL.md (`wc -l`).
+    pub lines: usize,
+    /// The `description:` frontmatter value, if present.
+    pub description: String,
+    /// Raw SKILL.md content (used for the duplication metric).
+    pub content: String,
+}
+
+/// The default roots searched for family members (matching the shell).
+pub fn default_roots() -> Vec<PathBuf> {
+    vec![PathBuf::from("skills"), PathBuf::from(".agents/skills")]
+}
+
+/// Recursively find skills under `roots` whose directory name is exactly
+/// `prefix` or begins with `prefix-`. Results are sorted by name.
+pub fn find_family(roots: &[PathBuf], prefix: &str) -> Vec<FamilySkill> {
+    let mut out = Vec::new();
+    for root in roots {
+        collect_family(root, prefix, &mut out);
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+fn collect_family(dir: &Path, prefix: &str, out: &mut Vec<FamilySkill>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let skill_md = path.join("SKILL.md");
+        if skill_md.is_file() && name_in_family(&name, prefix) {
+            if let Ok(content) = std::fs::read_to_string(&skill_md) {
+                out.push(FamilySkill {
+                    lines: content.lines().count(),
+                    description: frontmatter_description(&content),
+                    name,
+                    path: skill_md,
+                    content,
+                });
+            }
+        } else {
+            // Recurse into non-matching directories to reach nested skills.
+            collect_family(&path, prefix, out);
+        }
+    }
+}
+
+/// A name is in the family when it equals the prefix or starts with `prefix-`.
+fn name_in_family(name: &str, prefix: &str) -> bool {
+    name == prefix || name.starts_with(&format!("{prefix}-"))
+}
+
+/// Extract the `description:` frontmatter value (first occurrence).
+fn frontmatter_description(content: &str) -> String {
+    content
+        .lines()
+        .find_map(|l| l.strip_prefix("description:"))
+        .map(|v| v.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Average pairwise line-overlap similarity (percent) across the family, via
+/// the shared duplication engine. Returns 0 for fewer than two skills.
+pub fn average_duplication(skills: &[FamilySkill]) -> u32 {
+    if skills.len() < 2 {
+        return 0;
+    }
+    let mut total = 0u32;
+    let mut pairs = 0u32;
+    for i in 0..skills.len() {
+        for j in (i + 1)..skills.len() {
+            let (sim, _) = duplication::basic_similarity(&skills[i].content, &skills[j].content);
+            total += sim;
+            pairs += 1;
+        }
+    }
+    total.checked_div(pairs).unwrap_or(0)
+}
+
+/// Propose category names from the family members' name suffixes: for
+/// `prefix-<cat>-...` the category is `<cat>`. Falls back to `core`/`advanced`
+/// when no hyphenated members exist (ports the shell's default).
+pub fn propose_categories(skills: &[FamilySkill]) -> Vec<String> {
+    let mut cats: Vec<String> = Vec::new();
+    for s in skills {
+        // Strip everything up to and including the first hyphen.
+        if let Some((_, rest)) = s.name.split_once('-') {
+            let cat = rest.split('-').next().unwrap_or("");
+            if !cat.is_empty() {
+                cats.push(cat.to_string());
+            }
+        }
+    }
+    cats.sort();
+    cats.dedup();
+    if cats.is_empty() {
+        vec!["core".to_string(), "advanced".to_string()]
+    } else {
+        cats
+    }
+}
+
+/// Render the aggregation plan as Markdown (ports the shell's `generate_plan`).
+pub fn render_plan(family: &str, skills: &[FamilySkill], duplication: u32) -> String {
+    let total_lines: usize = skills.iter().map(|s| s.lines).sum();
+    let skill_count = skills.len();
+    let categories = propose_categories(skills);
+
+    let hub_lines = 65usize;
+    let refs = ((total_lines as f64 / 350.0).round() as usize).max(1);
+    let new_total = hub_lines + refs * 200;
+    let reduction = if total_lines > 0 {
+        format!(
+            "{:.1}",
+            (1.0 - new_total as f64 / total_lines as f64) * 100.0
+        )
+    } else {
+        "0.0".to_string()
+    };
+
+    let mut s = String::new();
+    s.push_str(&format!("# Aggregation Plan: {family}\n\n## Summary\n\n"));
+    s.push_str(&format!("- **Source Skills**: {skill_count}\n"));
+    s.push_str(&format!("- **Total Lines**: {total_lines}\n"));
+    s.push_str(&format!("- **Estimated Hub**: ~{hub_lines} lines\n"));
+    s.push_str(&format!("- **Estimated References**: ~{refs} files\n"));
+    s.push_str(&format!("- **Estimated Reduction**: {reduction}%\n\n"));
+
+    s.push_str(
+        "## Source Skills\n\n| Skill | Lines | Description |\n|-------|-------|-------------|\n",
+    );
+    for skill in skills {
+        let desc = if skill.description.chars().count() > 50 {
+            let short: String = skill.description.chars().take(50).collect();
+            format!("{short}...")
+        } else {
+            skill.description.clone()
+        };
+        s.push_str(&format!(
+            "| {} | {} | {} |\n",
+            skill.name, skill.lines, desc
+        ));
+    }
+
+    s.push_str("\n## Proposed Categories\n\n| Priority | Category | Prefix | Suggested Content |\n|----------|----------|--------|-------------------|\n");
+    for (idx, cat) in categories.iter().enumerate() {
+        let priority = match idx {
+            0 => "CRITICAL",
+            1 => "HIGH",
+            2 => "MEDIUM",
+            _ => "LOW",
+        };
+        s.push_str(&format!("| {priority} | {cat} | {cat}- | TBD |\n"));
+    }
+
+    s.push_str("\n## Implementation Steps\n\n");
+    s.push_str("1. **Design Structure** - Finalize category organization\n");
+    s.push_str("2. **Create Hub** - Write SKILL.md navigation (60-90 lines)\n");
+    s.push_str("3. **Create AGENTS.md** - Reference guide with file listing\n");
+    s.push_str("4. **Extract References** - Move content to categorized files\n");
+    s.push_str("5. **Deprecate Sources** - Move to .deprecated/\n");
+    s.push_str("6. **Verify** - Run quality evaluation\n\n");
+
+    s.push_str("## Recommendations\n\n");
+    let mut n = 1;
+    if skill_count < 3 {
+        s.push_str(&format!(
+            "{n}. Only 1-2 skills found - consider if aggregation is necessary\n"
+        ));
+        n += 1;
+    } else if skill_count >= 6 {
+        s.push_str(&format!(
+            "{n}. {skill_count} skills found - strong candidate for aggregation\n"
+        ));
+        n += 1;
+    }
+    if duplication > 30 {
+        s.push_str(&format!(
+            "{n}. High duplication ({duplication}%) - high priority for consolidation\n"
+        ));
+        n += 1;
+    } else if duplication > 20 {
+        s.push_str(&format!(
+            "{n}. Moderate duplication ({duplication}%) - good candidate for consolidation\n"
+        ));
+        n += 1;
+    } else {
+        s.push_str(&format!(
+            "{n}. Low duplication ({duplication}%) - review if skills are truly related\n"
+        ));
+        n += 1;
+    }
+    if total_lines > 2000 {
+        s.push_str(&format!(
+            "{n}. Large collection ({total_lines} lines) - significant reduction potential\n"
+        ));
+        n += 1;
+    }
+    s.push_str(&format!(
+        "{n}. Follow aggregation-implementation.md 6-step process\n"
+    ));
+    n += 1;
+    s.push_str(&format!(
+        "{n}. Create navigation hub (SKILL.md) with priority categories\n"
+    ));
+    n += 1;
+    s.push_str(&format!(
+        "{n}. Extract content to references/ directory by category\n"
+    ));
+
+    s.push_str("\n## Next Actions\n\n");
+    s.push_str("- [ ] Review this plan with team\n");
+    s.push_str("- [ ] Refine category structure\n");
+    s.push_str("- [ ] Estimate effort (hours)\n");
+    s.push_str("- [ ] Schedule implementation\n");
+    s.push_str("- [ ] Execute aggregation-implementation.md\n\n");
+    s.push_str("---\n\n*Generated by skill-quality-auditor*\n");
+
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn mk_skill(root: &Path, rel: &str, body: &str) {
+        let dir = root.join(rel);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("SKILL.md"), body).unwrap();
+    }
+
+    #[test]
+    fn name_in_family_matches_prefix_and_hyphen() {
+        assert!(name_in_family("bdd", "bdd"));
+        assert!(name_in_family("bdd-testing", "bdd"));
+        assert!(!name_in_family("bddx", "bdd"));
+        assert!(!name_in_family("other", "bdd"));
+    }
+
+    #[test]
+    fn find_family_recurses_nested_layout() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // Nested domain/skill layout that the shell could not handle.
+        mk_skill(
+            root,
+            "skills/testing/bdd-testing",
+            "---\ndescription: bdd core\n---\nbody\n",
+        );
+        mk_skill(
+            root,
+            "skills/testing/bdd-unit",
+            "---\ndescription: bdd units\n---\nbody\n",
+        );
+        mk_skill(
+            root,
+            "skills/other/unrelated",
+            "---\ndescription: no\n---\nbody\n",
+        );
+
+        let found = find_family(&[root.join("skills")], "bdd");
+        let names: Vec<&str> = found.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["bdd-testing", "bdd-unit"]);
+        assert_eq!(found[0].description, "bdd core");
+    }
+
+    #[test]
+    fn propose_categories_from_suffixes() {
+        let skills = vec![
+            FamilySkill {
+                name: "bdd-testing".into(),
+                path: "x".into(),
+                lines: 1,
+                description: String::new(),
+                content: String::new(),
+            },
+            FamilySkill {
+                name: "bdd-unit-runner".into(),
+                path: "x".into(),
+                lines: 1,
+                description: String::new(),
+                content: String::new(),
+            },
+        ];
+        assert_eq!(propose_categories(&skills), vec!["testing", "unit"]);
+    }
+
+    #[test]
+    fn propose_categories_default_when_no_suffix() {
+        let skills = vec![FamilySkill {
+            name: "bdd".into(),
+            path: "x".into(),
+            lines: 1,
+            description: String::new(),
+            content: String::new(),
+        }];
+        assert_eq!(propose_categories(&skills), vec!["core", "advanced"]);
+    }
+
+    #[test]
+    fn average_duplication_zero_for_single_skill() {
+        let skills = vec![FamilySkill {
+            name: "bdd".into(),
+            path: "x".into(),
+            lines: 1,
+            description: String::new(),
+            content: "a\nb\n".into(),
+        }];
+        assert_eq!(average_duplication(&skills), 0);
+    }
+
+    #[test]
+    fn render_plan_contains_summary_and_reduction() {
+        let skills = vec![
+            FamilySkill {
+                name: "bdd-testing".into(),
+                path: "x".into(),
+                lines: 700,
+                description: "short".into(),
+                content: "one\ntwo\n".into(),
+            },
+            FamilySkill {
+                name: "bdd-unit".into(),
+                path: "x".into(),
+                lines: 700,
+                description: "short".into(),
+                content: "one\ntwo\n".into(),
+            },
+        ];
+        let out = render_plan("bdd", &skills, average_duplication(&skills));
+        assert!(out.contains("# Aggregation Plan: bdd"));
+        assert!(out.contains("- **Source Skills**: 2"));
+        assert!(out.contains("- **Total Lines**: 1400"));
+        // refs = round(1400/350)=4, new_total=65+800=865, reduction=(1-865/1400)*100=38.2
+        assert!(out.contains("Estimated Reduction**: 38.2%"), "got:\n{out}");
+    }
+}

--- a/crates/skill-auditor/src/lib.rs
+++ b/crates/skill-auditor/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod duplication;
 pub mod install_cmd;
+pub mod prune;
 pub mod reporter;
 pub mod scorer;
 pub mod skill_bundle;

--- a/crates/skill-auditor/src/lib.rs
+++ b/crates/skill-auditor/src/lib.rs
@@ -3,6 +3,7 @@
 //! function of on-disk content plus the `skill-validator-rs` analysis; no LLM or
 //! network access is involved anywhere.
 
+pub mod aggregation;
 pub mod duplication;
 pub mod install_cmd;
 pub mod prune;

--- a/crates/skill-auditor/src/main.rs
+++ b/crates/skill-auditor/src/main.rs
@@ -3,6 +3,7 @@
 //! `--repo-root` and (batch only) `--fail-below`.
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use skill_auditor::aggregation;
 use skill_auditor::duplication;
 use skill_auditor::install_cmd::{self, InstallOptions, Selection, UninstallOptions};
 use skill_auditor::prune;
@@ -69,6 +70,8 @@ enum Command {
     Duplication(DuplicationArgs),
     /// Prune old audit snapshots under .context/audits, keeping the most recent.
     PruneAudits(PruneAuditsArgs),
+    /// Draft an aggregation plan for a skill family (skills sharing a prefix).
+    PlanAggregation(PlanAggregationArgs),
     /// Manage the bundled companion skill.
     Skill {
         #[command(subcommand)]
@@ -90,6 +93,17 @@ struct PruneAuditsArgs {
     /// Repo root (auto-detected if empty).
     #[arg(long = "repo-root")]
     repo_root: Option<String>,
+}
+
+#[derive(Args)]
+struct PlanAggregationArgs {
+    /// Skill-family prefix (matches a skill named `<prefix>` or `<prefix>-*`).
+    #[arg(long)]
+    family: String,
+    /// Root directory to search (repeatable). Defaults to `skills` and
+    /// `.agents/skills`.
+    #[arg(long = "skills-dir", value_name = "DIR")]
+    skills_dir: Vec<String>,
 }
 
 #[derive(Args)]
@@ -220,6 +234,7 @@ fn main() {
         ),
         Command::Duplication(args) => run_duplication(args),
         Command::PruneAudits(args) => run_prune_audits(args),
+        Command::PlanAggregation(args) => run_plan_aggregation(args),
         Command::Skill {
             action: SkillAction::Install(args),
         } => run_skill_install(args),
@@ -393,9 +408,17 @@ fn run_prune_audits(args: PruneAuditsArgs) -> std::result::Result<(), String> {
     let plans = prune::prune(&audits_root, args.keep, args.dry_run).map_err(|e| e.to_string())?;
 
     if args.dry_run {
-        println!("Dry run: keeping {} per skill under {}\n", args.keep, audits_root.display());
+        println!(
+            "Dry run: keeping {} per skill under {}\n",
+            args.keep,
+            audits_root.display()
+        );
     } else {
-        println!("Keeping {} per skill under {}\n", args.keep, audits_root.display());
+        println!(
+            "Keeping {} per skill under {}\n",
+            args.keep,
+            audits_root.display()
+        );
     }
 
     let mut removed_total = 0;
@@ -407,7 +430,11 @@ fn run_prune_audits(args: PruneAuditsArgs) -> std::result::Result<(), String> {
             rel.display().to_string()
         };
         removed_total += p.removed.len();
-        let verb = if args.dry_run { "would remove" } else { "removed" };
+        let verb = if args.dry_run {
+            "would remove"
+        } else {
+            "removed"
+        };
         if p.removed.is_empty() {
             println!("  {label}: kept {} (nothing to prune)", p.kept.len());
         } else {
@@ -420,8 +447,36 @@ fn run_prune_audits(args: PruneAuditsArgs) -> std::result::Result<(), String> {
         }
     }
 
-    let verb = if args.dry_run { "would remove" } else { "removed" };
-    println!("\nDone. {verb} {removed_total} snapshot(s) across {} skill(s).", plans.len());
+    let verb = if args.dry_run {
+        "would remove"
+    } else {
+        "removed"
+    };
+    println!(
+        "\nDone. {verb} {removed_total} snapshot(s) across {} skill(s).",
+        plans.len()
+    );
+    Ok(())
+}
+
+/// Draft and print an aggregation plan for the `--family` prefix.
+fn run_plan_aggregation(args: PlanAggregationArgs) -> std::result::Result<(), String> {
+    let roots: Vec<PathBuf> = if args.skills_dir.is_empty() {
+        aggregation::default_roots()
+    } else {
+        args.skills_dir.iter().map(PathBuf::from).collect()
+    };
+
+    let skills = aggregation::find_family(&roots, &args.family);
+    if skills.is_empty() {
+        return Err(format!("No skills found with prefix: {}", args.family));
+    }
+
+    let duplication = aggregation::average_duplication(&skills);
+    print!(
+        "{}",
+        aggregation::render_plan(&args.family, &skills, duplication)
+    );
     Ok(())
 }
 

--- a/crates/skill-auditor/src/main.rs
+++ b/crates/skill-auditor/src/main.rs
@@ -5,6 +5,7 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use skill_auditor::duplication;
 use skill_auditor::install_cmd::{self, InstallOptions, Selection, UninstallOptions};
+use skill_auditor::prune;
 use skill_auditor::reporter;
 use skill_auditor::scorer::{self, grade_rank, Result as AuditResult};
 use skill_auditor::skill_bundle;
@@ -66,11 +67,29 @@ enum Command {
     },
     /// Detect duplication across skills (line-overlap or composite similarity).
     Duplication(DuplicationArgs),
+    /// Prune old audit snapshots under .context/audits, keeping the most recent.
+    PruneAudits(PruneAuditsArgs),
     /// Manage the bundled companion skill.
     Skill {
         #[command(subcommand)]
         action: SkillAction,
     },
+}
+
+#[derive(Args)]
+struct PruneAuditsArgs {
+    /// Number of snapshots to keep per skill.
+    #[arg(long, default_value_t = prune::DEFAULT_KEEP)]
+    keep: usize,
+    /// Audits root (defaults to `<repo-root>/.context/audits`).
+    #[arg(long = "audits-dir")]
+    audits_dir: Option<String>,
+    /// Report what would be removed without deleting anything.
+    #[arg(long = "dry-run")]
+    dry_run: bool,
+    /// Repo root (auto-detected if empty).
+    #[arg(long = "repo-root")]
+    repo_root: Option<String>,
 }
 
 #[derive(Args)]
@@ -200,6 +219,7 @@ fn main() {
             repo_root.as_deref(),
         ),
         Command::Duplication(args) => run_duplication(args),
+        Command::PruneAudits(args) => run_prune_audits(args),
         Command::Skill {
             action: SkillAction::Install(args),
         } => run_skill_install(args),
@@ -351,6 +371,58 @@ fn print_batch_table(entries: &mut [Entry]) {
         0
     };
     println!("Total: {} skill(s)  Average: {avg}/140", entries.len());
+}
+
+/// Prune old audit snapshots under `.context/audits`, keeping the most recent
+/// `--keep` per skill.
+fn run_prune_audits(args: PruneAuditsArgs) -> std::result::Result<(), String> {
+    let audits_root = match &args.audits_dir {
+        Some(dir) => PathBuf::from(dir),
+        None => {
+            let repo_root = resolve_repo_root(args.repo_root.as_deref())
+                .map_err(|e| format!("cannot determine repo root: {e}"))?;
+            repo_root.join(".context").join("audits")
+        }
+    };
+
+    if !audits_root.is_dir() {
+        println!("No audit directory found: {}", audits_root.display());
+        return Ok(());
+    }
+
+    let plans = prune::prune(&audits_root, args.keep, args.dry_run).map_err(|e| e.to_string())?;
+
+    if args.dry_run {
+        println!("Dry run: keeping {} per skill under {}\n", args.keep, audits_root.display());
+    } else {
+        println!("Keeping {} per skill under {}\n", args.keep, audits_root.display());
+    }
+
+    let mut removed_total = 0;
+    for p in &plans {
+        let rel = p.dir.strip_prefix(&audits_root).unwrap_or(&p.dir);
+        let label = if rel.as_os_str().is_empty() {
+            ".".to_string()
+        } else {
+            rel.display().to_string()
+        };
+        removed_total += p.removed.len();
+        let verb = if args.dry_run { "would remove" } else { "removed" };
+        if p.removed.is_empty() {
+            println!("  {label}: kept {} (nothing to prune)", p.kept.len());
+        } else {
+            println!(
+                "  {label}: kept {}, {verb} {} ({})",
+                p.kept.len(),
+                p.removed.len(),
+                p.removed.join(", ")
+            );
+        }
+    }
+
+    let verb = if args.dry_run { "would remove" } else { "removed" };
+    println!("\nDone. {verb} {removed_total} snapshot(s) across {} skill(s).", plans.len());
+    Ok(())
 }
 
 /// Detect and report duplication across the skills under `--skills-dir`.

--- a/crates/skill-auditor/src/prune.rs
+++ b/crates/skill-auditor/src/prune.rs
@@ -1,0 +1,189 @@
+//! Prune old audit snapshots under `.context/audits`.
+//!
+//! Ports `prune-audits.sh`, reconciled to the Rust reporter's on-disk layout.
+//! The shell assumed `.context/audits/skill-audit/<date>/` with a `latest`
+//! symlink; the Rust reporter (see `reporter::store`) writes
+//! `.context/audits/<skill>/<date>/`, where `<skill>` is a `domain/skill-name`
+//! path. This walks any depth and, for every directory that directly contains
+//! date-named snapshot subdirectories, keeps the `keep` most recent and removes
+//! the rest. ISO `YYYY-MM-DD` names sort lexicographically in date order, so
+//! "most recent" is a reverse name sort.
+
+use std::path::{Path, PathBuf};
+
+/// Default number of snapshots to retain per skill (matches the shell).
+pub const DEFAULT_KEEP: usize = 5;
+
+/// A directory of dated snapshots and the prune decision for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrunePlan {
+    /// The directory holding the dated snapshots (e.g. `.context/audits/d/s`).
+    pub dir: PathBuf,
+    /// Snapshot dates retained, most recent first.
+    pub kept: Vec<String>,
+    /// Snapshot dates marked for removal, most recent first.
+    pub removed: Vec<String>,
+}
+
+/// True when `s` is an ISO `YYYY-MM-DD` date name.
+fn is_date_name(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() == 10
+        && b[4] == b'-'
+        && b[7] == b'-'
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[8..].iter().all(u8::is_ascii_digit)
+}
+
+/// Immediate subdirectory names of `dir` (empty when unreadable).
+fn subdirs(dir: &Path) -> Vec<(String, PathBuf)> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<(String, PathBuf)> = entries
+        .flatten()
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|e| (e.file_name().to_string_lossy().into_owned(), e.path()))
+        .collect();
+    out.sort();
+    out
+}
+
+/// Compute the prune plans under `audits_root` without deleting anything.
+///
+/// A directory that directly contains one or more date-named subdirectories is
+/// a snapshot holder: its dated children are sorted most-recent-first, the
+/// first `keep` retained and the remainder marked for removal. Non-date
+/// subdirectories are recursed into (so nested `domain/skill/<date>` layouts are
+/// found); date subdirectories are treated as leaf snapshots.
+pub fn plan(audits_root: &Path, keep: usize) -> Vec<PrunePlan> {
+    let mut plans = Vec::new();
+    walk(audits_root, keep, &mut plans);
+    plans
+}
+
+fn walk(dir: &Path, keep: usize, plans: &mut Vec<PrunePlan>) {
+    let children = subdirs(dir);
+    let mut dates: Vec<String> = Vec::new();
+    for (name, path) in &children {
+        if is_date_name(name) {
+            dates.push(name.clone());
+        } else {
+            walk(path, keep, plans);
+        }
+    }
+    if dates.is_empty() {
+        return;
+    }
+    dates.sort_by(|a, b| b.cmp(a)); // most recent first
+    let (kept, removed) = if dates.len() > keep {
+        let removed = dates.split_off(keep);
+        (dates, removed)
+    } else {
+        (dates, Vec::new())
+    };
+    plans.push(PrunePlan {
+        dir: dir.to_path_buf(),
+        kept,
+        removed,
+    });
+}
+
+/// Execute the prune under `audits_root`. When `dry_run` is true the plans are
+/// computed but nothing is deleted. Returns the plans (including those with an
+/// empty `removed` list, so callers can report what was kept).
+pub fn prune(audits_root: &Path, keep: usize, dry_run: bool) -> std::io::Result<Vec<PrunePlan>> {
+    let plans = plan(audits_root, keep);
+    if !dry_run {
+        for p in &plans {
+            for date in &p.removed {
+                std::fs::remove_dir_all(p.dir.join(date))?;
+            }
+        }
+    }
+    Ok(plans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn mk_snapshot(root: &Path, skill: &str, date: &str) {
+        let dir = root.join(skill).join(date);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("audit.json"), "{}").unwrap();
+    }
+
+    #[test]
+    fn is_date_name_matches_iso_only() {
+        assert!(is_date_name("2026-07-22"));
+        assert!(!is_date_name("2026-7-22"));
+        assert!(!is_date_name("latest"));
+        assert!(!is_date_name("2026-07-22x"));
+    }
+
+    #[test]
+    fn keeps_most_recent_n() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        for d in ["2026-01-01", "2026-02-01", "2026-03-01", "2026-04-01"] {
+            mk_snapshot(root, "domain/skill", d);
+        }
+        let plans = plan(root, 2);
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].kept, vec!["2026-04-01", "2026-03-01"]);
+        assert_eq!(plans[0].removed, vec!["2026-02-01", "2026-01-01"]);
+    }
+
+    #[test]
+    fn nothing_removed_when_under_limit() {
+        let tmp = tempdir().unwrap();
+        mk_snapshot(tmp.path(), "domain/skill", "2026-01-01");
+        let plans = plan(tmp.path(), 5);
+        assert_eq!(plans.len(), 1);
+        assert!(plans[0].removed.is_empty());
+        assert_eq!(plans[0].kept, vec!["2026-01-01"]);
+    }
+
+    #[test]
+    fn prunes_multiple_skills_independently() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        for d in ["2026-01-01", "2026-02-01", "2026-03-01"] {
+            mk_snapshot(root, "a/one", d);
+        }
+        mk_snapshot(root, "b/two", "2026-01-01");
+        let plans = plan(root, 1);
+        let by_dir: std::collections::HashMap<_, _> =
+            plans.iter().map(|p| (p.dir.clone(), p)).collect();
+        assert_eq!(by_dir[&root.join("a/one")].removed.len(), 2);
+        assert_eq!(by_dir[&root.join("b/two")].removed.len(), 0);
+    }
+
+    #[test]
+    fn dry_run_removes_nothing() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        for d in ["2026-01-01", "2026-02-01", "2026-03-01"] {
+            mk_snapshot(root, "domain/skill", d);
+        }
+        prune(root, 1, true).unwrap();
+        assert!(root.join("domain/skill/2026-01-01").exists());
+    }
+
+    #[test]
+    fn prune_removes_old_snapshots() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        for d in ["2026-01-01", "2026-02-01", "2026-03-01"] {
+            mk_snapshot(root, "domain/skill", d);
+        }
+        prune(root, 1, false).unwrap();
+        assert!(!root.join("domain/skill/2026-01-01").exists());
+        assert!(!root.join("domain/skill/2026-02-01").exists());
+        assert!(root.join("domain/skill/2026-03-01").exists());
+    }
+}

--- a/docs/src/pages/tools.astro
+++ b/docs/src/pages/tools.astro
@@ -34,6 +34,7 @@ const tools: Tool[] = [
       { usage: "skill-auditor evaluate <skill>", summary: "Evaluate a single skill." },
       { usage: "skill-auditor batch <skill...>", summary: "Evaluate multiple skills, with an optional --fail-below grade gate." },
       { usage: "skill-auditor duplication [dir]", summary: "Detect duplicate skills by line-overlap or --enhanced composite similarity." },
+      { usage: "skill-auditor prune-audits", summary: "Keep the most recent N audit snapshots per skill under .context/audits." },
       { usage: "skill-auditor skill install", summary: "Register the bundled skill into detected agent directories." },
       { usage: "skill-auditor skill bundle", summary: "List the skill files embedded in the binary (--manifest for JSON)." },
     ],

--- a/docs/src/pages/tools.astro
+++ b/docs/src/pages/tools.astro
@@ -35,6 +35,7 @@ const tools: Tool[] = [
       { usage: "skill-auditor batch <skill...>", summary: "Evaluate multiple skills, with an optional --fail-below grade gate." },
       { usage: "skill-auditor duplication [dir]", summary: "Detect duplicate skills by line-overlap or --enhanced composite similarity." },
       { usage: "skill-auditor prune-audits", summary: "Keep the most recent N audit snapshots per skill under .context/audits." },
+      { usage: "skill-auditor plan-aggregation --family <prefix>", summary: "Draft an aggregation plan for a family of skills sharing a name prefix." },
       { usage: "skill-auditor skill install", summary: "Register the bundled skill into detected agent directories." },
       { usage: "skill-auditor skill bundle", summary: "List the skill files embedded in the binary (--manifest for JSON)." },
     ],


### PR DESCRIPTION
## What
Wave 3 ports the non-bundled audit-tooling scripts to `skill-auditor`, applying the bundled-data principle.

### `prune-audits`
`skill-auditor prune-audits [--keep N] [--audits-dir P] [--dry-run]` — ports `prune-audits.sh`, **reconciled to the Rust reporter's layout**. The shell assumed `.context/audits/skill-audit/<date>/` + a `latest` symlink; the Rust reporter writes `.context/audits/<skill>/<date>/` (skill may be nested `domain/skill`). The port walks any depth and, for every directory holding date-named snapshots, keeps the N most recent and removes the rest.

### `plan-aggregation`
`skill-auditor plan-aggregation --family <prefix>` — ports `plan-aggregation.sh` with two improvements:
- **Layout fix**: the shell scanned only immediate children of `skills/`, so on the nested `skills/<domain>/<skill>/` layout it matched nothing. This recurses and matches by directory name at any depth (verified against the real `fp-*` family — 3 skills found).
- **Engine reuse**: average duplication uses the shared `duplication` line-overlap engine instead of re-implementing the shell's bespoke normalisation.

## Deliberately kept as shell
`generate-remediation-plan.sh` — it emits a fill-in-the-blanks scaffold governed by the skill's **bundled** `remediation-plan-template.yaml` + `.schema.json` (the same skill-intrinsic workflow as the shell-kept `validate-remediation-plan`), and it overlaps the existing data-driven `reporter::remediation`. Not ported.

## Testing
- `cargo test -p skill-auditor` — 101 pass (12 new: 6 prune + 6 aggregation)
- `cargo clippy -p skill-auditor --all-targets` — clean
- Manual smoke tests of both commands (dry-run + real prune; fp-* family plan)

## Notes for reviewers
Decision-support tooling for skill authors; makes no participant-facing or regulated decisions.