### PR TITLE
test(skill-validator): refresh golden corpus after genericization scrub

### DIFF
--- a/crates/skill-validator-rs/tests/golden-corpus/goldens.json
+++ b/crates/skill-validator-rs/tests/golden-corpus/goldens.json
@@ -8790,7 +8790,7 @@
       "token_counts": [
         {
           "File": "SKILL.md body",
-          "Tokens": 3594
+          "Tokens": 3591
         },
         {
           "File": "references/compliance.md",
@@ -8806,7 +8806,7 @@
         },
         {
           "File": "references/example-with-frontmatter.md",
-          "Tokens": 4608
+          "Tokens": 4586
         },
         {
           "File": "references/journal-command.md",
@@ -12902,7 +12902,7 @@
         },
         {
           "File": "evals/scenario-02.md",
-          "Tokens": 584
+          "Tokens": 572
         },
         {
           "File": "evals/scenario-03.md",
@@ -13091,7 +13091,7 @@
         },
         {
           "File": "references/sns-testing-guide.md",
-          "Tokens": 1737
+          "Tokens": 1735
         },
         {
           "File": "CHANGELOG.md",
@@ -13199,21 +13199,21 @@
         },
         {
           "File": "references/compare-cfn-templates.md",
-          "Tokens": 3190
+          "Tokens": 3136
         },
         {
           "File": "references/markdown-report-example.md",
-          "Tokens": 2138
+          "Tokens": 2133
         }
       ],
       "other_token_counts": [
         {
           "File": "evals/scenario-01.md",
-          "Tokens": 957
+          "Tokens": 956
         },
         {
           "File": "evals/scenario-02.md",
-          "Tokens": 859
+          "Tokens": 858
         },
         {
           "File": "evals/scenario-03.md",
@@ -14119,7 +14119,7 @@
         },
         {
           "File": "evals/scenario-05.md",
-          "Tokens": 1186
+          "Tokens": 1187
         }
       ],
       "errors": 1,


### PR DESCRIPTION
### **User description**
Follow-up to the internal-reference genericization scrub.

## What

That scrub changed token counts in a few corpus skills' docs, so the frozen golden-corpus (`goldens.json`) no longer matched and `rust_validator_matches_go_golden_corpus` failed.

Regenerated `goldens.json` via the pinned **Go reference** (`goref`) over the updated corpus — the authoritative source for the parity gate. The diff is **exactly 9 `Tokens` values** (journal-entry-creator, cfn/template-compare, cfn/behavior-validator, aws-cloudwatch-url-builder, terraform/validator); no structural or behavioural changes. The validator algorithm is unchanged — parity still holds on every other field across all 152 corpus skills.

## Verification

- `cargo build --workspace` clean.
- `cargo test --workspace` — all suites pass, 0 failed (golden_parity green).
- `git diff` on `goldens.json` = 9 token-count lines only.


___

### **PR Type**
Tests


___

### **Description**
- Refresh `goldens.json` token counts after genericization changes

- Update 9 token values across 5 corpus skills

- Validate parity with Go reference (`goref`) source

- Ensure golden_parity and test suite pass


___

### Diagram Walkthrough


```mermaid
flowchart LR
  corpus[("Corpus Skills")] -->|token counts changed| goldens.json[("goldens.json")]
  goldens.json -->|parity check| validator[("Rust Validator")]
  validator -->|pass| tests[("Test Suite")]
  tests -->|confirm| parity[("Golden Parity")]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>goldens.json</strong><dd><code>Update token counts in golden corpus for affected skills</code>&nbsp; </dd></summary>
<hr>

crates/skill-validator-rs/tests/golden-corpus/goldens.json

<ul><li>Updated 9 <code>Tokens</code> values in <code>token_counts</code> and <code>other_token_counts</code> arrays<br> <li> Changes reflect updated token counts for affected corpus skills:<br>   - <br><code>journal-entry-creator</code>: SKILL.md body (3594 → 3591)<br>   - <br><code>aws-cloudwatch-url-builder</code>: <code>references/example-with-frontmatter.md</code> <br>(4608 → 4586)<br>   - <code>cfn/behavior-validator</code>: <code>evals/scenario-02.md</code> (584 → <br>572)<br>   - <code>cfn/template-compare</code>: <code>references/compare-cfn-templates.md</code> <br>(3190 → 3136), <code>references/markdown-report-example.md</code> (2138 → 2133)<br>   - <br><code>terraform/validator</code>: <code>evals/scenario-05.md</code> (1186 → 1187)</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/238/files#diff-d44f58d0e2f60a15bf762d12c46e76eee7a422c725527a2d6b4189d61594a2b5">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

