### PR TITLE
ci(deps): bump getplumber/plumber from 0.4.2 to 0.4.3

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: plumber
-        uses: getplumber/plumber@feaea981266b40eea7985b7cb880d47a3426a570 # v0.4.2
+        uses: getplumber/plumber@fdd2a2d0555bb3b33cbb2efff3b955dea5a6bbf0 # v0.4.3
         # soft-fail: the action never fails on its own A-E score. continue-on-error:
         # a transient runtime error must not block either — the Critical gate below
         # is the only blocking signal. SARIF upload to Code Scanning is left on


### PR DESCRIPTION
Replaces Dependabot PR #200, which Dependabot closed when its recreate could not resolve the conflict with the plumber.yml gate rework (#222).

Single change: SHA-pin bump of `getplumber/plumber` from `@feaea98… # v0.4.2` to `@fdd2a2d… # v0.4.3`, reconstructed cleanly on current `main`. Same content Dependabot intended in #200.