### PR TITLE
ci(skill-audit): surface duplication in the PR comment (stacked on #220)

### DIFF
--- a/.github/workflows/skill-audit.yml
+++ b/.github/workflows/skill-audit.yml
@@ -79,6 +79,21 @@ jobs:
             duplication.json > duplication-relevant.json
           n=$(jq 'length' duplication-relevant.json)
           echo "relevant=$n" >> "$GITHUB_OUTPUT"
+          # Render a Markdown summary for the PR comment (surfaced in the
+          # "Cross-skill duplication" details block of the Skill Audit comment).
+          {
+            echo "summary<<DUP_EOF"
+            if [ "$n" -gt 0 ]; then
+              echo "**${n} high-similarity (>=70%) pair(s) involving a skill changed in this PR** — check for accidental copy-paste:"
+              echo ""
+              echo "| Skill A | Skill B | Similarity | Common lines |"
+              echo "| --- | --- | --- | --- |"
+              jq -r '.[] | "| `\(.name1)` | `\(.name2)` | \(.similarity)% | \(.common_lines) |"' duplication-relevant.json
+            else
+              echo "No high-similarity (>=70%) pairs involving skills changed in this PR."
+            fi
+            echo "DUP_EOF"
+          } >> "$GITHUB_OUTPUT"
           if [ "$n" -gt 0 ]; then
             echo "::warning::${n} high-similarity (>=70%) skill pair(s) involve a skill changed in this PR — check for accidental copy-paste. Advisory only; see the Skill Audit comment."
           fi
@@ -146,10 +161,17 @@ jobs:
 
             ${{ steps.audit.outputs.table }}
 
-            **Gate:** 
+            **Gate:**
             - ✅ pass = A / A+ (≥126)
             - ⚠️ warning = C – B+ (98–125, non-blocking)
             - ❌ fail = D / F (<98, blocks merge)
+
+            <details>
+            <summary>Cross-skill duplication (advisory)</summary>
+
+            ${{ steps.dup.outputs.summary }}
+
+            </details>
 
       - name: Enforce gate (fail on D/F)
         if: steps.dirs.outputs.found == 'true' && steps.audit.outputs.fail != '0'


### PR DESCRIPTION
## What

Adds a **Cross-skill duplication (advisory)** `<details>` block to the Skill Audit PR comment, rendered from the duplication scan introduced in #220. Shows any high-similarity (≥70%) pairs involving a skill changed in the PR, or a clean message when there are none.

## Stacking

⚠️ **Stacked on #220** (`feat/ci-skill-dup-batch-gate`) — the base of this PR is that branch, so the diff here is only the comment change. Merge #220 first; I'll then rebase this onto `main` and retarget it to `main`.

## Why separate from #220

#220 adds the gate and produces the duplication data; this PR is purely the visibility layer (surfacing it on the PR), keeping "gate" and "comment" as distinct reviewable changes, mirroring skill-quality-auditor's separate structural-audit comment.

## Verification

- `actionlint` clean.
- Simulated the summary rendering for both the "no dupes" and "dupes found" branches.

Part of the workflow-port series. Analysis: `.context/findings/workflow-port-analysis-2026-07-23.md`.