### PR TITLE
chore(mcp): register local dev MCP servers in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,34 @@
       "type": "stdio",
       "command": "tessl",
       "args": ["mcp", "start"]
+    },
+    "sigmap": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "sigmap", "--mcp"]
+    },
+    "aislop": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "--package=aislop", "aislop-mcp"]
+    },
+    "code-review-graph": {
+      "command": "uvx",
+      "args": ["code-review-graph", "serve"],
+      "type": "stdio"
+    },
+    "qmd": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@tobilu/qmd", "mcp"]
+    },
+    "context-mode": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "context-mode", "context-mode"],
+      "env": {
+        "CONTEXT_MODE_IDLE_TIMEOUT_MS": "900000"
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Registers five local dev MCP servers in the project `.mcp.json` (shared, project-scope): `sigmap`, `aislop`, `code-review-graph`, `qmd`, and `context-mode`, plus a formatting expansion of the existing `tessl` entry.

## Config correctness

The originally-staged version used `"transport": "stdio"` and `"environment": {…}`. Neither is a Claude Code `.mcp.json` key, verified against the [MCP docs](https://docs.anthropic.com/en/docs/claude-code/mcp):

- stdio servers use `command` / `args` / `env` (an entry with no `type` is treated as stdio; `type: "stdio"` is optional but used here for consistency with `tessl`). `transport` is not recognised and would be ignored.
- environment variables use `env`, not `environment` — so context-mode's `CONTEXT_MODE_IDLE_TIMEOUT_MS` would have been **silently dropped**.

Both are corrected in this PR: all entries use `type` / `command` / `args`, and context-mode uses `env`.

## Notes

- No secrets or tokens in the file (all servers launch via `npx`/`uvx`; the only env value is a timeout).
- Biome-formatted; valid JSON verified with `jq`.