### PR TITLE
ci(pr-agent): fix fallback chain so a Gemini outage doesn't silently drop the review

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -79,6 +79,13 @@ jobs:
           # litellm fallbacks so a single provider's rate limit is not a SPOF.
           config.model: "gemini/gemini-3.5-flash"
           config.fallback_models: '["mistral/mistral-small-2603", "cerebras/gpt-oss-120b"]'
+          # The fallback models are not in PR-Agent's built-in MAX_TOKENS table,
+          # so without this they fail with "not defined in MAX_TOKENS" the moment
+          # Gemini is unavailable (e.g. a 503), leaving the review silently
+          # unposted. A positive custom_model_max_tokens gives any unknown model
+          # a context budget so the fallback chain actually works. Both fallbacks
+          # support >=128k context.
+          config.custom_model_max_tokens: "128000"
           GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           # PR-Agent maps MISTRAL.KEY to MISTRAL_API_KEY; Cerebras has no
           # PR-Agent-specific key, litellm reads CEREBRAS_API_KEY from the env.


### PR DESCRIPTION
### **User description**
## Diagnosis

pr-agent **is** wired up (provider secrets exist, the job runs), but on PR #235 it posted no review. From the run log:

1. `gemini/gemini-3.5-flash` → **503 ServiceUnavailable** (transient overload). Model ID is valid, just busy.
2. Fallback `mistral/mistral-small-2603` → **`Model … is not defined in MAX_TOKENS … and no custom_model_max_tokens is set`**.
3. Fallback `cerebras/gpt-oss-120b` → same class of failure.

The step is `continue-on-error`, so the exhausted chain left the check green with **no review** — the silent no-op.

## Fix

Set `config.custom_model_max_tokens: "128000"`. The fallback models aren't in PR-Agent's bundled MAX_TOKENS table, so without a custom token budget they can't be used at all. With it, the fallback chain works when the primary (Gemini) is unavailable. Both fallbacks support ≥128k context.

## Verification

- `actionlint` clean.
- Root cause confirmed directly from the failed run's litellm logs (not guessed).
- Next non-skill PR (or a `/review` comment) will exercise the fallback path; if a fallback model ID itself turns out to be retired, that'll now surface as a distinct model-not-found error rather than the MAX_TOKENS block.


___

### **PR Type**
Enhancement


___

### **Description**
- Fix PR-Agent fallback chain to prevent silent review drops during model outages

- Set `custom_model_max_tokens` to enable fallback models with large context support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  gemini["gemini/gemini-3.5-flash"] -- 503 unavailable --> mistral["mistral/mistral-small-2603"]
  mistral -- 'MAX_TOKENS error' --> cerebras["cerebras/gpt-oss-120b"]
  cerebras -- 'MAX_TOKENS error' --> no_review["No review posted"]
  config["config.custom_model_max_tokens=128000"] -- enables --> mistral
  config -- enables --> cerebras
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Enable PR-Agent fallback models with custom token budget</code>&nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Added <code>config.custom_model_max_tokens: "128000"</code> to enable fallback <br>models<br> <li> Added inline documentation explaining the MAX_TOKENS limitation and <br>fix<br> <li> Both fallback models (<code>mistral/mistral-small-2603</code> and <br><code>cerebras/gpt-oss-120b</code>) support ≥128k context</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/236/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

