### PR TITLE
ci(plumber): disable classic branch-protection check — main uses a ruleset (closes #230)

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -838,8 +838,17 @@ github:
     # only read access is NOT enough. Without scope the collector
     # returns an empty branch list and the rule emits no findings,
     # same degraded contract as missing API auth elsewhere.
+    #
+    # DISABLED (see issue #230, ISSUE-505): `main` is protected by a GitHub
+    # *ruleset* (id 13518481), not classic branch protection. It enforces linear
+    # history, required status checks, pull-request + thread resolution, blocks
+    # force-push and deletion, and has no bypass actors. Plumber v0.4.x only
+    # reads the classic branch-protection API (which returns 404 for a
+    # ruleset-protected branch), so this control emits a false-positive High
+    # finding regardless of how strong the ruleset is. Re-enable if/when Plumber
+    # gains GitHub-ruleset support, or if classic branch protection is adopted.
     branchMustBeProtected:
-      enabled: true
+      enabled: false
       defaultMustBeProtected: true
       namePatterns:
         - main


### PR DESCRIPTION
Closes #230 (Plumber ISSUE-505, `branchMustBeProtected`).

## Root cause

`main` is protected by a **GitHub ruleset** (id 13518481), not classic branch protection. The ruleset enforces: linear history, required status checks (strict), pull-request + review-thread resolution, blocks force-push and deletion, and has **no bypass actors**.

Plumber v0.4.x inspects only the **classic** branch-protection API (`/branches/main/protection`), which returns **404** for a ruleset-protected branch. So `branchMustBeProtected` reports `main` as unprotected — a **false positive** regardless of how strong the ruleset is. Strengthening the ruleset would not clear it.

## Fix

Disable the `github` `branchMustBeProtected` control in `.plumber.yaml`, with an inline justification documenting the ruleset (id + enforced rules) and the tool limitation. Chosen over the alternatives (per discussion):
- Adding redundant classic branch protection alongside the ruleset (two overlapping systems).
- Strengthening the ruleset (a real option, but wouldn't clear ISSUE-505 since Plumber still can't read rulesets, and would need bypass actors for the bot/auto-merge flow).

## Result

- ISSUE-505 no longer emitted. On the next push to `main`, `plumber-file-issues.sh` sees zero High/Med/Low findings and **auto-closes #230**.
- Re-enable the control if Plumber gains GitHub-ruleset support, or if classic branch protection is later adopted.

## Note (separate, not addressed here)

The ruleset currently requires a PR but **0 approvals** and no code-owner review (there's no CODEOWNERS file). If you want to require reviews/code-owner approval on `main`, that's a deliberate governance change — happy to do it as a follow-up (it would need bypass actors for `release-automerge`/`pr-auto-rebase`).