### PR TITLE
ci: inert general-purpose PR Agent for non-skill PRs (port from skill-quality-auditor)

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,91 @@
+name: PR Agent
+
+# General-purpose LLM PR review (auto-describe + auto-review) for NON-skill PRs.
+#
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ DATA GOVERNANCE — READ BEFORE ENABLING                                     │
+# │                                                                            │
+# │ This workflow sends the PR diff and metadata to an EXTERNAL LLM provider   │
+# │ (Gemini / Mistral / Cerebras, via litellm). Under PLG's data-handling      │
+# │ rules, repository contents are potentially confidential, so turning this   │
+# │ on is a deliberate data-flow decision that must be signed off by whoever   │
+# │ owns AI-tooling data governance — it is not a routine CI toggle.           │
+# │                                                                            │
+# │ It ships INERT: the agent step is gated on a provider API-key secret being │
+# │ present, and NONE is configured. Adding a *_API_KEY secret is the switch   │
+# │ that turns it on. Do not add one without that sign-off.                    │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# Skill PRs are excluded (paths-ignore: skills/**) — they are already covered by
+# the Skill Audit gate, Tessl Review, and Copilot review. A second LLM opinion
+# on the same diff would be redundant.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    # paths-ignore only skips a run when EVERY changed file matches, so a mixed
+    # PR (skills + non-skills) still runs.
+    paths-ignore:
+      - "skills/**"
+  issue_comment:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-agent:
+    # Skip bot senders and fork PRs (fork PRs never see secrets on a plain
+    # pull_request trigger — GitHub redacts them). `!= true` (not `== false`)
+    # because issue_comment events leave pull_request.head.repo.fork null, and
+    # this job must still run for that event.
+    if: ${{ github.event.sender.type != 'Bot' && github.event.pull_request.head.repo.fork != true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Inert switch. The agent only runs when a provider key is configured; with
+      # none present (the default, by design) this skips cleanly and posts a
+      # notice explaining why. See the DATA GOVERNANCE note in the header.
+      - name: Check for a provider key
+        id: key
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+        run: |
+          if [ -n "$GEMINI_API_KEY" ] || [ -n "$MISTRAL_API_KEY" ] || [ -n "$CEREBRAS_API_KEY" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR Agent is inert — no provider API key is configured. This is intentional. Enabling it ships PR diffs to an external LLM and requires a data-governance sign-off (see the workflow header)."
+          fi
+
+      # Digest-pinned image (this repo pins every third-party action by immutable
+      # reference; .plumber.yaml enforces actionsMustBePinnedByCommitSha).
+      # continue-on-error: advisory only — a provider outage, rate-limit, or bad
+      # response must never turn this into a red, blocking check.
+      - name: PR Agent action step
+        if: steps.key.outputs.present == 'true'
+        continue-on-error: true
+        uses: docker://pragent/pr-agent@sha256:ea2ea90f072fd97708755e59827a317272f66097a1ef349eca23d39160bb0baf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Model IDs on every provider are point-in-time; expect to bump these
+          # as providers retire models. Gemini primary, Mistral then Cerebras as
+          # litellm fallbacks so a single provider's rate limit is not a SPOF.
+          config.model: "gemini/gemini-3.5-flash"
+          config.fallback_models: '["mistral/mistral-small-2603", "cerebras/gpt-oss-120b"]'
+          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # PR-Agent maps MISTRAL.KEY to MISTRAL_API_KEY; Cerebras has no
+          # PR-Agent-specific key, litellm reads CEREBRAS_API_KEY from the env.
+          MISTRAL.KEY: ${{ secrets.MISTRAL_API_KEY }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          # describe + review only. auto_improve must be an explicit "false" — if
+          # left unset, PR-Agent still runs /improve.
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_review: "true"
+          github_action_config.auto_improve: "false"


### PR DESCRIPTION
### **User description**
## ⚠️ Data governance — this ships inert on purpose

This workflow, when enabled, **sends the PR diff and metadata to an external LLM provider** (Gemini / Mistral / Cerebras via litellm). Under PLG's data-handling rules repository contents are potentially confidential, so turning it on is a **deliberate data-flow decision that needs sign-off from whoever owns AI-tooling data governance** — not a routine CI toggle.

It is committed **inert**: the agent step is gated on a provider `*_API_KEY` secret being present, and none is configured. It skips cleanly and posts an explanatory notice. **Adding a key is the switch that turns it on — please do not add one without that sign-off.** This PR is safe to merge as-is (it does nothing until a key exists).

> This is decision-support tooling; a human owner must make and document the go/no-go on external LLM data flow.

## What

Ports skill-quality-auditor's `pr-agent.yml`: LLM auto-describe + auto-review for **non-skill** PRs, advisory only (`continue-on-error`), digest-pinned image, Gemini primary with Mistral/Cerebras fallback.

## Why / scope

- Fills the gap for general (non-skill) PRs. Skill PRs are **excluded** (`paths-ignore: skills/**`) since they already get Skill Audit, Tessl Review, and Copilot review — a second LLM opinion there would be redundant.
- Bots and fork PRs are skipped (forks never see secrets).

## Open question for the reviewer

tekhne already has Copilot review on PRs. If that is considered sufficient, this can be closed instead of merged. I've kept it inert so the decision can be made without any data-flow risk in the meantime.

## Verification

- `actionlint` clean.
- Inert-by-default confirmed: with no provider key, the key-check step sets `present=false` and the agent step is skipped.

Part of the workflow-port series. Analysis: `.context/findings/workflow-port-analysis-2026-07-23.md`.


___

### **PR Type**
Enhancement


___

### **Description**
- Add inert PR Agent workflow for reviews.

- Exclude skill PRs to avoid redundancy.

- Gate execution on provider API key.

- Configure Gemini, Mistral, and Cerebras fallbacks.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  trigger["PR Event / Comment"] -- "Trigger" --> checkKeys["Check Provider API Keys"]
  checkKeys -- "Keys Missing" --> postNotice["Post Inert Notice & Skip"]
  checkKeys -- "Keys Present" --> runAgent["Run PR Agent Action"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Add inert PR Agent workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Adds a GitHub Actions workflow for automated PR description and <br>review.<br> <li> Excludes skill-related paths (<code>skills/**</code>) to avoid redundancy with <br>existing tools.<br> <li> Implements an inert check that skips execution and posts a notice <br>unless a provider API key is configured.<br> <li> Pins the PR Agent Docker image by SHA and configures Gemini, Mistral, <br>and Cerebras models.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/223/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

