### PR TITLE
fix(hk): resolve pre-commit friction from validate-artifacts + tracked tessl symlink

### DIFF
--- a/.github/skills/tessl__pr-comment-resolver
+++ b/.github/skills/tessl__pr-comment-resolver
@@ -1,1 +1,0 @@
-../../.tessl/tiles/sahildmk/pr-comment-resolver/skills/pr-comment-resolver

--- a/crates/skill-validator-rs/src/artifacts.rs
+++ b/crates/skill-validator-rs/src/artifacts.rs
@@ -358,6 +358,11 @@ fn check_subdirs(dir: &Path, dir_rel: &str, report: &mut ArtifactReport) {
     };
     for entry in entries.flatten().filter(is_dir) {
         let name = entry.file_name().to_string_lossy().into_owned();
+        // Dot-directories (e.g. `.tessl-plugin`) are skipped: the shell's `*/`
+        // glob does not match hidden entries, so they were never flagged.
+        if name.starts_with('.') {
+            continue;
+        }
         if !ALLOWED_SKILL_DIRS.contains(&name.as_str()) {
             report.error(
                 dir_rel,
@@ -378,6 +383,10 @@ fn check_assets(dir: &Path, dir_rel: &str, report: &mut ArtifactReport) {
     };
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().into_owned();
+        // Hidden entries are skipped by the shell's `*/` and `*.yaml` globs.
+        if name.starts_with('.') {
+            continue;
+        }
         if is_dir(&entry) {
             if !ALLOWED_ASSETS_DIRS.contains(&name.as_str()) {
                 report.error(
@@ -587,6 +596,20 @@ mod tests {
         assert!(report.results[0]
             .message
             .contains("non-standard directory 'weird'"));
+    }
+
+    #[test]
+    fn dot_directories_are_not_flagged() {
+        // `.tessl-plugin` (and any hidden dir) is skipped, matching the shell's
+        // `*/` glob which never matched dot-directories.
+        let dir = tempdir().unwrap();
+        let skill = dir.path().join("skills/d/my-skill");
+        write(&skill.join("SKILL.md"), "---\nname: my-skill\n---\nBody\n");
+        fs::create_dir_all(skill.join(".tessl-plugin")).unwrap();
+        write(&skill.join(".tessl-plugin/plugin.json"), "{}\n");
+        let mut report = ArtifactReport::default();
+        check_skill_dir(&skill, &mut report);
+        assert_eq!(report.errors(), 0, "{:?}", report.results);
     }
 
     #[test]

--- a/hk.pkl
+++ b/hk.pkl
@@ -31,6 +31,11 @@ local preCommit = new Mapping<String, Step> {
     // (Wave 2). Builds the Rust validator once (cached in target/release) then
     // invokes it; exit 1 = error (blocking), exit 0 = clean.
     ["skill-artifacts"] {
+        // Scoped to skill files so the step only runs (per-file) when a skill
+        // changes. Without a glob, a commit touching no skill files passes an
+        // empty {{files}}, which `validate artifacts` treats as a whole-tree
+        // scan and then blocks the commit on unrelated pre-existing findings.
+        glob = List("skills/**")
         shell = "sh -c"
         check = #"""
 if [ ! -x target/release/skill-validator-rs ]; then


### PR DESCRIPTION
## Problem
Committing while `.github/skills/tessl__pr-comment-resolver` was dirty made hk's pre-commit stash fail on every commit; and a commit touching no skill files made `validate artifacts` scan the whole tree and block on unrelated pre-existing findings. Both surfaced while landing Wave 4.

## Three coupled fixes

1. **Untrack `.github/skills/tessl__pr-comment-resolver`.** `.github/skills/` is gitignored (tessl-install-generated plugin symlinks). Four of the five symlinks there are correctly untracked; this one was accidentally committed and stayed tracked (an already-tracked file isn't ignored). That tracked-file-under-ignored-dir made `git stash --include-untracked` fail. Untracked now — the on-disk symlink is kept (tessl regenerates it) and it's consistent with its four siblings. It no longer shows as dirty at all.

2. **`validate artifacts` skips dot-directories.** The shell's `*/` glob never matched hidden entries, but the Rust port (Wave 2) used `read_dir`, so it flagged `.tessl-plugin/` (a legitimate tessl manifest dir) as "non-standard" in every skill — 86 false positives on a whole-tree scan. Now skipped in the skill-dir and `assets/` checks. Regression test added.

3. **Scope the hk `skill-artifacts` hook with `glob = skills/**`.** A commit with no skill files passed an empty `{{files}}`, which the validator treats as a whole-tree scan, blocking on unrelated findings. The hook now runs per-file only when a skill actually changes (matching the other skill hooks).

## Testing
- `cargo test -p skill-validator-rs` — all suites `0 failed` (new dot-dir regression test included)
- Verified the whole-tree scan no longer reports `.tessl-plugin`
- This PR's own commit passed hk cleanly with no workaround

## Notes for reviewers
Dev-tooling/hook hygiene only; no participant-facing or regulated impact. The pre-existing skill-content violations the whole-tree scan surfaced (shebangs, `../` refs in a few skills) are out of scope here and no longer block commits.