### PR TITLE
ci: add aislop full-repo code-quality gate (advisory)

### DIFF
--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -1,0 +1,51 @@
+name: aislop
+
+# Full-repo code-quality gate (aislop): catches dead imports, duplicate logic,
+# unsafe casts, narrative comments, swallowed errors, oversized functions and
+# similar, scored out of 100. aislop already runs locally via a PostToolUse
+# hook; this enforces the same gate in CI, where local hooks are bypassable
+# (--no-verify, web-UI merges, API commits).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Supersede an in-flight run when the ref updates (e.g. a rebase), so stale
+  # runs are cancelled instead of piling up.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality-gate:
+    name: aislop quality gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      # Advisory rollout. `aislop ci` exits 1 below ci.failBelow (or aislop's
+      # default) or on any error-severity diagnostic, and a full-repo scan today
+      # reports 30 errors / 3 confirmed defects — so gating hard right now would
+      # block every PR. continue-on-error keeps this non-blocking while the
+      # findings are surfaced in the run log; the local PostToolUse hook still
+      # enforces quality per-edit. Promote to a hard gate (drop
+      # continue-on-error) once a full-repo scan is clean. Mirrors the staged
+      # rollout of the cargo-audit step in rust-ci.yml.
+      #
+      # aislop is unpinned (@latest) to match the local PostToolUse hook, which
+      # also tracks latest; there is no aislop version pin in mise.toml. If CI
+      # reproducibility later requires it, pin a specific version here and in the
+      # hook together.
+      - name: aislop ci
+        continue-on-error: true
+        run: npx --yes aislop@latest ci .


### PR DESCRIPTION
## What

Adds `.github/workflows/aislop.yml` running `npx aislop@latest ci .` on PRs to `main` and on push to `main`. Modelled on your `Journal` repo's `aislop.yml`, adapted to tekhne conventions (SHA-pinned actions, PR/push triggers scoped to `main`, concurrency guard).

## Advisory, not blocking (correction)

I initially intended this as a blocking gate and reported that a full-repo scan passed. **That was wrong** — the "exit 0" I saw was a trailing `echo`, not aislop. A real full-repo `aislop ci .` reports **30 errors, 179 warnings, and 3 confirmed defects across 175 files**, so a hard gate would block every PR.

This PR therefore ships the step with `continue-on-error: true` — aislop runs and surfaces findings in the run log without blocking. The local PostToolUse hook still enforces quality per-edit. Promote to a hard gate (drop `continue-on-error`) once a full-repo scan is clean, mirroring the `cargo-audit` staged rollout in `rust-ci.yml`.

## Follow-up

The 30 errors / 3 confirmed defects want their own remediation effort before this can become blocking. Happy to open an issue to track that.

## Notes

- Actions SHA-pinned (`checkout` v7.0.0, `setup-node` v6.4.0) per repo/Plumber convention.
- `aislop` is `@latest`, matching the local hook (no version pin in `mise.toml`).
- No `.aislop/config.*` in the repo, so aislop defaults apply.

Verified with `actionlint` (clean).