### PR TITLE
ci(aislop): scope gate to core code + make it blocking (Wave 2)

### DIFF
--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -11,3 +11,12 @@ exclude:
   - "skills/**/references/**"
   - "skills/**/templates/**"
   - "skills/**/examples/**"
+
+# aislop's format engine also runs Biome, but its own bundled version
+# (@biomejs/biome ^2.5.1) differs from the repo's pinned Biome (^2.4.4 via
+# biome.json), so it reports phantom .ts formatting diffs. The repo's Biome
+# (biome.json + the hk pre-commit hook) is the single source of truth for
+# formatting, so disable aislop's duplicate pass rather than run two Biome
+# versions against each other.
+engines:
+  format: false

--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -11,6 +11,11 @@ exclude:
   - "skills/**/references/**"
   - "skills/**/templates/**"
   - "skills/**/examples/**"
+  # Curated skill scripts are gated and cleaned incrementally (tracked in
+  # issue #233), not by this blocking gate. The gate enforces quality on
+  # tekhne's own code (crates/, scripts/, features/, docs/). Removing this line
+  # brings skill scripts back under the gate once their backlog is cleared.
+  - "skills/**/scripts/**"
 
 # aislop's format engine also runs Biome, but its own bundled version
 # (@biomejs/biome ^2.5.1) differs from the repo's pinned Biome (^2.4.4 via

--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -33,19 +33,17 @@ jobs:
         with:
           node-version: 22
 
-      # Advisory rollout. `aislop ci` exits 1 below ci.failBelow (or aislop's
-      # default) or on any error-severity diagnostic, and a full-repo scan today
-      # reports 30 errors / 3 confirmed defects — so gating hard right now would
-      # block every PR. continue-on-error keeps this non-blocking while the
-      # findings are surfaced in the run log; the local PostToolUse hook still
-      # enforces quality per-edit. Promote to a hard gate (drop
-      # continue-on-error) once a full-repo scan is clean. Mirrors the staged
-      # rollout of the cargo-audit step in rust-ci.yml.
+      # Blocking gate. `aislop ci` exits 1 below ci.failBelow (default 70) or on
+      # any error-severity diagnostic. Scope is tekhne's own code (crates/,
+      # scripts/, features/, docs/); curated skill scripts are excluded in
+      # .aislop/config.yml and cleaned incrementally (tracked in issue #233), so
+      # they do not block. Core scores 78/100 with zero errors. When the skill
+      # scripts subtree is clean, drop the skills/**/scripts/** exclude to bring
+      # them under this gate too.
       #
       # aislop is unpinned (@latest) to match the local PostToolUse hook, which
       # also tracks latest; there is no aislop version pin in mise.toml. If CI
       # reproducibility later requires it, pin a specific version here and in the
       # hook together.
       - name: aislop ci
-        continue-on-error: true
         run: npx --yes aislop@latest ci .

--- a/skills/ci-cd/azure-pipelines/validator/scripts/check_best_practices.py
+++ b/skills/ci-cd/azure-pipelines/validator/scripts/check_best_practices.py
@@ -18,7 +18,7 @@ import sys
 import yaml
 import re
 from pathlib import Path
-from typing import Dict, List, Any, Set
+from typing import Dict, List, Any
 from collections import defaultdict
 
 

--- a/skills/ci-cd/azure-pipelines/validator/scripts/validate_syntax.py
+++ b/skills/ci-cd/azure-pipelines/validator/scripts/validate_syntax.py
@@ -17,7 +17,6 @@ import yaml
 import re
 from pathlib import Path
 from typing import Dict, List, Any, Tuple, Set
-from collections import defaultdict
 
 
 class ValidationError:

--- a/skills/ci-cd/fluentbit/validator/scripts/validate_config.py
+++ b/skills/ci-cd/fluentbit/validator/scripts/validate_config.py
@@ -7,15 +7,13 @@ Checks syntax, semantics, security, performance, and best practices.
 """
 
 import argparse
-import configparser
 import json
 import os
 import re
 import shutil
 import subprocess
 import sys
-from collections import defaultdict
-from typing import Dict, List, Tuple, Optional
+from typing import Dict
 
 
 class FluentBitValidator:

--- a/skills/ci-cd/jenkinsfile/generator/scripts/generate_declarative.py
+++ b/skills/ci-cd/jenkinsfile/generator/scripts/generate_declarative.py
@@ -13,8 +13,8 @@ from pathlib import Path
 # Add lib to path
 sys.path.insert(0, str(Path(__file__).parent / 'lib'))
 
-from common_patterns import PipelinePatterns, StageTemplates, PostConditions, EnvironmentTemplates
-from syntax_helpers import DeclarativeSyntax, FormattingHelpers, ValidationHelpers
+from common_patterns import PipelinePatterns, StageTemplates, PostConditions
+from syntax_helpers import DeclarativeSyntax, FormattingHelpers
 
 
 class DeclarativePipelineGenerator:

--- a/skills/ci-cd/jenkinsfile/generator/scripts/generate_scripted.py
+++ b/skills/ci-cd/jenkinsfile/generator/scripts/generate_scripted.py
@@ -14,7 +14,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / 'lib'))
 
 from common_patterns import PipelinePatterns
-from syntax_helpers import ScriptedSyntax, FormattingHelpers, ValidationHelpers
+from syntax_helpers import ScriptedSyntax, FormattingHelpers
 
 
 class ScriptedPipelineGenerator:

--- a/skills/documentation/research/notebooklm/scripts/auth_manager.py
+++ b/skills/documentation/research/notebooklm/scripts/auth_manager.py
@@ -17,7 +17,7 @@ import shutil
 import re
 import sys
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Dict, Any
 
 from patchright.sync_api import sync_playwright, BrowserContext
 

--- a/skills/documentation/research/notebooklm/scripts/cleanup_manager.py
+++ b/skills/documentation/research/notebooklm/scripts/cleanup_manager.py
@@ -7,7 +7,7 @@ Manages cleanup of skill data and browser state
 import shutil
 import argparse
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Dict, Any
 
 
 class CleanupManager:

--- a/skills/documentation/research/notebooklm/scripts/notebook_manager.py
+++ b/skills/documentation/research/notebooklm/scripts/notebook_manager.py
@@ -7,7 +7,6 @@ Based on the MCP server implementation
 
 import json
 import argparse
-import uuid
 import os
 import logging
 from pathlib import Path

--- a/skills/documentation/research/sci-data-extractor/scripts/extractor.py
+++ b/skills/documentation/research/sci-data-extractor/scripts/extractor.py
@@ -10,7 +10,7 @@ import sys
 import json
 import argparse
 from pathlib import Path
-from typing import Optional, Dict, List, Any
+from typing import Optional, Dict, List
 
 try:
     import fitz  # PyMuPDF

--- a/skills/documentation/research/sci-hub-search/scripts/sci_hub_search.py
+++ b/skills/documentation/research/sci-hub-search/scripts/sci_hub_search.py
@@ -11,7 +11,7 @@ import argparse
 import logging
 import urllib3
 from pathlib import Path
-from typing import Optional, Dict, List, Any
+from typing import Dict, List, Any
 
 try:
     from scihub import SciHub

--- a/skills/infrastructure/terragrunt/validator/scripts/detect_custom_resources.py
+++ b/skills/infrastructure/terragrunt/validator/scripts/detect_custom_resources.py
@@ -17,7 +17,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import List
 from collections import defaultdict
 
 

--- a/skills/observability/promql/validator/scripts/check_best_practices.py
+++ b/skills/observability/promql/validator/scripts/check_best_practices.py
@@ -9,7 +9,7 @@ Provides actionable suggestions for improving query efficiency and correctness.
 import re
 import sys
 import json
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List
 
 
 class PromQLBestPracticesChecker:

--- a/skills/observability/promql/validator/scripts/validate_syntax.py
+++ b/skills/observability/promql/validator/scripts/validate_syntax.py
@@ -9,7 +9,7 @@ Checks for correct metric names, label matchers, operators, functions, and time 
 import re
 import sys
 import json
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List
 
 
 class PromQLSyntaxValidator:


### PR DESCRIPTION
Makes the aislop gate **blocking** for tekhne's own code, and clears the mechanical debt. Builds on Wave 1 (#231, merged).

## What

1. **Scope the gate to core code + make it blocking.** Full-repo aislop is ~20/100 (167 warnings, overwhelmingly in curated skill scripts needing behaviour-risky per-site refactoring). tekhne's own code — `crates/`, `scripts/`, `features/`, `docs/` — scores **78/100 with zero errors**, so the gate can enforce quality there today.
   - `.aislop/config.yml`: exclude `skills/**/scripts/**` (curated skill scripts cleaned incrementally, tracked in **#233**).
   - `aislop.yml`: drop `continue-on-error` → the gate now blocks.
2. **Disable aislop's format engine** (`engines: { format: false }`). It runs its own bundled Biome (`^2.5.1`) which disagreed with the repo's pinned Biome (`^2.4.4`, `biome.json` + hk hook), producing 28 phantom `.ts` diffs. The repo's Biome is the single source of truth.
3. **Remove 22 unused imports** across 13 skill Python scripts (via `aislop fix`).

## Result

- `aislop ci .` exits **0** (core score 78 ≥ 70 threshold, 0 errors). `actionlint` clean.
- Blocking gate now enforced on tekhne's own code.

## Deferred (tracked in #233)

Curated skill-script cleanup: broad/bare-except narrowing, chained-dict-get, repetitive-dispatch, deep-nesting, file-too-large, function-too-long. When that subtree scores ≥ 70, drop the `skills/**/scripts/**` exclude to bring it under the gate.

Note: aislop's `# aislop-ignore` directive does NOT suppress these Python rules, so those warnings need genuine narrowing/refactoring, not waivers.