### PR TITLE
fix(skills): clean up 53 artifact-convention violations (#216)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ See `skills/agentic-harness/skill-quality-auditor/references/skill-taxonomy.md` 
 - `templates/`: YAML extensions (`.yaml` or `.yml`) only.
 - `schemas/`: JSON Schema files named `*.schema.json` with a `"$schema"` URL.
 - `scripts/`: Executable scripts with proper shebangs (sh/bash/python3/bun/node).
-- Skills must be self-contained: no `../` paths, no absolute `skills/X/Y` paths, no `.context/` or `.agents/` references in SKILL.md (code blocks exempt).
+- Skills must be self-contained: no `../` paths, no absolute `skills/X/Y` paths, no `.context/` or `.agents/` references in SKILL.md (fenced code blocks and inline code spans are exempt).
 
 ### Tessl Registry Preparation
 

--- a/crates/skill-validator-rs/src/artifacts.rs
+++ b/crates/skill-validator-rs/src/artifacts.rs
@@ -123,6 +123,14 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
+        // Dot-directories (e.g. `scripts/.tools/` holding vendored, gitignored
+        // binaries) are skipped: the shell's `**` globbing never descended into
+        // hidden path components, so their contents were never scanned. Matches
+        // the dot-directory skip already applied to check_subdirs / check_assets.
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with('.') {
+            continue;
+        }
         match entry.file_type() {
             Ok(t) if t.is_dir() => collect_files(&path, out),
             Ok(t) if t.is_file() => out.push(path),
@@ -456,9 +464,12 @@ fn frontmatter_name(content: &str) -> Option<String> {
     Some(cleaned)
 }
 
-/// True when `../` appears outside fenced code blocks. Lines from a ```` ``` ````
-/// fence to the next fence (inclusive) are removed first, matching the shell's
-/// `sed '/^```/,/^```/d'`.
+/// True when `../` appears outside code. Lines from a ```` ``` ```` fence to the
+/// next fence (inclusive) are removed first, matching the shell's
+/// `sed '/^```/,/^```/d'`. Backtick-delimited inline code spans are also stripped
+/// from each surviving line: illustrative snippets like `` `curl .../merge_requests` ``
+/// (an ellipsis, not a parent path) are examples, not skill dependencies, so they
+/// carry the same "inside code" exemption as fenced blocks.
 fn contains_parent_ref_outside_code(content: &str) -> bool {
     let mut in_fence = false;
     for line in content.lines() {
@@ -470,11 +481,29 @@ fn contains_parent_ref_outside_code(content: &str) -> bool {
         if in_fence {
             continue;
         }
-        if line.contains("../") {
+        if strip_inline_code(line).contains("../") {
             return true;
         }
     }
     false
+}
+
+/// Remove backtick-delimited inline code spans from a single line, leaving only
+/// prose. An unterminated backtick drops the remainder of the line (matching how
+/// Markdown renders a dangling span as literal text we conservatively ignore).
+fn strip_inline_code(line: &str) -> String {
+    let mut out = String::new();
+    let mut in_code = false;
+    for ch in line.chars() {
+        if ch == '`' {
+            in_code = !in_code;
+            continue;
+        }
+        if !in_code {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -638,6 +667,35 @@ mod tests {
     fn parent_ref_inside_code_ignored() {
         let content = "---\nname: s\n---\n```sh\ncat ../foo\n```\nClean prose.\n";
         assert!(!contains_parent_ref_outside_code(content));
+    }
+
+    #[test]
+    fn parent_ref_inside_inline_code_ignored() {
+        // An ellipsis inside an inline code span (`curl .../merge_requests`) is an
+        // illustrative snippet, not a parent-path dependency: it must not be flagged.
+        let content = "---\nname: s\n---\nUse `curl .../merge_requests` here.\n";
+        assert!(!contains_parent_ref_outside_code(content));
+    }
+
+    #[test]
+    fn parent_ref_in_prose_still_flagged_with_inline_code_present() {
+        // A real `../` in prose is still caught even when an inline span sits on the
+        // same line, so the inline-code exemption cannot mask a genuine reference.
+        let content = "---\nname: s\n---\nSee ../other and run `ls` now.\n";
+        assert!(contains_parent_ref_outside_code(content));
+    }
+
+    #[test]
+    fn tree_scan_skips_dot_directories() {
+        // A vendored binary under `scripts/.tools/` (gitignored in practice) must
+        // not be flagged as an unrecognised script type: the whole-tree scan skips
+        // hidden path components, matching the shell's `**` globbing.
+        let dir = tempdir().unwrap();
+        let skill = dir.path().join("skills/d/my-skill");
+        write(&skill.join("SKILL.md"), "---\nname: my-skill\n---\nBody\n");
+        write(&skill.join("scripts/.tools/actionlint"), "binary-ish\n");
+        let report = check_tree(&dir.path().join("skills"));
+        assert_eq!(report.errors(), 0, "{:?}", report.results);
     }
 
     #[test]

--- a/skills/ci-cd/azure-pipelines/validator/scripts/python_wrapper.sh
+++ b/skills/ci-cd/azure-pipelines/validator/scripts/python_wrapper.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091
+# ^ SC1091: sourced paths are resolved at runtime, not statically
 # Python Wrapper Script for Azure Pipelines Validator
 # Handles PyYAML and yamllint dependencies with transparent venv management
 #

--- a/skills/ci-cd/azure-pipelines/validator/scripts/validate_azure_pipelines.sh
+++ b/skills/ci-cd/azure-pipelines/validator/scripts/validate_azure_pipelines.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 #
 # Azure Pipelines Validator
 #
@@ -77,13 +78,13 @@ auto_detect_files() {
 
     local count=${#files[@]}
 
-    if [ $count -eq 0 ]; then
+    if [ "$count" -eq 0 ]; then
         echo -e "${YELLOW}No Azure Pipelines files found.${NC}"
         echo ""
         echo "Searched for: azure-pipelines*.yml, azure-pipelines*.yaml"
         echo "Please specify a file path or create an azure-pipelines.yml file."
         exit 2
-    elif [ $count -eq 1 ]; then
+    elif [ "$count" -eq 1 ]; then
         FILE_PATH="${files[0]}"
         echo -e "${BLUE}Auto-detected:${NC} $FILE_PATH"
         echo ""

--- a/skills/ci-cd/azure-pipelines/validator/scripts/yamllint_check.sh
+++ b/skills/ci-cd/azure-pipelines/validator/scripts/yamllint_check.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091
+# ^ SC1091: sourced paths are resolved at runtime, not statically
 # YAML Lint Check Script for Azure Pipelines
 # Runs yamllint with Azure Pipelines-specific configuration
 #

--- a/skills/ci-cd/fluentbit/validator/scripts/validate.sh
+++ b/skills/ci-cd/fluentbit/validator/scripts/validate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 #
 # Fluent Bit Config Validator - Convenience Wrapper Script
 #

--- a/skills/ci-cd/github-actions/validator/scripts/install_tools.sh
+++ b/skills/ci-cd/github-actions/validator/scripts/install_tools.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 # GitHub Actions Validator - Tool Installation Script
 # Installs act and actionlint tools locally in the current directory
 

--- a/skills/ci-cd/github-actions/validator/scripts/validate_workflow.sh
+++ b/skills/ci-cd/github-actions/validator/scripts/validate_workflow.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2034
+# ^ SC2034: vars consumed by scripts that source this file
 # GitHub Actions Validator - Workflow Validation Script
 # Validates GitHub Actions workflows using actionlint and act
 # Includes version checking and reference file hints
@@ -131,8 +134,10 @@ check_action_versions() {
                     local current_version="${version_info%%:*}"
                     local minimum_version="${version_info##*:}"
 
-                    local current_major=$(get_major_version "$current_version")
-                    local minimum_major=$(get_major_version "$minimum_version")
+                    local current_major
+                    current_major=$(get_major_version "$current_version")
+                    local minimum_major
+                    minimum_major=$(get_major_version "$minimum_version")
 
                     # Handle SHA pinning - extract version from comment if present
                     local used_major=""
@@ -298,7 +303,8 @@ validate_with_actionlint() {
     local workflow_path=$1
     log_section "Running actionlint"
 
-    local actionlint_path=$(get_tool_path "actionlint")
+    local actionlint_path
+    actionlint_path=$(get_tool_path "actionlint")
 
     if [ -f "$workflow_path" ]; then
         log_info "Validating: $workflow_path"
@@ -353,7 +359,8 @@ test_with_act() {
         return 1
     fi
 
-    local act_path=$(get_tool_path "act")
+    local act_path
+    act_path=$(get_tool_path "act")
 
     # Convert workflow_path to absolute path
     local abs_workflow_path="$workflow_path"
@@ -411,7 +418,7 @@ test_with_act() {
         # Check if the file is inside .github/workflows
         if [[ "$abs_workflow_path" == *"/.github/workflows/"* ]]; then
             # File is in .github/workflows - use -W flag with relative path
-            workflow_flag="-W ${abs_workflow_path#$repo_root/}"
+            workflow_flag="-W ${abs_workflow_path#"$repo_root"/}"
             target_description="workflow: $(basename "$abs_workflow_path")"
         else
             # File is outside .github/workflows (e.g., examples/)
@@ -438,7 +445,8 @@ test_with_act() {
     fi
 
     # Save current directory
-    local original_dir="$(pwd)"
+    local original_dir
+    original_dir="$(pwd)"
 
     # Change to repository root for act
     cd "$repo_root" || {
@@ -497,7 +505,7 @@ test_with_act() {
     # Interpret results
     if [ $act_exit_code -eq 0 ]; then
         log_info "✓ act validation passed"
-        cd "$original_dir"
+        cd "$original_dir" || return 1
         return 0
     else
         # Check for specific error conditions
@@ -505,12 +513,12 @@ test_with_act() {
             log_error "✗ act encountered EOF error"
             log_warn "This should not happen with -P flags set"
             log_info "Try running: act --list manually to diagnose"
-            cd "$original_dir"
+            cd "$original_dir" || return 1
             return 1
         elif echo "$act_output" | grep -q "unable to get git repo"; then
             log_warn "Not a git repository - some act features limited"
             log_info "act validation completed with warnings"
-            cd "$original_dir"
+            cd "$original_dir" || return 1
             return 0
         elif echo "$act_output" | grep -qi "pull access denied\|image.*not found"; then
             log_error "✗ Docker image pull failed"
@@ -518,7 +526,7 @@ test_with_act() {
             log_warn "  - Docker registry connectivity issues"
             log_warn "  - Rate limiting"
             log_warn "First-time run will download ~500MB of images"
-            cd "$original_dir"
+            cd "$original_dir" || return 1
             return 1
         elif echo "$act_output" | grep -qi "error\|failed"; then
             log_error "✗ act validation failed (exit code: $act_exit_code)"
@@ -527,11 +535,11 @@ test_with_act() {
             log_warn "  - Invalid action references"
             log_warn "  - Docker image issues"
             log_warn "  - Configuration problems"
-            cd "$original_dir"
+            cd "$original_dir" || return 1
             return 1
         else
             log_warn "act completed with warnings (exit code: $act_exit_code)"
-            cd "$original_dir"
+            cd "$original_dir" || return 1
             return 0
         fi
     fi

--- a/skills/ci-cd/gitlab-ci/validator/scripts/install_tools.sh
+++ b/skills/ci-cd/gitlab-ci/validator/scripts/install_tools.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 
 #
 # GitLab CI Validator - Tool Installation Script

--- a/skills/ci-cd/gitlab-ci/validator/scripts/python_wrapper.sh
+++ b/skills/ci-cd/gitlab-ci/validator/scripts/python_wrapper.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091
+# ^ SC1091: sourced paths are resolved at runtime, not statically
 # Wrapper script that handles PyYAML dependency
 # Creates a persistent venv if PyYAML is not available
 

--- a/skills/ci-cd/gitlab-ci/validator/scripts/validate_gitlab_ci.sh
+++ b/skills/ci-cd/gitlab-ci/validator/scripts/validate_gitlab_ci.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2329
+# ^ SC2329: functions invoked by scripts that source this file
 
 #
 # GitLab CI/CD Validator - Main Orchestrator Script

--- a/skills/ci-cd/helm/generator/scripts/generate_chart_structure.sh
+++ b/skills/ci-cd/helm/generator/scripts/generate_chart_structure.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 
 # Script to scaffold basic Helm chart directory structure
 # Usage: bash generate_chart_structure.sh <chart-name> <output-directory> [options]

--- a/skills/ci-cd/helm/generator/scripts/generate_standard_helpers.sh
+++ b/skills/ci-cd/helm/generator/scripts/generate_standard_helpers.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 
 # Script to generate standard Helm helpers (_helpers.tpl)
 # Usage: bash generate_standard_helpers.sh <chart-name> <chart-directory> [options]

--- a/skills/ci-cd/helm/validator/scripts/detect_crd_wrapper.sh
+++ b/skills/ci-cd/helm/validator/scripts/detect_crd_wrapper.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091
+# ^ SC1091: sourced paths are resolved at runtime, not statically
 # Wrapper script for detect_crd.py that handles PyYAML dependency
 # Creates a temporary venv if PyYAML is not available
 
@@ -24,7 +27,7 @@ fi
 
 # PyYAML not available, create temporary venv
 TEMP_VENV=$(mktemp -d -t helm-validator.XXXXXX)
-trap "rm -rf $TEMP_VENV" EXIT
+trap 'rm -rf "$TEMP_VENV"' EXIT
 
 echo "PyYAML not found in system Python. Creating temporary environment..." >&2
 

--- a/skills/ci-cd/helm/validator/scripts/generate_helpers.sh
+++ b/skills/ci-cd/helm/validator/scripts/generate_helpers.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 # Generate standard Helm helpers (_helpers.tpl) for a chart
 
 set -e

--- a/skills/ci-cd/helm/validator/scripts/setup_tools.sh
+++ b/skills/ci-cd/helm/validator/scripts/setup_tools.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 # Check for required Helm validation tools and provide installation instructions
 
 set -e

--- a/skills/ci-cd/helm/validator/scripts/validate_chart_structure.sh
+++ b/skills/ci-cd/helm/validator/scripts/validate_chart_structure.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 # Validate Helm chart directory structure
 
 set -e

--- a/skills/ci-cd/jenkinsfile/generator/scripts/lib/common_patterns.py
+++ b/skills/ci-cd/jenkinsfile/generator/scripts/lib/common_patterns.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Common Jenkins pipeline patterns and templates
 """

--- a/skills/ci-cd/jenkinsfile/generator/scripts/lib/syntax_helpers.py
+++ b/skills/ci-cd/jenkinsfile/generator/scripts/lib/syntax_helpers.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Helper functions for generating proper Groovy/Jenkins syntax
 """

--- a/skills/ci-cd/jenkinsfile/validator/scripts/best_practices.sh
+++ b/skills/ci-cd/jenkinsfile/validator/scripts/best_practices.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 
 # Best Practices Checker
 # Checks Jenkins pipelines against best practices from official documentation
@@ -126,9 +127,10 @@ get_code_without_comments() {
 check_combined_shell_commands() {
     local file=$1
     # Only count actual sh/bat steps, not comments
-    local sh_count=$(get_code_without_comments "$file" | grep -cE '^\s*(sh|bat)\s+["\047]' || true)
+    local sh_count
+    sh_count=$(get_code_without_comments "$file" | grep -cE '^\s*(sh|bat)\s+["\047]' || true)
 
-    if [ $sh_count -gt 5 ]; then
+    if [ "$sh_count" -gt 5 ]; then
         log_warning "Performance" "Found $sh_count individual sh/bat steps - consider combining them"
         log_warning "Performance" "  → Use single sh step with triple-quoted multi-line string"
         log_warning "Performance" "  → This reduces overhead and improves performance"
@@ -200,7 +202,8 @@ check_credential_management() {
 check_parallel_execution() {
     local file=$1
     # Only count actual stage definitions, not comments
-    local stage_count=$(get_code_without_comments "$file" | grep -cE '^\s*stage[\s\(]' || true)
+    local stage_count
+    stage_count=$(get_code_without_comments "$file" | grep -cE '^\s*stage[\s\(]' || true)
 
     # Check for actual parallel block usage, not just mentions in comments
     if get_code_without_comments "$file" | grep -qE '^\s*parallel\s*[\(\{]|parallel\s*:'; then
@@ -220,7 +223,7 @@ check_parallel_execution() {
                 log_info "Optimization" "  → Stops remaining parallel tasks on first failure"
             fi
         fi
-    elif [ $stage_count -gt 4 ]; then
+    elif [ "$stage_count" -gt 4 ]; then
         log_info "Optimization" "Found $stage_count stages - consider parallel execution for independent stages"
         log_info "Optimization" "  → Can significantly reduce build time"
     fi
@@ -419,20 +422,22 @@ check_security_practices() {
 # 15. Check for maintainability
 check_maintainability() {
     local file=$1
-    local line_count=$(wc -l < "$file" | tr -d ' ')
+    local line_count
+    line_count=$(wc -l < "$file" | tr -d ' ')
 
-    if [ $line_count -gt 500 ]; then
+    if [ "$line_count" -gt 500 ]; then
         log_warning "Maintainability" "Pipeline is $line_count lines - consider breaking into shared libraries"
         log_warning "Maintainability" "  → Use @Library for reusable code"
-    elif [ $line_count -gt 300 ]; then
+    elif [ "$line_count" -gt 300 ]; then
         log_info "Maintainability" "Pipeline is $line_count lines - watch for complexity growth"
     else
         log_pass "Pipeline size is manageable ($line_count lines)"
     fi
 
     # Check for comments
-    local comment_count=$(grep -cE '^\s*//' "$file" || true)
-    if [ $comment_count -lt 3 ] && [ $line_count -gt 100 ]; then
+    local comment_count
+    comment_count=$(grep -cE '^\s*//' "$file" || true)
+    if [ "$comment_count" -lt 3 ] && [ "$line_count" -gt 100 ]; then
         log_info "Maintainability" "Few comments detected - add comments for complex logic"
     fi
 }

--- a/skills/ci-cd/jenkinsfile/validator/scripts/common_validation.sh
+++ b/skills/ci-cd/jenkinsfile/validator/scripts/common_validation.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2034
+# ^ SC2034: vars consumed by scripts that source this file
 
 # Common Validation Functions
 # Shared validation functions for both Declarative and Scripted pipelines
@@ -51,7 +54,8 @@ detect_pipeline_type() {
     local file=$1
 
     # Remove comments and empty lines
-    local first_meaningful=$(grep -v '^\s*//' "$file" | grep -v '^\s*$' | head -1)
+    local first_meaningful
+    first_meaningful=$(grep -v '^\s*//' "$file" | grep -v '^\s*$' | head -1)
 
     if echo "$first_meaningful" | grep -q '^\s*pipeline\s*{'; then
         echo "declarative"
@@ -317,13 +321,15 @@ check_variable_usage() {
 
         # Track variable definitions
         if echo "$line" | grep -qE '(def|String|Integer|Boolean)\s+[a-zA-Z_][a-zA-Z0-9_]*\s*='; then
-            local var_name=$(echo "$line" | grep -oE '[a-zA-Z_][a-zA-Z0-9_]*\s*=' | sed 's/\s*=//')
+            local var_name
+            var_name=$(echo "$line" | grep -oE '[a-zA-Z_][a-zA-Z0-9_]*\s*=' | sed 's/\s*=//')
             defined_vars["$var_name"]=$line_num
         fi
 
         # Track variable usage (simple heuristic)
         if echo "$line" | grep -qE '\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?'; then
-            local vars=$(echo "$line" | grep -oE '\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?' | sed 's/[\${}]//g')
+            local vars
+            vars=$(echo "$line" | grep -oE '\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?' | sed 's/[\${}]//g')
             for var in $vars; do
                 used_vars["$var"]=$line_num
             done
@@ -331,7 +337,8 @@ check_variable_usage() {
 
         # Check for undefined variables being used
         if echo "$line" | grep -qE '\$[a-zA-Z_][a-zA-Z0-9_]*' && ! echo "$line" | grep -qE '(def|String|params\.|env\.)'; then
-            local var=$(echo "$line" | grep -oE '\$[a-zA-Z_][a-zA-Z0-9_]*' | sed 's/\$//' | head -1)
+            local var
+            var=$(echo "$line" | grep -oE '\$[a-zA-Z_][a-zA-Z0-9_]*' | sed 's/\$//' | head -1)
             if [[ ! -v defined_vars["$var"] ]] && [[ "$var" != "WORKSPACE" ]] && [[ "$var" != "BUILD_NUMBER" ]] && [[ "$var" != "JOB_NAME" ]]; then
                 log_info "$line_num" "Variable '\$$var' used but not explicitly defined - ensure it's set by environment"
             fi
@@ -371,7 +378,8 @@ detect_plugins() {
 
     for pattern in "${plugin_patterns[@]}"; do
         if grep -q "$pattern" "$file"; then
-            local plugin_name=$(echo "$pattern" | sed 's/[\.\\].*$//' | sed 's/ $//')
+            local plugin_name
+            plugin_name=$(echo "$pattern" | sed 's/[\.\\].*$//' | sed 's/ $//')
             plugins["$plugin_name"]=1
         fi
     done

--- a/skills/ci-cd/jenkinsfile/validator/scripts/validate_declarative.sh
+++ b/skills/ci-cd/jenkinsfile/validator/scripts/validate_declarative.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2034
+# ^ SC2034: vars consumed by scripts that source this file
+# shellcheck disable=SC2094
+# ^ SC2094: reads the same file in several commands; every access is a read, none writes it
 
 # Declarative Pipeline Validator
 # Validates Jenkins Declarative Pipeline syntax and structure
@@ -56,7 +61,8 @@ validate_pipeline_block() {
     local file=$1
 
     # Remove comments and empty lines for checking
-    local first_meaningful=$(grep -v '^\s*//' "$file" | grep -v '^\s*$' | head -1)
+    local first_meaningful
+    first_meaningful=$(grep -v '^\s*//' "$file" | grep -v '^\s*$' | head -1)
 
     if ! echo "$first_meaningful" | grep -q '^\s*pipeline\s*{'; then
         log_error 1 "Declarative pipeline must start with 'pipeline {' block"
@@ -72,7 +78,8 @@ validate_required_sections() {
 
     # Check for agent section
     if ! grep -q '^\s*agent\s' "$file"; then
-        local line=$(grep -n 'pipeline\s*{' "$file" | head -1 | cut -d: -f1)
+        local line
+        line=$(grep -n 'pipeline\s*{' "$file" | head -1 | cut -d: -f1)
         # Default to line 1 if pipeline block not found
         line=${line:-1}
         log_error "$line" "Missing required section 'agent' - must be defined at pipeline or stage level"
@@ -81,7 +88,8 @@ validate_required_sections() {
 
     # Check for stages section
     if ! grep -q '^\s*stages\s*{' "$file"; then
-        local line=$(grep -n 'pipeline\s*{' "$file" | head -1 | cut -d: -f1)
+        local line
+        line=$(grep -n 'pipeline\s*{' "$file" | head -1 | cut -d: -f1)
         # Default to line 1 if pipeline block not found
         line=${line:-1}
         log_error "$line" "Missing required section 'stages'"
@@ -91,7 +99,8 @@ validate_required_sections() {
     # If stages exists, check for at least one stage
     if grep -q '^\s*stages\s*{' "$file"; then
         if ! grep -q '^\s*stage(' "$file"; then
-            local line=$(grep -n 'stages\s*{' "$file" | head -1 | cut -d: -f1)
+            local line
+            line=$(grep -n 'stages\s*{' "$file" | head -1 | cut -d: -f1)
             line=${line:-1}
             log_error "$line" "stages block must contain at least one stage"
             log_error "$line" "  → Add 'stage('name') { ... }' inside stages block"
@@ -123,15 +132,18 @@ validate_stages() {
 
             # Initialize brace depth - account for opening brace on stage line itself
             # e.g., stage('Build') { has one opening brace
-            local stage_open_braces=$(echo "$line" | grep -o '{' | wc -l)
-            local stage_close_braces=$(echo "$line" | grep -o '}' | wc -l)
+            local stage_open_braces
+            stage_open_braces=$(echo "$line" | grep -o '{' | wc -l)
+            local stage_close_braces
+            stage_close_braces=$(echo "$line" | grep -o '}' | wc -l)
             local brace_depth=$((stage_open_braces - stage_close_braces))
 
             # Look for steps, parallel, or script blocks within this stage
             # Use brace depth tracking to find the stage boundary correctly
             for ((i=0; i<100; i++)); do
                 ((check_line++))
-                local next_line=$(sed -n "${check_line}p" "$file")
+                local next_line
+                next_line=$(sed -n "${check_line}p" "$file")
 
                 # Skip empty lines and comments
                 if echo "$next_line" | grep -qE '^\s*(//.*)?$'; then
@@ -139,8 +151,10 @@ validate_stages() {
                 fi
 
                 # Track brace depth
-                local open_braces=$(echo "$next_line" | grep -o '{' | wc -l)
-                local close_braces=$(echo "$next_line" | grep -o '}' | wc -l)
+                local open_braces
+                open_braces=$(echo "$next_line" | grep -o '{' | wc -l)
+                local close_braces
+                close_braces=$(echo "$next_line" | grep -o '}' | wc -l)
                 brace_depth=$((brace_depth + open_braces - close_braces))
 
                 # Check for valid stage body types at the stage level (brace_depth == 1)
@@ -185,7 +199,8 @@ validate_stages() {
 
                 for ((j=0; j<50 && look_back>1; j++)); do
                     ((look_back--))
-                    local prev_line=$(sed -n "${look_back}p" "$file")
+                    local prev_line
+                    prev_line=$(sed -n "${look_back}p" "$file")
 
                     if echo "$prev_line" | grep -qE '^\s*parallel\s*\{'; then
                         is_nested_in_parallel=true
@@ -277,9 +292,12 @@ validate_syntax() {
         fi
 
         # Remove escaped quotes before counting
-        local clean_line=$(echo "$line" | sed "s/\\\\'//g" | sed 's/\\"//g')
-        local single_quotes=$(echo "$clean_line" | grep -o "'" | wc -l)
-        local double_quotes=$(echo "$clean_line" | grep -o '"' | wc -l)
+        local clean_line
+        clean_line=$(echo "$line" | sed "s/\\\\'//g" | sed 's/\\"//g')
+        local single_quotes
+        single_quotes=$(echo "$clean_line" | grep -o "'" | wc -l)
+        local double_quotes
+        double_quotes=$(echo "$clean_line" | grep -o '"' | wc -l)
 
         # Only flag truly unbalanced quotes (not in multi-line contexts)
         # Skip if line has shell command patterns that commonly span lines
@@ -301,7 +319,8 @@ validate_syntax() {
         # Only flag when followed by { (not function calls like step([...]))
         # Note: 'stage' is valid as stage('name'), so we check specifically for 'stage {'
         if echo "$line" | grep -qE '^\s*(option|parameter|trigger|tool)\s*\{'; then
-            local typo=$(echo "$line" | grep -oE '(option|parameter|trigger|tool)')
+            local typo
+            typo=$(echo "$line" | grep -oE '(option|parameter|trigger|tool)')
             log_error "$line_num" "Possible typo: '$typo' (did you mean '${typo}s'?)"
         fi
         # Special check for 'step {' (not step( which is valid)
@@ -345,7 +364,8 @@ validate_parallel() {
     local file=$1
 
     if grep -q '^\s*parallel\s*{' "$file"; then
-        local line=$(grep -n 'parallel\s*{' "$file" | head -1 | cut -d: -f1)
+        local line
+        line=$(grep -n 'parallel\s*{' "$file" | head -1 | cut -d: -f1)
 
         # Check for parallelsAlwaysFailFast() in pipeline options (global setting)
         local has_global_failfast=false
@@ -391,7 +411,8 @@ validate_when() {
 
             for ((i=0; i<10; i++)); do
                 ((check_line++))
-                local next_line=$(sed -n "${check_line}p" "$file")
+                local next_line
+                next_line=$(sed -n "${check_line}p" "$file")
 
                 if echo "$next_line" | grep -qE '^\s*(branch|environment|expression|tag|not|allOf|anyOf)'; then
                     has_condition=true
@@ -429,11 +450,14 @@ validate_matrix() {
             # Check matrix block structure
             for ((i=0; i<50; i++)); do
                 ((check_line++))
-                local next_line=$(sed -n "${check_line}p" "$file")
+                local next_line
+                next_line=$(sed -n "${check_line}p" "$file")
 
                 # Track braces
-                local open=$(echo "$next_line" | grep -o '{' | wc -l)
-                local close=$(echo "$next_line" | grep -o '}' | wc -l)
+                local open
+                open=$(echo "$next_line" | grep -o '{' | wc -l)
+                local close
+                close=$(echo "$next_line" | grep -o '}' | wc -l)
                 brace_count=$((brace_count + open - close))
 
                 if echo "$next_line" | grep -q '^\s*axes\s*{'; then
@@ -477,7 +501,8 @@ validate_matrix() {
 
             for ((i=0; i<10; i++)); do
                 ((check_line++))
-                local next_line=$(sed -n "${check_line}p" "$file")
+                local next_line
+                next_line=$(sed -n "${check_line}p" "$file")
 
                 if echo "$next_line" | grep -q '^\s*name\s'; then
                     has_name=true
@@ -511,7 +536,8 @@ validate_matrix() {
 
             for ((i=0; i<20; i++)); do
                 ((check_line++))
-                local next_line=$(sed -n "${check_line}p" "$file")
+                local next_line
+                next_line=$(sed -n "${check_line}p" "$file")
 
                 if echo "$next_line" | grep -q '^\s*exclude\s*{'; then
                     has_exclude=true

--- a/skills/ci-cd/jenkinsfile/validator/scripts/validate_jenkinsfile.sh
+++ b/skills/ci-cd/jenkinsfile/validator/scripts/validate_jenkinsfile.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2001
+# ^ SC2001: sed regex substitution is not expressible as shell parameter expansion
 
 # Jenkinsfile Validator - Main Orchestrator Script
 # Runs all validators in sequence with unified output

--- a/skills/ci-cd/jenkinsfile/validator/scripts/validate_scripted.sh
+++ b/skills/ci-cd/jenkinsfile/validator/scripts/validate_scripted.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2034
+# ^ SC2034: vars consumed by scripts that source this file
+# shellcheck disable=SC2094
+# ^ SC2094: reads the same file in several commands; every access is a read, none writes it
 
 # Scripted Pipeline Validator
 # Validates Jenkins Scripted Pipeline syntax and structure
@@ -65,8 +70,10 @@ validate_groovy_syntax() {
         fi
 
         # Check for unmatched braces (simple check)
-        local open_braces=$(echo "$line" | grep -o '{' | wc -l)
-        local close_braces=$(echo "$line" | grep -o '}' | wc -l)
+        local open_braces
+        open_braces=$(echo "$line" | grep -o '{' | wc -l)
+        local close_braces
+        close_braces=$(echo "$line" | grep -o '}' | wc -l)
 
         # Check for unmatched quotes
         # Skip lines that are part of multi-line strings (triple quotes or heredocs)
@@ -80,9 +87,12 @@ validate_groovy_syntax() {
         fi
 
         # Remove escaped quotes before counting
-        local clean_line=$(echo "$line" | sed "s/\\\\'//g" | sed 's/\\"//g')
-        local single_quotes=$(echo "$clean_line" | grep -o "'" | wc -l)
-        local double_quotes=$(echo "$clean_line" | grep -o '"' | wc -l)
+        local clean_line
+        clean_line=$(echo "$line" | sed "s/\\\\'//g" | sed 's/\\"//g')
+        local single_quotes
+        single_quotes=$(echo "$clean_line" | grep -o "'" | wc -l)
+        local double_quotes
+        double_quotes=$(echo "$clean_line" | grep -o '"' | wc -l)
 
         # Only flag truly unbalanced quotes (not in multi-line contexts)
         if (( single_quotes % 2 != 0 )); then
@@ -104,8 +114,10 @@ validate_groovy_syntax() {
     done < "$file"
 
     # Check overall brace balance
-    local total_open=$(grep -o '{' "$file" | wc -l)
-    local total_close=$(grep -o '}' "$file" | wc -l)
+    local total_open
+    total_open=$(grep -o '{' "$file" | wc -l)
+    local total_close
+    total_close=$(grep -o '}' "$file" | wc -l)
 
     if (( total_open != total_close )); then
         log_error "EOF" "Unbalanced braces: $total_open opening, $total_close closing"
@@ -167,7 +179,8 @@ validate_error_handling() {
 
             for ((i=0; i<100; i++)); do
                 ((check_line++))
-                local next_line=$(sed -n "${check_line}p" "$file")
+                local next_line
+                next_line=$(sed -n "${check_line}p" "$file")
 
                 # Match catch with optional leading } for "} catch (" pattern
                 if echo "$next_line" | grep -qE 'catch\s*\('; then
@@ -198,11 +211,14 @@ validate_error_handling() {
 
             for ((i=0; i<100 && check_back>0; i++)); do
                 ((check_back--))
-                local prev_line=$(sed -n "${check_back}p" "$file")
+                local prev_line
+                prev_line=$(sed -n "${check_back}p" "$file")
 
                 # Track brace depth to understand scope
-                local close_braces=$(echo "$prev_line" | grep -o '}' | wc -l)
-                local open_braces=$(echo "$prev_line" | grep -o '{' | wc -l)
+                local close_braces
+                close_braces=$(echo "$prev_line" | grep -o '}' | wc -l)
+                local open_braces
+                open_braces=$(echo "$prev_line" | grep -o '{' | wc -l)
                 brace_depth=$((brace_depth + close_braces - open_braces))
 
                 # Check if we find a try block at the right depth
@@ -245,7 +261,8 @@ validate_noncps() {
 
             for ((i=0; i<30; i++)); do
                 ((check_line++))
-                local next_line=$(sed -n "${check_line}p" "$file")
+                local next_line
+                next_line=$(sed -n "${check_line}p" "$file")
 
                 # Check for async pipeline steps in @NonCPS method
                 if echo "$next_line" | grep -qE '\s+(sh|bat|sleep|timeout|node|stage)\s*["\047(]'; then
@@ -279,7 +296,8 @@ validate_variables() {
 
         # Track variables declared with def, String, Integer, Boolean, Map, List
         if echo "$line" | grep -qE '^\s*(def|String|Integer|Boolean|Map|List)\s+([a-zA-Z_][a-zA-Z0-9_]*)'; then
-            local var_name=$(echo "$line" | grep -oE '(def|String|Integer|Boolean|Map|List)\s+[a-zA-Z_][a-zA-Z0-9_]*' | awk '{print $2}')
+            local var_name
+            var_name=$(echo "$line" | grep -oE '(def|String|Integer|Boolean|Map|List)\s+[a-zA-Z_][a-zA-Z0-9_]*' | awk '{print $2}')
             if [[ -n "$var_name" ]]; then
                 declared_vars="$declared_vars:$var_name:"
             fi
@@ -301,7 +319,8 @@ validate_variables() {
             # Check if it's not a property assignment (has dot notation)
             if ! echo "$line" | grep -q '\.'; then
                 # Extract variable name
-                local var_name=$(echo "$line" | grep -oE '^\s*[a-zA-Z_][a-zA-Z0-9_]*' | tr -d ' ')
+                local var_name
+                var_name=$(echo "$line" | grep -oE '^\s*[a-zA-Z_][a-zA-Z0-9_]*' | tr -d ' ')
                 # Only warn if variable was not previously declared
                 if [[ "$declared_vars" != *":$var_name:"* ]]; then
                     log_info "$line_num" "Consider using 'def' for variable declaration for better scoping"

--- a/skills/ci-cd/jenkinsfile/validator/scripts/validate_shared_library.sh
+++ b/skills/ci-cd/jenkinsfile/validator/scripts/validate_shared_library.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2034
+# ^ SC2034: vars consumed by scripts that source this file
+# shellcheck disable=SC2094
+# ^ SC2094: reads the same file in several commands; every access is a read, none writes it
 
 # Shared Library Validator
 # Validates Jenkins Shared Library files (vars/*.groovy, src/**/*.groovy)
@@ -68,7 +73,8 @@ log_info() {
 # Detect file type within shared library
 detect_library_file_type() {
     local file=$1
-    local filepath=$(realpath "$file" 2>/dev/null || echo "$file")
+    local filepath
+    filepath=$(realpath "$file" 2>/dev/null || echo "$file")
 
     if [[ "$filepath" == */vars/*.groovy ]]; then
         echo "vars"
@@ -91,7 +97,8 @@ detect_library_file_type() {
 # Validate vars/*.groovy global variable files
 validate_vars_file() {
     local file=$1
-    local filename=$(basename "$file" .groovy)
+    local filename
+    filename=$(basename "$file" .groovy)
     local line_num=0
     local has_call_method=false
     local has_doc_comment=false
@@ -130,7 +137,8 @@ validate_vars_file() {
         # Check for @NonCPS annotation usage
         if echo "$line" | grep -q '@NonCPS'; then
             # Check next non-empty line for pipeline steps
-            local next_lines=$(tail -n +$((line_num + 1)) "$file" | head -20)
+            local next_lines
+            next_lines=$(tail -n +$((line_num + 1)) "$file" | head -20)
             if echo "$next_lines" | grep -qE '^\s*(sh|bat|echo|checkout|archiveArtifacts|junit|input|build)\s'; then
                 log_error "$line_num" "@NonCPS method contains pipeline steps (sh, echo, etc.)"
                 log_error "$line_num" "  → Pipeline steps cannot be used in @NonCPS methods"
@@ -141,7 +149,8 @@ validate_vars_file() {
         # Check for proper error handling in pipeline steps
         if echo "$line" | grep -qE '^\s*sh\s+["\047]'; then
             # Check if inside try block
-            local context=$(head -n $line_num "$file" | tail -20)
+            local context
+            context=$(head -n $line_num "$file" | tail -20)
             if ! echo "$context" | grep -q 'try\s*{'; then
                 log_info "$line_num" "Consider wrapping sh step in try-catch for error handling"
             fi
@@ -174,7 +183,8 @@ validate_vars_file() {
         # Check for proper CPS handling with closures
         if echo "$line" | grep -qE '\.(each|collect|find|findAll|any|every)\s*\{'; then
             # Check if marked @NonCPS
-            local prev_lines=$(head -n $line_num "$file" | tail -10)
+            local prev_lines
+            prev_lines=$(head -n $line_num "$file" | tail -10)
             if ! echo "$prev_lines" | grep -q '@NonCPS'; then
                 log_info "$line_num" "Groovy closure detected - ensure method is @NonCPS if not using pipeline steps"
                 log_info "$line_num" "  → Closures like .each{}, .collect{} require @NonCPS annotation"
@@ -214,7 +224,8 @@ validate_vars_file() {
 # Validate src/**/*.groovy class files
 validate_src_file() {
     local file=$1
-    local filename=$(basename "$file" .groovy)
+    local filename
+    filename=$(basename "$file" .groovy)
     local line_num=0
     local has_package=false
     local has_class=false
@@ -276,7 +287,8 @@ validate_src_file() {
     fi
 
     # Check class naming matches filename
-    local class_name=$(grep -oE '^\s*(class|interface|enum|trait)\s+([A-Z][a-zA-Z0-9]*)' "$file" | head -1 | awk '{print $2}')
+    local class_name
+    class_name=$(grep -oE '^\s*(class|interface|enum|trait)\s+([A-Z][a-zA-Z0-9]*)' "$file" | head -1 | awk '{print $2}')
     if [ -n "$class_name" ] && [ "$class_name" != "$filename" ]; then
         log_error "1" "Class name '$class_name' does not match filename '$filename'"
     fi
@@ -325,7 +337,8 @@ print_results() {
 # Validate a single file
 validate_file() {
     local file=$1
-    local file_type=$(detect_library_file_type "$file")
+    local file_type
+    file_type=$(detect_library_file_type "$file")
 
     case "$file_type" in
         vars)

--- a/skills/development/scripting/bash-script/generator/scripts/generate_script_template.sh
+++ b/skills/development/scripting/bash-script/generator/scripts/generate_script_template.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2012
+# ^ SC2012: ls is used for time-sorted / formatted listing; find -printf is non-portable (macOS)
 #
 # Generate bash script templates
 #
 
 set -euo pipefail
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
 readonly TEMPLATES_DIR="${SCRIPT_DIR}/../assets/templates"
 
 usage() {

--- a/skills/development/scripting/bash-script/validator/scripts/shellcheck_wrapper.sh
+++ b/skills/development/scripting/bash-script/validator/scripts/shellcheck_wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 #
 # ShellCheck Wrapper with Temporary Virtual Environment
 #

--- a/skills/development/scripting/bash-script/validator/scripts/validate.sh
+++ b/skills/development/scripting/bash-script/validator/scripts/validate.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2001
+# ^ SC2001: sed regex substitution is not expressible as shell parameter expansion
 #
 # Bash/Shell Script Validator
 # Validates bash and shell scripts for syntax errors, best practices, security issues, and optimizations
@@ -179,6 +182,7 @@ run_shellcheck() {
     fi
 
     local output
+    # shellcheck disable=SC2086  # word-splitting of the config/flag var is intentional
     if output=$($shellcheck_cmd $shell_arg -f gcc "$file" 2>&1); then
         print_success "No ShellCheck issues found"
         return 0

--- a/skills/development/scripting/makefile/generator/scripts/add_standard_targets.sh
+++ b/skills/development/scripting/makefile/generator/scripts/add_standard_targets.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2034
+# ^ SC2034: vars consumed by scripts that source this file
 #
 # add_standard_targets.sh
 # Description: Add standard GNU targets to an existing Makefile
@@ -11,8 +14,10 @@
 set -euo pipefail
 
 # Script metadata
-readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+readonly SCRIPT_NAME
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
 
 # Colors for output
 if [[ -t 1 ]]; then

--- a/skills/development/scripting/makefile/generator/scripts/generate_makefile_template.sh
+++ b/skills/development/scripting/makefile/generator/scripts/generate_makefile_template.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2034
+# ^ SC2034: vars consumed by scripts that source this file
 #
 # generate_makefile_template.sh
 # Description: Generate Makefile templates for different project types
@@ -8,8 +11,10 @@
 set -euo pipefail
 
 # Script metadata
-readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+readonly SCRIPT_NAME
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
 
 # Default values
 FORCE=0

--- a/skills/development/scripting/makefile/validator/scripts/validate_makefile.sh
+++ b/skills/development/scripting/makefile/validator/scripts/validate_makefile.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2016,SC2329
+# ^ SC2016: single quotes are intentional (literal, no expansion wanted); SC2329: functions invoked by scripts that source this file
 
 # Makefile Validator Script
 # Validates Makefile syntax, best practices, security, and optimization using mbake tool

--- a/skills/infrastructure/ansible/validator/scripts/check_fqcn.sh
+++ b/skills/infrastructure/ansible/validator/scripts/check_fqcn.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 
 # Ansible FQCN (Fully Qualified Collection Name) Checker
 # Identifies modules using short names instead of FQCN format
@@ -179,7 +180,8 @@ check_module() {
             echo "$results" | head -5 | while read -r line; do
                 echo "  $line"
             done
-            local count=$(echo "$results" | wc -l | tr -d ' ')
+            local count
+            count=$(echo "$results" | wc -l | tr -d ' ')
             if [ "$count" -gt 5 ]; then
                 echo "  ... and $((count - 5)) more occurrences"
             fi

--- a/skills/infrastructure/ansible/validator/scripts/extract_ansible_info_wrapper.sh
+++ b/skills/infrastructure/ansible/validator/scripts/extract_ansible_info_wrapper.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091
+# ^ SC1091: sourced paths are resolved at runtime, not statically
 # Wrapper script for extract_ansible_info.py that handles PyYAML dependency
 # Creates a temporary venv if PyYAML is not available
 
@@ -24,7 +27,7 @@ fi
 
 # PyYAML not available, create temporary venv
 TEMP_VENV=$(mktemp -d -t ansible-validator.XXXXXX)
-trap "rm -rf $TEMP_VENV" EXIT
+trap 'rm -rf "$TEMP_VENV"' EXIT
 
 echo "PyYAML not found in system Python. Creating temporary environment..." >&2
 

--- a/skills/infrastructure/ansible/validator/scripts/scan_secrets.sh
+++ b/skills/infrastructure/ansible/validator/scripts/scan_secrets.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 
 # Ansible Secret Scanner
 # Scans Ansible files for hardcoded secrets that Checkov may miss

--- a/skills/infrastructure/ansible/validator/scripts/setup_tools.sh
+++ b/skills/infrastructure/ansible/validator/scripts/setup_tools.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2329
+# ^ SC2329: functions invoked by scripts that source this file
 
 # Setup and validation tool for Ansible Validator
 # Checks for required tools and provides installation instructions

--- a/skills/infrastructure/ansible/validator/scripts/test_role.sh
+++ b/skills/infrastructure/ansible/validator/scripts/test_role.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091,SC2329
+# ^ SC1091: sourced paths are resolved at runtime, not statically; SC2329: functions invoked by scripts that source this file
 
 # Ansible Role Testing Script with Molecule
 # Automatically installs molecule in temporary venv if not available
@@ -86,7 +89,7 @@ else
 
     # Setup cleanup trap
     cleanup() {
-        if [ $CLEANUP_VENV -eq 1 ] && [ -n "$TEMP_VENV" ]; then
+        if [ "$CLEANUP_VENV" -eq 1 ] && [ -n "$TEMP_VENV" ]; then
             echo ""
             echo "Cleaning up temporary environment..."
             rm -rf "$TEMP_VENV"

--- a/skills/infrastructure/ansible/validator/scripts/validate_playbook.sh
+++ b/skills/infrastructure/ansible/validator/scripts/validate_playbook.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091,SC2329
+# ^ SC1091: sourced paths are resolved at runtime, not statically; SC2329: functions invoked by scripts that source this file
 
 # Comprehensive Ansible Playbook Validation Script
 # Automatically installs ansible and ansible-lint in temporary venv if not available
@@ -96,7 +99,7 @@ if [ $USE_SYSTEM_ANSIBLE -eq 0 ] || [ $USE_SYSTEM_ANSIBLE_LINT -eq 0 ]; then
 
     # Setup cleanup trap
     cleanup() {
-        if [ $CLEANUP_VENV -eq 1 ] && [ -n "$TEMP_VENV" ]; then
+        if [ "$CLEANUP_VENV" -eq 1 ] && [ -n "$TEMP_VENV" ]; then
             echo ""
             echo "Cleaning up temporary environment..."
             rm -rf "$TEMP_VENV"
@@ -145,6 +148,7 @@ if [ -n "$YAMLLINT_CMD" ]; then
         YAMLLINT_CONFIG=""
     fi
 
+    # shellcheck disable=SC2086  # word-splitting of the config/flag var is intentional
     if $YAMLLINT_CMD $YAMLLINT_CONFIG "$PLAYBOOK_ABS"; then
         echo -e "${COLOR_GREEN}✓ YAML syntax check passed${COLOR_RESET}"
     else
@@ -189,6 +193,7 @@ if [ $USE_SYSTEM_ANSIBLE_LINT -eq 1 ] || [ -n "$TEMP_VENV" ]; then
     fi
 
     # Run ansible-lint and capture exit code
+    # shellcheck disable=SC2086  # word-splitting of the config/flag var is intentional
     if run_ansible_lint $ANSIBLE_LINT_CONFIG "$PLAYBOOK_ABS"; then
         echo -e "${COLOR_GREEN}✓ Ansible lint check passed${COLOR_RESET}"
     else

--- a/skills/infrastructure/ansible/validator/scripts/validate_playbook_security.sh
+++ b/skills/infrastructure/ansible/validator/scripts/validate_playbook_security.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091,SC2034,SC2329
+# ^ SC1091: sourced paths are resolved at runtime, not statically; SC2034: vars consumed by scripts that source this file; SC2329: functions invoked by scripts that source this file
 
 # Ansible Playbook Security Validation Script using Checkov
 # Automatically installs checkov in temporary venv if not available
@@ -74,7 +77,7 @@ if [ $USE_SYSTEM_CHECKOV -eq 0 ]; then
 
     # Setup cleanup trap
     cleanup() {
-        if [ $CLEANUP_VENV -eq 1 ] && [ -n "$TEMP_VENV" ]; then
+        if [ "$CLEANUP_VENV" -eq 1 ] && [ -n "$TEMP_VENV" ]; then
             echo ""
             echo "Cleaning up temporary environment..."
             rm -rf "$TEMP_VENV"

--- a/skills/infrastructure/ansible/validator/scripts/validate_role.sh
+++ b/skills/infrastructure/ansible/validator/scripts/validate_role.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091,SC2034,SC2329
+# ^ SC1091: sourced paths are resolved at runtime, not statically; SC2034: vars consumed by scripts that source this file; SC2329: functions invoked by scripts that source this file
 
 # Comprehensive Ansible Role Validation Script
 # Automatically installs ansible and ansible-lint in temporary venv if not available
@@ -96,7 +99,7 @@ if [ $USE_SYSTEM_ANSIBLE -eq 0 ] || [ $USE_SYSTEM_ANSIBLE_LINT -eq 0 ]; then
 
     # Setup cleanup trap
     cleanup() {
-        if [ $CLEANUP_VENV -eq 1 ] && [ -n "$TEMP_VENV" ]; then
+        if [ "$CLEANUP_VENV" -eq 1 ] && [ -n "$TEMP_VENV" ]; then
             echo ""
             echo "Cleaning up temporary environment..."
             rm -rf "$TEMP_VENV"
@@ -205,6 +208,7 @@ if [ -n "$YAMLLINT_CMD" ]; then
     if [ -n "$YAML_FILES" ]; then
         YAML_ERRORS=0
         for file in $YAML_FILES; do
+            # shellcheck disable=SC2086  # word-splitting of the config/flag var is intentional
             if ! $YAMLLINT_CMD $YAMLLINT_CONFIG "$file" 2>&1 | grep -v "warning  found forbidden document start"; then
                 YAML_ERRORS=$((YAML_ERRORS + 1))
             fi
@@ -280,6 +284,7 @@ if [ $USE_SYSTEM_ANSIBLE_LINT -eq 1 ] || [ -n "$TEMP_VENV" ]; then
     fi
 
     # Run ansible-lint on the role
+    # shellcheck disable=SC2086  # word-splitting of the config/flag var is intentional
     if run_ansible_lint $ANSIBLE_LINT_CONFIG "$ROLE_ABS_PATH" 2>&1; then
         echo -e "${COLOR_GREEN}✓ Ansible lint check passed${COLOR_RESET}"
     else

--- a/skills/infrastructure/ansible/validator/scripts/validate_role_security.sh
+++ b/skills/infrastructure/ansible/validator/scripts/validate_role_security.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091,SC2034,SC2329
+# ^ SC1091: sourced paths are resolved at runtime, not statically; SC2034: vars consumed by scripts that source this file; SC2329: functions invoked by scripts that source this file
 
 # Ansible Role Security Validation Script using Checkov
 # Automatically installs checkov in temporary venv if not available
@@ -68,7 +71,7 @@ if [ $USE_SYSTEM_CHECKOV -eq 0 ]; then
 
     # Setup cleanup trap
     cleanup() {
-        if [ $CLEANUP_VENV -eq 1 ] && [ -n "$TEMP_VENV" ]; then
+        if [ "$CLEANUP_VENV" -eq 1 ] && [ -n "$TEMP_VENV" ]; then
             echo ""
             echo "Cleaning up temporary environment..."
             rm -rf "$TEMP_VENV"

--- a/skills/infrastructure/cfn/behavior-validator/scripts/compare-resources.sh
+++ b/skills/infrastructure/cfn/behavior-validator/scripts/compare-resources.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2012
+# ^ SC2012: ls is used for time-sorted / formatted listing; find -printf is non-portable (macOS)
 # Compare CloudFormation Resource Properties
 # Compares a specific resource's properties before and after a change
 

--- a/skills/infrastructure/cfn/behavior-validator/scripts/watch-cfn-events.sh
+++ b/skills/infrastructure/cfn/behavior-validator/scripts/watch-cfn-events.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 # CloudFormation Event Watcher
 # Watches CloudFormation events in real-time during stack updates
 

--- a/skills/infrastructure/cfn/template-compare/scripts/compare-cfn-templates.sh
+++ b/skills/infrastructure/cfn/template-compare/scripts/compare-cfn-templates.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2329
+# ^ SC2329: functions invoked by scripts that source this file
+# shellcheck disable=SC2129
+# ^ SC2129: sequential appends to the report file are intentional and readable here
 #
 # CloudFormation Template Comparison Script
 # 
@@ -103,7 +108,8 @@ retrieve_deployed_template() {
         exit 2
     fi
     
-    local line_count=$(wc -l < "$WORK_DIR/deployed.json")
+    local line_count
+    line_count=$(wc -l < "$WORK_DIR/deployed.json")
     log_success "Retrieved deployed template ($line_count lines)"
 }
 
@@ -124,7 +130,8 @@ locate_local_template() {
             exit 2
         fi
         
-        local template_count=$(find cdk.out -name "*.template.json" -type f | wc -l)
+        local template_count
+        template_count=$(find cdk.out -name "*.template.json" -type f | wc -l)
         
         if [ "$template_count" -eq 0 ]; then
             log_error "No CloudFormation templates found in cdk.out/"
@@ -138,7 +145,8 @@ locate_local_template() {
         cp cdk.out/*.template.json "$WORK_DIR/local.json"
     fi
     
-    local line_count=$(wc -l < "$WORK_DIR/local.json")
+    local line_count
+    line_count=$(wc -l < "$WORK_DIR/local.json")
     log_success "Located local template ($line_count lines)"
 }
 
@@ -164,8 +172,10 @@ compare_structure() {
 compare_resources() {
     log_info "Comparing resources..."
     
-    local deployed_count=$(jq -r '.Resources | keys | length' "$WORK_DIR/deployed.json")
-    local local_count=$(jq -r '.Resources | keys | length' "$WORK_DIR/local.json")
+    local deployed_count
+    deployed_count=$(jq -r '.Resources | keys | length' "$WORK_DIR/deployed.json")
+    local local_count
+    local_count=$(jq -r '.Resources | keys | length' "$WORK_DIR/local.json")
     
     echo "  Deployed: $deployed_count resources"
     echo "  Local:    $local_count resources"
@@ -175,9 +185,12 @@ compare_resources() {
     jq -r '.Resources | keys | sort[]' "$WORK_DIR/local.json" > "$WORK_DIR/local-resources.txt"
     
     # Find differences
-    local added=$(comm -13 "$WORK_DIR/deployed-resources.txt" "$WORK_DIR/local-resources.txt" 2>/dev/null | wc -l)
-    local removed=$(comm -23 "$WORK_DIR/deployed-resources.txt" "$WORK_DIR/local-resources.txt" 2>/dev/null | wc -l)
-    local common=$(comm -12 "$WORK_DIR/deployed-resources.txt" "$WORK_DIR/local-resources.txt" 2>/dev/null | wc -l)
+    local added
+    added=$(comm -13 "$WORK_DIR/deployed-resources.txt" "$WORK_DIR/local-resources.txt" 2>/dev/null | wc -l)
+    local removed
+    removed=$(comm -23 "$WORK_DIR/deployed-resources.txt" "$WORK_DIR/local-resources.txt" 2>/dev/null | wc -l)
+    local common
+    common=$(comm -12 "$WORK_DIR/deployed-resources.txt" "$WORK_DIR/local-resources.txt" 2>/dev/null | wc -l)
     
     echo "  Common:   $common resources"
     
@@ -203,8 +216,10 @@ compare_resources() {
 compare_cdk_nag() {
     log_info "Comparing CDK Nag suppressions..."
     
-    local deployed_suppressions=$(jq -r '[.Resources | to_entries[] | select(.value.Metadata.cdk_nag != null) | .key] | length' "$WORK_DIR/deployed.json")
-    local local_suppressions=$(jq -r '[.Resources | to_entries[] | select(.value.Metadata.cdk_nag != null) | .key] | length' "$WORK_DIR/local.json")
+    local deployed_suppressions
+    deployed_suppressions=$(jq -r '[.Resources | to_entries[] | select(.value.Metadata.cdk_nag != null) | .key] | length' "$WORK_DIR/deployed.json")
+    local local_suppressions
+    local_suppressions=$(jq -r '[.Resources | to_entries[] | select(.value.Metadata.cdk_nag != null) | .key] | length' "$WORK_DIR/local.json")
     
     echo "  Deployed: $deployed_suppressions resources with suppressions"
     echo "  Local:    $local_suppressions resources with suppressions"
@@ -224,8 +239,10 @@ analyze_renamed_resources() {
     local local_res="$2"
     
     # Extract base name without trailing hash (last 16 chars typically)
-    local deployed_base=$(echo "$deployed_res" | sed -E 's/[A-F0-9]{16}$//' | sed -E 's/[a-f0-9]{8}$//')
-    local local_base=$(echo "$local_res" | sed -E 's/[A-F0-9]{16}$//' | sed -E 's/[a-f0-9]{8}$//')
+    local deployed_base
+    deployed_base=$(echo "$deployed_res" | sed -E 's/[A-F0-9]{16}$//' | sed -E 's/[a-f0-9]{8}$//')
+    local local_base
+    local_base=$(echo "$local_res" | sed -E 's/[A-F0-9]{16}$//' | sed -E 's/[a-f0-9]{8}$//')
     
     # Check if base names are similar (allowing for small variations)
     if [ "$deployed_base" = "$local_base" ]; then
@@ -234,8 +251,10 @@ analyze_renamed_resources() {
     fi
     
     # Check if only difference is stack name suffix (e.g., lctmonitoringst vs lctmonitoringstthoroc)
-    local deployed_normalized=$(echo "$deployed_res" | sed -E 's/lctmonitoringst[a-z0-9]*/lctmonitoringst/' | sed -E 's/[A-F0-9]{16}$//' | sed -E 's/[a-f0-9]{8}$//')
-    local local_normalized=$(echo "$local_res" | sed -E 's/lctmonitoringst[a-z0-9]*/lctmonitoringst/' | sed -E 's/[A-F0-9]{16}$//' | sed -E 's/[a-f0-9]{8}$//')
+    local deployed_normalized
+    deployed_normalized=$(echo "$deployed_res" | sed -E 's/lctmonitoringst[a-z0-9]*/lctmonitoringst/' | sed -E 's/[A-F0-9]{16}$//' | sed -E 's/[a-f0-9]{8}$//')
+    local local_normalized
+    local_normalized=$(echo "$local_res" | sed -E 's/lctmonitoringst[a-z0-9]*/lctmonitoringst/' | sed -E 's/[A-F0-9]{16}$//' | sed -E 's/[a-f0-9]{8}$//')
     
     if [ "$deployed_normalized" = "$local_normalized" ]; then
         echo "RENAMED"
@@ -329,20 +348,24 @@ EOF
         # Match renamed resources
         while IFS= read -r local_res; do
             local found_match=0
-            local local_type=$(jq -r ".Resources[\"$local_res\"].Type" "$WORK_DIR/local.json")
+            local local_type
+            local_type=$(jq -r ".Resources[\"$local_res\"].Type" "$WORK_DIR/local.json")
             
             # Extract base resource name (everything before the hash pattern)
             # For resources like "BeehiveAccessSecurityGrouptolctmonitoringstthorocBeehiveDbSecurityGroup6B95C6C8543226F10A21"
             # We want to match on the functional part, ignoring stack refs and hashes
-            local local_base=$(echo "$local_res" | sed -E 's/lctmonitoringst[a-z0-9]*/STACKREF/g' | sed -E 's/[A-F0-9]{4,16}//g' | sed -E 's/[a-f0-9]{8}//g')
+            local local_base
+            local_base=$(echo "$local_res" | sed -E 's/lctmonitoringst[a-z0-9]*/STACKREF/g' | sed -E 's/[A-F0-9]{4,16}//g' | sed -E 's/[a-f0-9]{8}//g')
             
             while IFS= read -r deployed_res; do
-                local deployed_type=$(jq -r ".Resources[\"$deployed_res\"].Type" "$WORK_DIR/deployed.json")
+                local deployed_type
+                deployed_type=$(jq -r ".Resources[\"$deployed_res\"].Type" "$WORK_DIR/deployed.json")
                 
                 # Only match if types are the same
                 if [ "$deployed_type" = "$local_type" ]; then
                     # Extract base from deployed resource
-                    local deployed_base=$(echo "$deployed_res" | sed -E 's/lctmonitoringst[a-z0-9]*/STACKREF/g' | sed -E 's/[A-F0-9]{4,16}//g' | sed -E 's/[a-f0-9]{8}//g')
+                    local deployed_base
+                    deployed_base=$(echo "$deployed_res" | sed -E 's/lctmonitoringst[a-z0-9]*/STACKREF/g' | sed -E 's/[A-F0-9]{4,16}//g' | sed -E 's/[a-f0-9]{8}//g')
                     
                     if [ "$deployed_base" = "$local_base" ]; then
                         echo "$deployed_res → $local_res ($local_type)" >> "$WORK_DIR/renamed-resources.txt"
@@ -467,8 +490,10 @@ EOF
 EOF
 
     # Extract and compare SNS Topics with details
-    local deployed_topics=$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::SNS::Topic") | .key' "$WORK_DIR/deployed.json")
-    local local_topics=$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::SNS::Topic") | .key' "$WORK_DIR/local.json")
+    local deployed_topics
+    deployed_topics=$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::SNS::Topic") | .key' "$WORK_DIR/deployed.json")
+    local local_topics
+    local_topics=$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::SNS::Topic") | .key' "$WORK_DIR/local.json")
     
     if [ -z "$deployed_topics" ] && [ -z "$local_topics" ]; then
         echo "No SNS Topics found in either template." >> "$report_file"
@@ -479,8 +504,10 @@ EOF
             echo "No topics found." >> "$report_file"
         else
             echo "$deployed_topics" | while read -r topic; do
-                local display_name=$(jq -r ".Resources[\"$topic\"].Properties.DisplayName // \"N/A\"" "$WORK_DIR/deployed.json")
-                local topic_name=$(jq -r ".Resources[\"$topic\"].Properties.TopicName // \"N/A\"" "$WORK_DIR/deployed.json")
+                local display_name
+                display_name=$(jq -r ".Resources[\"$topic\"].Properties.DisplayName // \"N/A\"" "$WORK_DIR/deployed.json")
+                local topic_name
+                topic_name=$(jq -r ".Resources[\"$topic\"].Properties.TopicName // \"N/A\"" "$WORK_DIR/deployed.json")
                 echo "- **$topic**" >> "$report_file"
                 echo "  - Display Name: \`$display_name\`" >> "$report_file"
                 echo "  - Topic Name: \`$topic_name\`" >> "$report_file"
@@ -494,8 +521,10 @@ EOF
             echo "No topics found." >> "$report_file"
         else
             echo "$local_topics" | while read -r topic; do
-                local display_name=$(jq -r ".Resources[\"$topic\"].Properties.DisplayName // \"N/A\"" "$WORK_DIR/local.json")
-                local topic_name=$(jq -r ".Resources[\"$topic\"].Properties.TopicName // \"N/A\"" "$WORK_DIR/local.json")
+                local display_name
+                display_name=$(jq -r ".Resources[\"$topic\"].Properties.DisplayName // \"N/A\"" "$WORK_DIR/local.json")
+                local topic_name
+                topic_name=$(jq -r ".Resources[\"$topic\"].Properties.TopicName // \"N/A\"" "$WORK_DIR/local.json")
                 echo "- **$topic**" >> "$report_file"
                 echo "  - Display Name: \`$display_name\`" >> "$report_file"
                 echo "  - Topic Name: \`$topic_name\`" >> "$report_file"
@@ -508,8 +537,10 @@ EOF
     echo "" >> "$report_file"
     
     # Extract and compare SNS Subscriptions with details
-    local deployed_subs=$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::SNS::Subscription") | .key' "$WORK_DIR/deployed.json")
-    local local_subs=$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::SNS::Subscription") | .key' "$WORK_DIR/local.json")
+    local deployed_subs
+    deployed_subs=$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::SNS::Subscription") | .key' "$WORK_DIR/deployed.json")
+    local local_subs
+    local_subs=$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::SNS::Subscription") | .key' "$WORK_DIR/local.json")
     
     if [ -z "$deployed_subs" ] && [ -z "$local_subs" ]; then
         echo "No SNS Subscriptions found in either template." >> "$report_file"
@@ -522,9 +553,12 @@ EOF
             echo "No subscriptions found in deployed template." >> "$report_file"
         else
             echo "$deployed_subs" | while read -r sub; do
-                local protocol=$(jq -r ".Resources[\"$sub\"].Properties.Protocol // \"N/A\"" "$WORK_DIR/deployed.json")
-                local endpoint=$(jq -r ".Resources[\"$sub\"].Properties.Endpoint // \"N/A\"" "$WORK_DIR/deployed.json")
-                local topic_arn=$(jq -r ".Resources[\"$sub\"].Properties.TopicArn // \"N/A\"" "$WORK_DIR/deployed.json")
+                local protocol
+                protocol=$(jq -r ".Resources[\"$sub\"].Properties.Protocol // \"N/A\"" "$WORK_DIR/deployed.json")
+                local endpoint
+                endpoint=$(jq -r ".Resources[\"$sub\"].Properties.Endpoint // \"N/A\"" "$WORK_DIR/deployed.json")
+                local topic_arn
+                topic_arn=$(jq -r ".Resources[\"$sub\"].Properties.TopicArn // \"N/A\"" "$WORK_DIR/deployed.json")
                 echo "- **$sub**" >> "$report_file"
                 echo "  - Protocol: \`$protocol\`" >> "$report_file"
                 echo "  - Endpoint: \`$endpoint\`" >> "$report_file"
@@ -539,9 +573,12 @@ EOF
             echo "No subscriptions found in local template." >> "$report_file"
         else
             echo "$local_subs" | while read -r sub; do
-                local protocol=$(jq -r ".Resources[\"$sub\"].Properties.Protocol // \"N/A\"" "$WORK_DIR/local.json")
-                local endpoint=$(jq -r ".Resources[\"$sub\"].Properties.Endpoint // \"N/A\"" "$WORK_DIR/local.json")
-                local topic_arn=$(jq -r ".Resources[\"$sub\"].Properties.TopicArn // \"N/A\"" "$WORK_DIR/local.json")
+                local protocol
+                protocol=$(jq -r ".Resources[\"$sub\"].Properties.Protocol // \"N/A\"" "$WORK_DIR/local.json")
+                local endpoint
+                endpoint=$(jq -r ".Resources[\"$sub\"].Properties.Endpoint // \"N/A\"" "$WORK_DIR/local.json")
+                local topic_arn
+                topic_arn=$(jq -r ".Resources[\"$sub\"].Properties.TopicArn // \"N/A\"" "$WORK_DIR/local.json")
                 echo "- **$sub**" >> "$report_file"
                 echo "  - Protocol: \`$protocol\`" >> "$report_file"
                 echo "  - Endpoint: \`$endpoint\`" >> "$report_file"

--- a/skills/infrastructure/dockerfile/generator/scripts/generate_dockerignore.sh
+++ b/skills/infrastructure/dockerfile/generator/scripts/generate_dockerignore.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 # Generate a comprehensive .dockerignore file
 
 set -euo pipefail

--- a/skills/infrastructure/dockerfile/generator/scripts/generate_golang.sh
+++ b/skills/infrastructure/dockerfile/generator/scripts/generate_golang.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 # Generate a production-ready Go Dockerfile with multi-stage build
 
 set -euo pipefail

--- a/skills/infrastructure/dockerfile/generator/scripts/generate_java.sh
+++ b/skills/infrastructure/dockerfile/generator/scripts/generate_java.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 # Generate a production-ready Java Dockerfile with multi-stage build
 
 set -euo pipefail

--- a/skills/infrastructure/dockerfile/generator/scripts/generate_nodejs.sh
+++ b/skills/infrastructure/dockerfile/generator/scripts/generate_nodejs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 # Generate a production-ready Node.js Dockerfile with multi-stage build
 
 set -euo pipefail

--- a/skills/infrastructure/dockerfile/generator/scripts/generate_python.sh
+++ b/skills/infrastructure/dockerfile/generator/scripts/generate_python.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shell: bash
 # Generate a production-ready Python Dockerfile with multi-stage build
 
 set -euo pipefail

--- a/skills/infrastructure/dockerfile/validator/scripts/dockerfile-validate.sh
+++ b/skills/infrastructure/dockerfile/validator/scripts/dockerfile-validate.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC2034,SC2329
+# ^ SC2034: vars consumed by scripts that source this file; SC2329: functions invoked by scripts that source this file
 
 ################################################################################
 # Dockerfile Validator - Complete Lifecycle Management
@@ -63,7 +66,7 @@ cleanup() {
         echo -e "${GREEN}✓ Cleanup complete${NC}"
     fi
 
-    exit $exit_code
+    exit "$exit_code"
 }
 
 # Set trap for cleanup on any exit
@@ -85,10 +88,10 @@ check_python() {
 
     # Verify Python version (need 3.8+)
     PYTHON_VERSION=$($PYTHON_CMD --version 2>&1 | awk '{print $2}')
-    MAJOR=$(echo $PYTHON_VERSION | cut -d. -f1)
-    MINOR=$(echo $PYTHON_VERSION | cut -d. -f2)
+    MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+    MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
 
-    if [ "$MAJOR" -lt 3 ] || ([ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 8 ]); then
+    if [ "$MAJOR" -lt 3 ] || { [ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 8 ]; }; then
         echo -e "${RED}ERROR: Python 3.8+ required (found $PYTHON_VERSION)${NC}" >&2
         exit 2
     fi

--- a/skills/infrastructure/terraform/validator/scripts/extract_tf_info_wrapper.sh
+++ b/skills/infrastructure/terraform/validator/scripts/extract_tf_info_wrapper.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091
+# ^ SC1091: sourced paths are resolved at runtime, not statically
 # Wrapper script for extract_tf_info.py that handles python-hcl2 dependency
 # Creates a temporary venv if python-hcl2 is not available, auto-cleans on exit
 
@@ -33,7 +36,7 @@ fi
 
 # python-hcl2 not available, create temporary venv
 TEMP_VENV=$(mktemp -d -t terraform-validator.XXXXXX)
-trap "rm -rf $TEMP_VENV" EXIT
+trap 'rm -rf "$TEMP_VENV"' EXIT
 
 echo "python-hcl2 not found in system Python. Creating temporary environment..." >&2
 

--- a/skills/infrastructure/terraform/validator/scripts/install_checkov.sh
+++ b/skills/infrastructure/terraform/validator/scripts/install_checkov.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
+# shellcheck disable=SC1091
+# ^ SC1091: sourced paths are resolved at runtime, not statically
 
 # Checkov Installation Script with Virtual Environment
 # This script installs Checkov in an isolated virtual environment and provides
@@ -67,11 +70,14 @@ check_python() {
         exit 1
     fi
 
-    local python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-    local major=$(echo "$python_version" | cut -d. -f1)
-    local minor=$(echo "$python_version" | cut -d. -f2)
+    local python_version
+    python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+    local major
+    major=$(echo "$python_version" | cut -d. -f1)
+    local minor
+    minor=$(echo "$python_version" | cut -d. -f2)
 
-    if [ "$major" -lt 3 ] || ([ "$major" -eq 3 ] && [ "$minor" -lt 9 ]); then
+    if [ "$major" -lt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -lt 9 ]; }; then
         echo -e "${RED}ERROR: Python 3.9 or higher is required${NC}" >&2
         echo "Current version: $python_version" >&2
         echo "Please upgrade Python and try again" >&2
@@ -119,7 +125,8 @@ install_checkov() {
     deactivate
 
     # Get installed version
-    local version=$("$INSTALL_DIR/bin/checkov" --version 2>&1 | head -n 1)
+    local version
+    version=$("$INSTALL_DIR/bin/checkov" --version 2>&1 | head -n 1)
     echo -e "${GREEN}✓${NC} Checkov installed: $version"
 }
 
@@ -152,7 +159,8 @@ WRAPPER_EOF
 
 # Check if wrapper is in PATH
 check_path() {
-    local bin_dir=$(dirname "$WRAPPER_LINK")
+    local bin_dir
+    bin_dir=$(dirname "$WRAPPER_LINK")
 
     if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
         echo ""
@@ -252,7 +260,8 @@ do_upgrade() {
     fi
 
     # Get current version
-    local current_version=$("$INSTALL_DIR/bin/checkov" --version 2>&1 | head -n 1)
+    local current_version
+    current_version=$("$INSTALL_DIR/bin/checkov" --version 2>&1 | head -n 1)
     echo "Current version: $current_version"
     echo ""
     echo "Upgrading checkov..."
@@ -263,7 +272,8 @@ do_upgrade() {
     deactivate
 
     # Get new version
-    local new_version=$("$INSTALL_DIR/bin/checkov" --version 2>&1 | head -n 1)
+    local new_version
+    new_version=$("$INSTALL_DIR/bin/checkov" --version 2>&1 | head -n 1)
 
     echo ""
     echo -e "${GREEN}✓${NC} Upgrade complete"
@@ -279,7 +289,8 @@ do_status() {
 
     # Check Python
     if command -v python3 &> /dev/null; then
-        local python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+        local python_version
+        python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
         echo -e "Python: ${GREEN}✓${NC} $python_version"
     else
         echo -e "Python: ${RED}✗${NC} Not installed"
@@ -301,7 +312,8 @@ do_status() {
 
     # Check if checkov is accessible
     if command -v checkov &> /dev/null; then
-        local version=$(checkov --version 2>&1 | head -n 1)
+        local version
+        version=$(checkov --version 2>&1 | head -n 1)
         echo -e "Checkov Command: ${GREEN}✓${NC} $version"
     else
         echo -e "Checkov Command: ${RED}✗${NC} Not in PATH"

--- a/skills/infrastructure/terraform/validator/scripts/run_checkov.sh
+++ b/skills/infrastructure/terraform/validator/scripts/run_checkov.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 
 # Checkov Terraform Security Scanner Wrapper Script
 # This script provides a convenient interface for running Checkov security scans

--- a/skills/infrastructure/terragrunt/validator/scripts/validate_terragrunt.sh
+++ b/skills/infrastructure/terragrunt/validator/scripts/validate_terragrunt.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shell: bash
 
 # Terragrunt Validation Script
 # This script performs comprehensive validation of Terragrunt configurations including:


### PR DESCRIPTION
Closes #216.

## What

Remediates the 53 pre-existing artifact-convention violations surfaced by the whole-tree `validate artifacts` scan. The scan now reports **0 errors** (was 53).

### Shebang conventions (51 files)
- **49** non-portable shell shebangs: normalise line 1 to `#!/usr/bin/env bash` and add the `# shell: bash` opt-in marker. Bash semantics preserved; the env-based shebang picks up a modern bash from `PATH` where the old `#!/bin/bash` forced the system one.
- **2** Python helper modules under `scripts/lib/`: add the required `#!/usr/bin/env python3` shebang.

### Validator correctness (`skill-validator-rs`)
- **Dot-directory skip**: the whole-tree scan (`collect_files`) now skips dot-directories, matching the shell's `**` globbing and the dot-dir skip already applied to `check_subdirs` / `check_assets` (#215). This drops the false "unrecognised script type" finding for the gitignored, vendored `scripts/.tools/actionlint` binary.
- **Inline-code self-containment**: the `../` self-containment check now strips backtick-delimited inline code spans as well as fenced blocks. The illustrative `curl .../merge_requests` ellipsis in `gitlab-api/SKILL.md` was a false positive (an ellipsis, not a parent path); prose `../` outside code is still flagged. No SKILL.md content change, so golden-corpus token counts stay bit-exact.
- Adds unit tests for both refinements.

## Fix forward: shellcheck cleanliness

Touching the 49 scripts pulled them into the per-file `shellcheck` pre-commit gate, which surfaced **290 pre-existing findings**. Rather than revert or bypass, all were resolved so the scripts are genuinely shellcheck-clean:

**Fixed** (real issues):
- SC2155 declare/assign split (104 sites)
- SC2086 quote scalar expansions
- SC2164 `cd ... || return 1`
- SC2064 single-quote trap so `$TEMP_VENV` expands at `EXIT`
- SC2235 `{ ...; }` brace group over subshell
- SC2295 quote parameter-expansion pattern

**Disabled with inline justification** (false positives / intentional / not cleanly fixable):
- SC2034 + SC2329 — vars/functions consumed by scripts that `source` these libraries
- SC1091 — sourced paths resolved at runtime
- SC2016 — literal single quotes are intentional
- SC2094 — same file read in several commands, all reads (no write)
- SC2129 — sequential report-file appends are intentional/readable
- SC2001 — sed regex not expressible as shell parameter expansion
- SC2012 — time-sorted `ls`; `find -printf` is non-portable on macOS
- SC2086 (line-level) — deliberate word-splitting of config/flag vars

## Verification
- `validate artifacts` whole-tree scan: **0 errors** (was 53)
- `shellcheck` on all 49 scripts: **0 findings**
- `bash -n` on all 49 scripts under bash 5: pass
- `skill-validator-rs` full test suite: **0 failed** across all suites (incl. golden parity, bit-exact)
- `cargo fmt --check` and `cargo clippy`: clean
- Pre-commit hooks (readme-sync, python-allowlist, shellcheck, skill-artifacts): all pass

## Scope note
Dev-tooling / convention hygiene only. No participant-facing, regulated, or data-handling impact.