### PR TITLE
fix(aislop): clear all 30 aislop errors (Wave 1 of cleanup-to-green)

### DIFF
--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -1,0 +1,13 @@
+# aislop configuration (committed; CI reads this).
+#
+# Exclude illustrative skill content from the scan. Files under references/,
+# templates/, and examples/ are teaching material meant to be copied into a
+# user's own project, not tekhne's own buildable source. For example the
+# opencode-toolkit references import "@opencode-ai/plugin" (the real OpenCode
+# SDK), which is correctly absent from this repo's package.json and so trips the
+# hallucinated-import rule as a false positive. Skill scripts/ (real, runnable
+# deliverables) are deliberately NOT excluded and remain scanned.
+exclude:
+  - "skills/**/references/**"
+  - "skills/**/templates/**"
+  - "skills/**/examples/**"

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ hk.local.pkl
 /target/
 
 .tokensave/
-.aislop/
+# Ignore aislop local state but keep the committed config (scan excludes) so CI
+# reads it; baseline.json / session.jsonl / history.jsonl stay ignored.
+.aislop/*
+!.aislop/config.yml
 .tmp/

--- a/skills/documentation/research/google-scholar-search/scripts/google-scholar-search.py
+++ b/skills/documentation/research/google-scholar-search/scripts/google-scholar-search.py
@@ -9,6 +9,7 @@ and get author information from Google Scholar.
 import argparse
 import json
 import sys
+import logging
 from typing import Dict, Any, List, Optional
 import requests
 from bs4 import BeautifulSoup
@@ -258,7 +259,7 @@ class OutputHandler:
                 json.dump(data, f, indent=2, ensure_ascii=False)
             print(f"\n结果已保存到: {filepath}")
         except Exception as e:
-            print(f"Error writing to file: {str(e)}", file=sys.stderr)
+            logging.getLogger(__name__).error("Error writing to file: %s", e)
 
 
 def main():

--- a/skills/documentation/research/notebooklm/scripts/ask_question.py
+++ b/skills/documentation/research/notebooklm/scripts/ask_question.py
@@ -230,7 +230,9 @@ def ask_notebooklm(question: str, notebook_url: str, headless: bool = True, use_
                 if thinking_element and thinking_element.is_visible():
                     time.sleep(1)
                     continue
-            except:
+            except Exception:
+                # Best-effort readiness probe; a stale/absent element just means
+                # we fall through and try to read the response this poll.
                 pass
 
             # Try to find the new response with MCP selectors
@@ -311,13 +313,15 @@ def ask_notebooklm(question: str, notebook_url: str, headless: bool = True, use_
         if context:
             try:
                 context.close()
-            except:
+            except Exception:
+                # Best-effort cleanup; the context may already be closed.
                 pass
 
         if playwright:
             try:
                 playwright.stop()
-            except:
+            except Exception:
+                # Best-effort cleanup; ignore errors while stopping Playwright.
                 pass
 
 

--- a/skills/documentation/research/notebooklm/scripts/auth_manager.py
+++ b/skills/documentation/research/notebooklm/scripts/auth_manager.py
@@ -75,6 +75,7 @@ class AuthManager:
                     saved_info = json.load(f)
                     info.update(saved_info)
             except Exception:
+                # Saved auth metadata is optional; keep the computed defaults.
                 pass
 
         if info['state_exists']:
@@ -149,12 +150,14 @@ class AuthManager:
                 try:
                     context.close()
                 except Exception:
+                    # Best-effort cleanup; the context may already be closed.
                     pass
 
             if playwright:
                 try:
                     playwright.stop()
                 except Exception:
+                    # Best-effort cleanup; ignore errors while stopping Playwright.
                     pass
 
     def _save_browser_state(self, context: BrowserContext):
@@ -177,7 +180,8 @@ class AuthManager:
             with open(self.auth_info_file, 'w') as f:
                 json.dump(info, f, indent=2)
         except Exception:
-            pass  # Non-critical
+            # Saving auth metadata is non-critical; ignore write failures.
+            pass
 
     def clear_auth(self) -> bool:
         """
@@ -276,11 +280,13 @@ class AuthManager:
                 try:
                     context.close()
                 except Exception:
+                    # Best-effort cleanup; the context may already be closed.
                     pass
             if playwright:
                 try:
                     playwright.stop()
                 except Exception:
+                    # Best-effort cleanup; ignore errors while stopping Playwright.
                     pass
 
 

--- a/skills/documentation/research/notebooklm/scripts/browser_session.py
+++ b/skills/documentation/research/notebooklm/scripts/browser_session.py
@@ -7,6 +7,7 @@ Based on the original NotebookLM API implementation
 
 import time
 import sys
+import logging
 from typing import Any, Dict, Optional
 from pathlib import Path
 
@@ -162,6 +163,7 @@ class BrowserSession:
             if responses:
                 return responses[-1].inner_text()
         except Exception:
+            # Best-effort snapshot; treat any read failure as "no response yet".
             pass
         return None
 
@@ -179,6 +181,7 @@ class BrowserSession:
                     time.sleep(0.5)
                     continue
             except Exception:
+                # Best-effort readiness probe; fall through to read the response.
                 pass
 
             try:
@@ -200,6 +203,7 @@ class BrowserSession:
                             last_candidate = latest_text
 
             except Exception:
+                # Best-effort poll; a transient DOM read error just retries.
                 pass
 
             time.sleep(0.5)
@@ -228,7 +232,8 @@ class BrowserSession:
             try:
                 self.page.close()
             except Exception as e:
-                print(f"  ⚠️ Error closing page: {e}")
+                # Best-effort close; a page that is already gone is fine to skip.
+                logging.getLogger(__name__).warning("Error closing page: %s", e)
 
         print(f"✅ Session {self.id} closed")
 

--- a/skills/documentation/research/notebooklm/scripts/browser_utils.py
+++ b/skills/documentation/research/notebooklm/scripts/browser_utils.py
@@ -7,7 +7,10 @@ Handles browser launching, stealth features, and common interactions
 import json
 import time
 import random
-from typing import Optional, List
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from patchright.sync_api import Playwright, BrowserContext, Page
 from config import BROWSER_PROFILE_DIR, STATE_FILE, BROWSER_ARGS, USER_AGENT
@@ -54,7 +57,8 @@ class BrowserFactory:
                         context.add_cookies(state['cookies'])
                         # print(f"  🔧 Injected {len(state['cookies'])} cookies from state.json")
             except Exception as e:
-                print(f"  ⚠️  Could not load state.json: {e}")
+                # Cookie injection is optional; the persistent profile still works.
+                logger.warning("Could not load state.json: %s", e)
 
 
 class StealthUtils:
@@ -73,7 +77,8 @@ class StealthUtils:
             # Try waiting if not immediately found
             try:
                 element = page.wait_for_selector(selector, timeout=2000)
-            except:
+            except Exception:
+                # Element may not appear; handled by the not-found guard below.
                 pass
         
         if not element:

--- a/skills/documentation/research/notebooklm/scripts/browser_utils.py
+++ b/skills/documentation/research/notebooklm/scripts/browser_utils.py
@@ -8,7 +8,6 @@ import json
 import time
 import random
 import logging
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/skills/documentation/research/notebooklm/scripts/cleanup_manager.py
+++ b/skills/documentation/research/notebooklm/scripts/cleanup_manager.py
@@ -124,6 +124,7 @@ class CleanupManager:
                     if item.is_file():
                         total += item.stat().st_size
             except Exception:
+                # Best-effort size probe; return whatever was summed so far.
                 pass
             return total
         return 0

--- a/skills/documentation/research/notebooklm/scripts/notebook_manager.py
+++ b/skills/documentation/research/notebooklm/scripts/notebook_manager.py
@@ -9,6 +9,7 @@ import json
 import argparse
 import uuid
 import os
+import logging
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 from datetime import datetime
@@ -58,7 +59,7 @@ class NotebookLibrary:
             with open(self.library_file, 'w') as f:
                 json.dump(data, f, indent=2)
         except Exception as e:
-            print(f"❌ Error saving library: {e}")
+            logging.getLogger(__name__).error("Error saving library: %s", e)
 
     def add_notebook(
         self,

--- a/skills/documentation/research/notebooklm/scripts/setup_environment.py
+++ b/skills/documentation/research/notebooklm/scripts/setup_environment.py
@@ -8,6 +8,7 @@ import os
 import sys
 import subprocess
 import venv
+import logging
 from pathlib import Path
 
 
@@ -80,7 +81,7 @@ class SkillEnvironment:
                     )
                     print("✅ Chrome installed")
                 except subprocess.CalledProcessError as e:
-                    print(f"⚠️ Warning: Failed to install Chrome: {e}")
+                    logging.getLogger(__name__).warning("Failed to install Chrome: %s", e)
                     print("   You may need to run manually: python -m patchright install chrome")
                     print("   Chrome is required (not Chromium) for reliability!")
 

--- a/skills/documentation/research/pubmed-search/scripts/pubmed_search.py
+++ b/skills/documentation/research/pubmed-search/scripts/pubmed_search.py
@@ -24,6 +24,7 @@ try:
     from dotenv import load_dotenv
     load_dotenv()
 except ImportError:
+    # python-dotenv is optional; env vars can be provided directly.
     pass
 
 

--- a/skills/documentation/research/sci-data-extractor/scripts/extractor.py
+++ b/skills/documentation/research/sci-data-extractor/scripts/extractor.py
@@ -31,7 +31,8 @@ try:
     from dotenv import load_dotenv
     load_dotenv()
 except ImportError:
-    pass  # 如果没有安装 python-dotenv，跳过加载
+    # python-dotenv is optional; skip .env loading when it is not installed.
+    pass
 
 
 # ============================================

--- a/skills/documentation/research/sci-hub-search/scripts/sci_hub_search.py
+++ b/skills/documentation/research/sci-hub-search/scripts/sci_hub_search.py
@@ -8,6 +8,7 @@ import os
 import sys
 import json
 import argparse
+import logging
 import urllib3
 from pathlib import Path
 from typing import Optional, Dict, List, Any
@@ -34,6 +35,7 @@ try:
     from dotenv import load_dotenv
     load_dotenv()
 except ImportError:
+    # python-dotenv is optional; env vars can be provided directly.
     pass
 
 
@@ -168,7 +170,7 @@ class SciHubSearch:
                         papers.append(result)
 
         except Exception as e:
-            print(f"关键词搜索出错: {e}")
+            logging.getLogger(__name__).error("Keyword search failed: %s", e)
 
         return papers
 

--- a/skills/documentation/research/semantic-scholar-search/scripts/semantic-scholar-search.py
+++ b/skills/documentation/research/semantic-scholar-search/scripts/semantic-scholar-search.py
@@ -9,6 +9,7 @@ get paper details, author information, and citation data from Semantic Scholar.
 import argparse
 import json
 import sys
+import logging
 from typing import Dict, Any, List, Optional
 import semanticscholar as sch
 from semanticscholar import SemanticScholar, Author, Paper
@@ -264,7 +265,7 @@ class OutputHandler:
                 json.dump(data, f, indent=2, ensure_ascii=False)
             print(f"\n结果已保存到: {filepath}")
         except Exception as e:
-            print(f"Error writing to file: {str(e)}", file=sys.stderr)
+            logging.getLogger(__name__).error("Error writing to file: %s", e)
 
 
 def main():

--- a/skills/infrastructure/terraform/validator/scripts/extract_tf_info.py
+++ b/skills/infrastructure/terraform/validator/scripts/extract_tf_info.py
@@ -30,6 +30,7 @@ Requirements:
 import json
 import os
 import sys
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -76,9 +77,9 @@ class TerraformParser:
             self._extract_locals(parsed, filepath)
 
         except hcl2.lark_parser.UnexpectedToken as e:
-            print(f"HCL syntax error in {filepath}: {e}", file=sys.stderr)
+            logging.getLogger(__name__).error("HCL syntax error in %s: %s", filepath, e)
         except Exception as e:
-            print(f"Error parsing {filepath}: {e}", file=sys.stderr)
+            logging.getLogger(__name__).error("Error parsing %s: %s", filepath, e)
 
     def parse_directory(self, dirpath: str) -> None:
         """Parse all .tf files in a directory recursively."""

--- a/skills/infrastructure/terragrunt/validator/scripts/detect_custom_resources.py
+++ b/skills/infrastructure/terragrunt/validator/scripts/detect_custom_resources.py
@@ -14,6 +14,7 @@ import os
 import re
 import json
 import argparse
+import logging
 import sys
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
@@ -262,7 +263,7 @@ class ResourceDetector:
                     self.extract_providers(content, filepath)
                     self.extract_modules(content, filepath)
             except Exception as e:
-                print(f"Error reading {filepath}: {e}", file=sys.stderr)
+                logging.getLogger(__name__).error("Error reading %s: %s", filepath, e)
 
     def generate_report(self, output_format: str = 'text') -> str:
         """Generate a report of custom resources found."""


### PR DESCRIPTION
### **User description**
Wave 1 of the aislop remediation programme (driving the full-repo aislop score to the 70 threshold so the advisory gate can become blocking).

## What

**All 30 aislop error-severity findings are cleared** (repo `errors` 30 → 0).

1. **3 hallucinated-import false positives** — resolved via a committed `.aislop/config.yml` that excludes illustrative skill content (`references/`, `templates/`, `examples/`). The `opencode-toolkit` reference files import the real `@opencode-ai/plugin` SDK, correctly absent from this repo's `package.json`. `.gitignore` now tracks `config.yml` while keeping `.aislop/` local state ignored.
2. **27 swallowed-exception errors** across 14 skill scripts:
   - Deliberate best-effort / cleanup / optional-import swallows now carry an **intent comment** (aislop's sanctioned way to mark a deliberate, safe ignore).
   - Error-reporting catches that only `print`ed now **log via the `logging` module** (`logger.warning`/`error`).

## Scope note

This is the errors-only wave. **167 warnings remain** (score is 15/100 vs the 70 threshold) — `python-repetitive-dispatch` (42), `deep-nesting` (20), `file-too-large` (14), `broad-except`/`bare-except`, `unused-import`, formatting, etc. — concentrated in curated skill scripts. Those are Waves 2-4:
- **Wave 2**: broad-except / bare-except / chained-dict-get + mechanical (unused-import, formatting)
- **Wave 3**: repetitive-dispatch ladders
- **Wave 4**: nesting / file-size / function-length / rust-unwrap, then flip `aislop.yml` to blocking once score ≥ 70.

`aislop.yml` stays **advisory** until Wave 4.

## Verification

- `aislop scan .` → errors 0 (was 30).
- All 14 edited Python scripts compile (`py_compile`).
- Pre-commit hooks (skill-artifacts, python-allowlist, yaml) pass.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Resolve 30 `aislop` static analysis errors.
  - Add `.aislop/config.yml` to exclude illustrative content.
  - Replace bare exceptions with explicit ones and intent comments.
  - Upgrade stderr prints to proper logging statements.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Input ["30 aislop Errors"]
    H["Hallucinated Imports"]
    S["Swallowed Exceptions"]
    P["Bare Print Statements"]
  end

  subgraph Solutions ["Remediation Steps"]
    C["Add .aislop/config.yml"]
    I["Add Intent Comments & Explicit Exceptions"]
    L["Replace print with logging"]
  end

  H --> C
  S --> I
  P --> L

  C --> G["0 Errors / Green Build"]
  I --> G
  L --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>google-scholar-search.py</strong><dd><code>Replace stderr print with logging error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-776335bd0849e66e2efb5e7c27a7d6236886612265b6d8e11d2222f2a596791d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ask_question.py</strong><dd><code>Add explicit exceptions and intent comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-95a9c30a5b3aff7c85976f7b76d2e6573acc87bb3805eaf9818bc1cf64a2d496">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth_manager.py</strong><dd><code>Add explicit exceptions and intent comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-c2ca0391e87d8a78be7ce988d7f29e4c9fca1f875577f200db240067026d9903">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>browser_session.py</strong><dd><code>Add explicit exceptions, intent comments, and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-23c5d7d7eff2acd5c6e269b25938aa39813480bfce6e732085dc659e35b19293">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>browser_utils.py</strong><dd><code>Add explicit exceptions, intent comments, and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-5d23be6ba3604326541a185559e375530e83a68b435fcf3e9879ac968f8d42fe">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cleanup_manager.py</strong><dd><code>Add explicit exceptions and intent comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-b43a9fce3b41de4c438b029c50decc1f07faf2de0bba5652702d40dacc777460">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notebook_manager.py</strong><dd><code>Replace print with logging error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-9961cb96a473de729b2af4542e4a5616cd22d4ec260cb19beea71f8c0c9ea75e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setup_environment.py</strong><dd><code>Replace print with logging warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-f6812ded8527026e8f3cffd5392e147f243da930336d6570285a667466796a16">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pubmed_search.py</strong><dd><code>Add intent comment for optional import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-e7352cb427a1b89b723c91422645149f662b161e81d191e9b723792b7754c577">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>extractor.py</strong><dd><code>Add intent comment for optional import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-afaa1b969e4f403faa0cd995888bcc0d0c8cf05d9877816e4661bc5ffa4db262">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sci_hub_search.py</strong><dd><code>Add intent comment and replace print with logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-37e4949d28d69d832fb70d6aeed1c6529c00c54e4b579faf58ca27e0191c0a93">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>semantic-scholar-search.py</strong><dd><code>Replace print with logging error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-b55b580b7f21fdd12cf7061c63a5b0d0f1cb0a44e13be9fb72c8c9308f9719cd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>extract_tf_info.py</strong><dd><code>Replace print with logging error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-efe14e6a82cf14d05ad80b055b8a9a301195a471023725cb6a26d8477634e72f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>detect_custom_resources.py</strong><dd><code>Replace print with logging error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-74b0057e39a33454015e097807c4365c7bdab36b1813dacaa53338c8b7bbdf47">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config.yml</strong><dd><code>Exclude illustrative directories from scans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/231/files#diff-0d33ead9453e023b5ae38da2ee56254a1ca435faf2fad2bdf0ee40d94e1a6b9d">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

