### PR TITLE
ci(plumber): Critical-findings gate + High/Med/Low backlog (port from skill-quality-auditor)

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -2,15 +2,19 @@ name: Plumber
 
 # CI/CD security scanning for this repository's GitHub Actions workflows and
 # repository configuration (unpinned actions, untrusted shell input, missing
-# branch protection, over-broad permissions). Findings surface in the Security
-# tab (Code Scanning) and in the job summary as a Plumber Score (A-E).
+# branch protection, over-broad permissions). Findings surface in three places:
+# the Security tab (Code Scanning SARIF), a per-PR compliance comment, and — for
+# High/Medium/Low — a single persistent backlog issue.
 #
-# Advisory mode: findings are reported but never block a PR. `soft-fail` covers
-# score-gate failures; `continue-on-error` additionally keeps transient runtime
-# errors (e.g. a rate-limited SLSA attestation check during a PR burst) from
-# blocking merges, which `soft-fail` alone does not. To gate CI on the score
-# once the baseline is clean, drop both and add `min-score: "B"` (see
-# https://getplumber.io/docs/cli/github). Config lives in .plumber.yaml at the
+# Gating model (ported from pantheon-org/skill-quality-auditor):
+#   - Critical findings BLOCK the PR (scripts/plumber-gate.sh).
+#   - High/Medium/Low are tracked, never blocking: a rolling backlog issue on
+#     push to main (scripts/plumber-file-issues.sh) and a per-PR comment
+#     (scripts/plumber-pr-comment.sh).
+# The Plumber action itself runs with soft-fail + continue-on-error so its own
+# A-E score gate and any transient runtime error (e.g. a rate-limited SLSA
+# attestation check during a PR burst) never block; the ONLY blocking signal is
+# a Critical finding via plumber-gate.sh. Config lives in .plumber.yaml at the
 # repo root (required by the action).
 
 on:
@@ -40,77 +44,50 @@ jobs:
     permissions:
       contents: read
       security-events: write # upload SARIF to Code Scanning
-      pull-requests: write # post the advisory Plumber Score comment on PRs
+      issues: write # maintain the High/Medium/Low backlog issue
+      pull-requests: write # post the compliance comment on PRs
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: plumber
         uses: getplumber/plumber@feaea981266b40eea7985b7cb880d47a3426a570 # v0.4.2
-        # Advisory: a failed scan (including transient runtime errors) must not
-        # block the PR. Drop this together with `soft-fail` when gating on score.
+        # soft-fail: the action never fails on its own A-E score. continue-on-error:
+        # a transient runtime error must not block either — the Critical gate below
+        # is the only blocking signal. SARIF upload to Code Scanning is left on
+        # (default); `output` just fixes the JSON report path for the scripts.
         continue-on-error: true
         with:
-          # Advisory only: report findings without failing the job. Remove this
-          # and set `min-score` to start gating PRs on the Plumber Score.
           soft-fail: "true"
-          # Publishing a public score badge to score.getplumber.io is an
-          # explicit opt-in; keep it off. To enable, set this to "true" and add
-          # `id-token: write` to the job permissions above.
+          # Publishing a public score badge to score.getplumber.io is an explicit
+          # opt-in; keep it off. To enable, set "true" and add `id-token: write`.
           score-push: "false"
+          output: results.json
 
-      # In advisory mode the check just passes, so findings are easy to miss.
-      # Surface the Plumber Score as a single upserted PR comment. Skipped when
-      # gating on score (a failing required check is the signal instead).
-      - name: Comment Plumber Score on PR
-        if: github.event_name == 'pull_request' && !cancelled()
+      # Critical findings block the PR. Reads the JSON report the action wrote;
+      # tolerant of a missing report (transient scan error → warn, don't block).
+      - name: Gate on Critical findings
+        run: scripts/plumber-gate.sh results.json
+
+      # Rolling backlog issue for High/Medium/Low. Push-to-main only: it reflects
+      # the state of main, not a PR branch's speculative merged state — running it
+      # on PRs would make concurrent PRs fight over the single rollup issue.
+      - name: File issues for High/Medium/Low findings
+        if: always() && github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-          REPORT: ${{ steps.plumber.outputs.report }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          SECURITY_URL: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning
-        run: |
-          set -euo pipefail
-          marker="<!-- plumber-advisory -->"
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: scripts/plumber-file-issues.sh results.json
 
-          if [ -n "${REPORT:-}" ] && [ -s "${REPORT:-/dev/null}" ]; then
-            read -r score points crit high med low < <(
-              jq -r '[.plumberScore.score,
-                      (.plumberScore.finalPoints | floor),
-                      .plumberScore.counts.critical,
-                      .plumberScore.counts.high,
-                      .plumberScore.counts.medium,
-                      .plumberScore.counts.low] | @tsv' "$REPORT"
-            )
-            codes="$(jq -r '.plumberScore.codeLosses // []
-                            | sort_by(-.count)[]
-                            | "| \(.code) | \(.severity) | \(.count) |"' "$REPORT")"
-            [ -n "$codes" ] || codes="| _none_ | | |"
-            body="$marker
-          ## Plumber Score: ${score} (${points}/100)
+      # Fork PRs run with a read-only GITHUB_TOKEN regardless of the permissions
+      # block above, so gh pr comment would 403.
+      - name: Skip PR comment for fork PRs
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        run: echo "::notice::Fork PR — GITHUB_TOKEN is read-only, skipping the compliance comment. See this check's log and the Critical gate result."
 
-          Advisory CI/CD security scan. This does **not** block the PR; it reports the score for awareness. Full detail is in the [Code Scanning alerts](${SECURITY_URL}) and the [run summary](${RUN_URL}).
-
-          **Findings by severity:** critical ${crit} · high ${high} · medium ${med} · low ${low}
-
-          | Issue | Severity | Count |
-          | --- | --- | --- |
-          ${codes}
-          "
-          else
-            body="$marker
-          ## Plumber Score: unavailable
-
-          The advisory CI/CD security scan did not produce a report this run (for example a transient runtime error). It does **not** block the PR. See the [run log](${RUN_URL}) for detail."
-          fi
-
-          # Upsert one comment: edit the bot's previous advisory comment in
-          # place, else create it. Best-effort: on Dependabot or fork PRs the
-          # token is read-only, so a write failure must not fail the job
-          # (advisory never blocks). The marker only tags the comment for humans.
-          if gh pr comment "$PR" --body "$body" --edit-last --create-if-none; then
-            echo "Posted advisory Plumber comment on PR #$PR"
-          else
-            echo "::notice::Could not post the advisory Plumber comment (read-only token on a Dependabot/fork PR?); skipping."
-          fi
+      - name: Comment compliance result on the PR
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: scripts/plumber-pr-comment.sh results.json

--- a/scripts/plumber-file-issues.sh
+++ b/scripts/plumber-file-issues.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# plumber-file-issues.sh
+#
+# Maintains a single persistent GitHub issue listing every High/Medium/Low
+# severity Plumber finding, located by a stable marker in the issue body
+# (not by title, which someone might edit). Every run regenerates the full
+# body from the current report: creates the issue if none exists, edits it in
+# place if open, reopens + edits it if a prior run closed it. If a run has zero
+# High/Medium/Low findings and the issue is open, it is closed as resolved.
+# This never creates more than one open issue.
+#
+# Plumber has no native "findings" array with a per-finding severity field —
+# each control writes its own `<control>Result.issues[]` with a different
+# shape (jobName vs job vs branchName, etc). Severity per issue code is only
+# available in `plumberScore.codeLosses[]`, so this walks every top-level
+# `*Result` key generically and joins each issue back to its severity by
+# code. Critical findings are not listed here — plumber-gate.sh blocks on
+# those instead.
+set -euo pipefail
+
+RESULTS_PATH="${1:?usage: plumber-file-issues.sh <results.json>}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+TMP_BODY="${RUNNER_TEMP:-/tmp}/plumber-issue-body.md"
+MARKER="<!-- plumber-compliance-backlog -->"
+TITLE="[Plumber] Compliance backlog (High/Medium/Low)"
+
+if [ ! -f "$RESULTS_PATH" ]; then
+    echo "No ${RESULTS_PATH} found; skipping issue filing."
+    exit 0
+fi
+
+FINDINGS_JSON="$(jq -c '
+    (.plumberScore.codeLosses // []) as $losses
+    | ($losses | map({(.code): .severity}) | add // {}) as $sevmap
+    | [
+        to_entries[]
+        | select(.key | endswith("Result"))
+        | .key as $rk
+        | (.value.issues // [])[]
+        | {resultKey: $rk, code: (.code // "UNKNOWN"), severity: ($sevmap[.code] // "unknown"), issue: .}
+        | select(.severity == "high" or .severity == "medium" or .severity == "low")
+    ]
+' "$RESULTS_PATH")"
+
+COUNT="$(jq 'length' <<<"$FINDINGS_JSON")"
+
+EXISTING_JSON="$(gh issue list --repo "$REPO" --search "\"${MARKER}\" in:body" --state all --json number,state --jq '.[0] // empty' 2>/dev/null || true)"
+EXISTING_NUM=""
+EXISTING_STATE=""
+if [ -n "$EXISTING_JSON" ]; then
+    EXISTING_NUM="$(jq -r '.number' <<<"$EXISTING_JSON")"
+    EXISTING_STATE="$(jq -r '.state' <<<"$EXISTING_JSON")"
+fi
+
+if [ "$COUNT" -eq 0 ]; then
+    echo "No High/Medium/Low findings this run."
+    if [ -n "$EXISTING_NUM" ] && [ "$EXISTING_STATE" = "OPEN" ]; then
+        gh issue comment "$EXISTING_NUM" --repo "$REPO" --body "All previously tracked findings are resolved as of this run. Closing."
+        gh issue close "$EXISTING_NUM" --repo "$REPO" --reason completed
+        echo "Closed #${EXISTING_NUM} (all findings resolved)."
+    fi
+    exit 0
+fi
+
+{
+    echo "Plumber found ${COUNT} High/Medium/Low-severity finding(s) as of the latest run on \`${GITHUB_SHA:-unknown}\`."
+    echo ""
+    echo "This issue is regenerated on every run — its body reflects the current findings, not a history. Do not edit it by hand."
+    echo ""
+    for sev in high medium low; do
+        sev_findings="$(jq -c --arg sev "$sev" '[.[] | select(.severity == $sev)]' <<<"$FINDINGS_JSON")"
+        sev_count="$(jq 'length' <<<"$sev_findings")"
+        [ "$sev_count" -eq 0 ] && continue
+        title_case="$(tr '[:lower:]' '[:upper:]' <<<"${sev:0:1}")${sev:1}"
+        echo "## ${title_case} (${sev_count})"
+        echo ""
+        echo "| Code | Location | Source |"
+        echo "| --- | --- | --- |"
+        jq -r '.[] | "| \(.code) | \(.issue.jobName // .issue.job // .issue.branchName // "unknown") | \(.issue.url // "-") |"' <<<"$sev_findings"
+        echo ""
+    done
+    echo "$MARKER"
+} >"$TMP_BODY"
+
+if [ -n "$EXISTING_NUM" ]; then
+    gh issue edit "$EXISTING_NUM" --repo "$REPO" --title "$TITLE" --body-file "$TMP_BODY"
+    if [ "$EXISTING_STATE" = "CLOSED" ]; then
+        gh issue reopen "$EXISTING_NUM" --repo "$REPO"
+        echo "Reopened and updated #${EXISTING_NUM}."
+    else
+        echo "Updated #${EXISTING_NUM}."
+    fi
+else
+    ISSUE_URL="$(gh issue create --repo "$REPO" --title "$TITLE" --body-file "$TMP_BODY")"
+    echo "Filed ${ISSUE_URL}."
+fi

--- a/scripts/plumber-gate.sh
+++ b/scripts/plumber-gate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# plumber-gate.sh
+#
+# Fails the job if the Plumber JSON report contains any Critical-severity
+# finding. Plumber's own exit code reflects overall compliance against its
+# score threshold, not per-finding severity, so this gates on
+# plumberScore.counts.critical directly instead.
+#
+# Ported from pantheon-org/skill-quality-auditor, with one tekhne-specific
+# change: a MISSING report is treated as a transient scan failure (warn, do not
+# block), not a hard failure. plumber.yml runs the Plumber action with
+# continue-on-error precisely so transient runtime errors (e.g. a rate-limited
+# SLSA attestation check during a PR burst) never block merges; hard-failing
+# here on a missing report would defeat that. A report that IS present and shows
+# Critical findings still blocks.
+set -euo pipefail
+
+RESULTS_PATH="${1:?usage: plumber-gate.sh <results.json>}"
+
+if [ ! -f "$RESULTS_PATH" ]; then
+    echo "::warning::${RESULTS_PATH} not found; Plumber did not produce a report (likely a transient scan error). Critical gate skipped this run."
+    exit 0
+fi
+
+CRITICAL_COUNT="$(jq '.plumberScore.counts.critical // 0' "$RESULTS_PATH")"
+
+if [ "$CRITICAL_COUNT" -gt 0 ]; then
+    echo "::error::${CRITICAL_COUNT} Critical-severity Plumber finding(s) present — see the Code Scanning alerts or job summary for detail."
+    jq -r '
+        (.plumberScore.codeLosses // [])[]
+        | select(.severity == "critical")
+        | "::error::[\(.code)] \(.count) Critical-severity finding(s)"
+    ' "$RESULTS_PATH"
+    exit 1
+fi
+
+echo "No Critical-severity Plumber findings. Gate passed."

--- a/scripts/plumber-pr-comment.sh
+++ b/scripts/plumber-pr-comment.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# plumber-pr-comment.sh
+#
+# Posts a PR comment with the Critical gate result and a per-severity breakdown
+# of every finding on this branch (code, location, source link) — the same
+# detail plumber-file-issues.sh writes into the rollup issue, so a PR author can
+# see exactly what to fix without opening the Plumber check's log.
+#
+# Finds the existing comment by its <!-- plumber-pr-comment --> marker and edits
+# it in place, rather than posting a fresh comment every run. Deliberately NOT
+# `gh pr comment --edit-last`: that edits the last comment by the authenticated
+# identity, not by this script — and every automated comment in this repo posts
+# as the same github-actions[bot] identity, so --edit-last would silently
+# overwrite whichever tool commented most recently. Marker-based lookup targets
+# only this script's own comment.
+#
+# Finding extraction mirrors plumber-file-issues.sh: Plumber has no unified
+# findings[] array with a per-finding severity, so this walks every top-level
+# `*Result` key's issues[] generically and joins each one back to its severity
+# via plumberScore.codeLosses.
+set -euo pipefail
+
+RESULTS_PATH="${1:?usage: plumber-pr-comment.sh <results.json>}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+PR_NUMBER="${PR_NUMBER:?PR_NUMBER must be set}"
+ROLLUP_MARKER="<!-- plumber-compliance-backlog -->"
+COMMENT_MARKER="<!-- plumber-pr-comment -->"
+TMP_BODY="${RUNNER_TEMP:-/tmp}/plumber-pr-comment.md"
+MAX_ROWS_PER_SECTION=25
+
+if [ ! -f "$RESULTS_PATH" ]; then
+    echo "No ${RESULTS_PATH} found; skipping PR comment."
+    exit 0
+fi
+
+FINDINGS_JSON="$(jq -c '
+    (.plumberScore.codeLosses // []) as $losses
+    | ($losses | map({(.code): .severity}) | add // {}) as $sevmap
+    | [
+        to_entries[]
+        | select(.key | endswith("Result"))
+        | .key as $rk
+        | (.value.issues // [])[]
+        | {resultKey: $rk, code: (.code // "UNKNOWN"), severity: ($sevmap[.code] // "unknown"), issue: .}
+    ]
+' "$RESULTS_PATH")"
+
+CRITICAL_COUNT="$(jq '.plumberScore.counts.critical // 0' "$RESULTS_PATH")"
+HIGH_COUNT="$(jq '.plumberScore.counts.high // 0' "$RESULTS_PATH")"
+MEDIUM_COUNT="$(jq '.plumberScore.counts.medium // 0' "$RESULTS_PATH")"
+LOW_COUNT="$(jq '.plumberScore.counts.low // 0' "$RESULTS_PATH")"
+TOTAL_COUNT="$((CRITICAL_COUNT + HIGH_COUNT + MEDIUM_COUNT + LOW_COUNT))"
+
+ROLLUP_ISSUE="$(gh issue list --repo "$REPO" --search "\"${ROLLUP_MARKER}\" in:body" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+
+write_section() {
+    local sev="$1" label="$2"
+    local sev_findings sev_count
+    sev_findings="$(jq -c --arg sev "$sev" '[.[] | select(.severity == $sev)]' <<<"$FINDINGS_JSON")"
+    sev_count="$(jq 'length' <<<"$sev_findings")"
+    [ "$sev_count" -eq 0 ] && return 0
+
+    echo "### ${label} (${sev_count})"
+    echo ""
+    echo "| Code | Location | Source |"
+    echo "| --- | --- | --- |"
+    jq -r --argjson max "$MAX_ROWS_PER_SECTION" '
+        .[:$max][]
+        | "| \(.code) | \(.issue.jobName // .issue.job // .issue.branchName // "unknown") | \(.issue.url // "-") |"
+    ' <<<"$sev_findings"
+    if [ "$sev_count" -gt "$MAX_ROWS_PER_SECTION" ]; then
+        echo ""
+        echo "_...and $((sev_count - MAX_ROWS_PER_SECTION)) more. See \`plumber explain <code>\` or the full \`plumber-compliance\` artifact on this run for the rest._"
+    fi
+    echo ""
+}
+
+{
+    echo "## 🛡️ Plumber — CI/CD Security Compliance"
+    echo ""
+
+    if [ "$CRITICAL_COUNT" -gt 0 ]; then
+        echo "### 🔴 ${CRITICAL_COUNT} Critical-severity finding(s) — blocking merge"
+        echo ""
+    else
+        echo "### ✅ No Critical-severity findings"
+        echo ""
+    fi
+
+    write_section critical "🔴 Critical"
+    write_section high "🟠 High"
+    write_section medium "🟡 Medium"
+    write_section low "🔵 Low"
+
+    if [ "$TOTAL_COUNT" -eq 0 ]; then
+        echo "No findings on this branch."
+        echo ""
+    elif [ -n "$ROLLUP_ISSUE" ]; then
+        echo "High/Medium/Low findings are tracked in #${ROLLUP_ISSUE} once this merges — that issue reflects \`main\`, not this PR's branch, and only updates on push to \`main\`, so it may not match the tables above until then."
+        echo ""
+    fi
+
+    echo "_[View this run](${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_RUN_ID:-})_"
+    echo ""
+    echo "$COMMENT_MARKER"
+} >"$TMP_BODY"
+
+EXISTING_COMMENT_ID="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate 2>/dev/null \
+    | jq -r --arg marker "$COMMENT_MARKER" '[.[] | select((.body // "") | contains($marker))] | last.id // empty' \
+    || true)"
+
+if [ -n "$EXISTING_COMMENT_ID" ]; then
+    # -F (not -f): the "@file reads the value from a file" convention is
+    # documented only for -F/--field. -f/--raw-field takes its value completely
+    # literally, so -f body="@$TMP_BODY" would post the literal string
+    # "@/path/to/file" as the comment body instead of its contents.
+    gh api "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" -X PATCH -F body="@${TMP_BODY}" >/dev/null
+else
+    gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$TMP_BODY"
+fi


### PR DESCRIPTION
## What

Ports skill-quality-auditor's Plumber gating model into tekhne's `plumber.yml`, adding three scripts under `scripts/`:

- **`plumber-gate.sh`** — blocks the PR on any **Critical** finding (reads `plumberScore.counts.critical`).
- **`plumber-file-issues.sh`** — maintains a single rolling backlog issue for **High/Medium/Low** findings, on push to main only.
- **`plumber-pr-comment.sh`** — posts a per-severity finding breakdown (code / location / source) on the PR, upserted by marker.

## Why

Today tekhne's Plumber is fully advisory — it comments a score but nothing blocks, and High/Med/Low findings aren't tracked anywhere durable. This makes Critical findings blocking while keeping everything else non-blocking-but-visible.

## Deliberate tekhne adaptations (vs the source repo)

- **SARIF upload to Code Scanning is preserved** — I did *not* copy the source's `upload-sarif: false`. The scan still populates the Security tab.
- **Transient-error tolerance is preserved** — the Plumber action keeps `soft-fail: true` + `continue-on-error: true`, and `plumber-gate.sh` treats a *missing* report as a transient scan error (warns, does not block). The only hard-block is a Critical finding when a report exists. This keeps tekhne's documented "transient runtime errors never block merges" stance while still gating on Critical.
- `output: results.json` fixes the report path so the scripts get a stable, `-f`-guarded argument.
- The previous inline advisory PR comment (`<!-- plumber-advisory -->`) is replaced by the richer per-finding `plumber-pr-comment.sh` (`<!-- plumber-pr-comment -->`).

## Verification

- `shellcheck` clean on all three scripts; `bash -n` syntax OK.
- `actionlint` clean on `plumber.yml`.
- Unit-tested `plumber-gate.sh` exit codes against synthetic reports: Critical → exit 1, none → exit 0, missing report → warn + exit 0.

Part of the workflow-port series. Analysis: `.context/findings/workflow-port-analysis-2026-07-23.md`.