### PR TITLE
feat(journal): corpus index (pantheon-journal index)

### DIFF
--- a/crates/journal/src/index.rs
+++ b/crates/journal/src/index.rs
@@ -1,0 +1,552 @@
+//! Generate the journal browse index.
+//!
+//! Port of the journal CLI's `index/` tree. The NDJSON data file is the
+//! machine-readable source of truth (one record per logical entry); the
+//! markdown view is rendered from the same scanned entries so the two never
+//! disagree. Both are deterministic: entries arrive newest-first from the scan,
+//! and records serialise in a fixed key order.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use common::{Error, Result};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::scan::Entry;
+use crate::taxonomy::Taxonomy;
+
+/// Default machine-readable index path (the source of truth).
+pub const INDEX_DATA_PATH: &str = "docs/journal-index.ndjson";
+/// Default human-readable index path (rendered from the data).
+pub const INDEX_VIEW_PATH: &str = "docs/journal-index.md";
+
+/// One record in the index NDJSON: one line equals one logical entry. Field
+/// order here is the serialisation order, kept fixed for deterministic output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IndexRecord {
+    pub file: String,
+    pub files: Vec<String>,
+    pub slug: String,
+    pub date: String,
+    pub title: String,
+    pub tags: Vec<String>,
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    pub tickets: Vec<String>,
+    pub authors: Vec<String>,
+    pub status: String,
+    pub summary: String,
+}
+
+/// Project a scanned entry onto the record written to NDJSON.
+pub fn entry_to_record(entry: &Entry) -> IndexRecord {
+    IndexRecord {
+        file: entry.file.clone(),
+        files: entry.files.clone(),
+        slug: entry.slug.clone(),
+        date: entry.date.clone(),
+        title: entry.title.clone(),
+        tags: entry.tags.clone(),
+        entry_type: entry.entry_type.clone(),
+        tickets: entry.tickets.clone(),
+        authors: entry.authors.clone(),
+        status: entry.status.clone(),
+        summary: entry.summary.clone(),
+    }
+}
+
+/// Serialise records to NDJSON: one compact JSON object per line, with a
+/// trailing newline when non-empty. Order is preserved from the caller.
+pub fn records_to_ndjson(records: &[IndexRecord]) -> Result<String> {
+    if records.is_empty() {
+        return Ok(String::new());
+    }
+    let mut out = String::new();
+    for r in records {
+        let line = serde_json::to_string(r).map_err(|e| Error::json("index record", e))?;
+        out.push_str(&line);
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+/// The effective canonical tag set: tags at or over threshold, plus `pin`,
+/// minus `suppress`.
+pub fn compute_canonical(
+    counts: &BTreeMap<String, usize>,
+    taxonomy: &Taxonomy,
+) -> BTreeSet<String> {
+    let mut canonical: BTreeSet<String> = BTreeSet::new();
+    for (tag, count) in counts {
+        if *count as u32 >= taxonomy.threshold {
+            canonical.insert(tag.clone());
+        }
+    }
+    for pinned in &taxonomy.pin {
+        canonical.insert(pinned.clone());
+    }
+    for suppressed in &taxonomy.suppress {
+        canonical.remove(suppressed);
+    }
+    canonical
+}
+
+const MONTHS: [&str; 12] = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
+
+/// "June 2026" from a `YYYY-MM-DD` date, or the raw date on a parse failure.
+fn month_label(date: &str) -> String {
+    let month: usize = date.get(5..7).and_then(|m| m.parse().ok()).unwrap_or(0);
+    let year = date.get(0..4).unwrap_or(date);
+    match month {
+        1..=12 => format!("{} {}", MONTHS[month - 1], year),
+        _ => date.to_string(),
+    }
+}
+
+/// A `- [YYYY-MM-DD title](../file)` bullet.
+fn bullet(e: &Entry) -> String {
+    format!("- [{} {}](../{})", e.date, e.title, e.file)
+}
+
+/// `## Recent Entries`: a table of the newest `limit` entries.
+fn render_recent(entries: &[Entry], limit: usize) -> String {
+    let recent = &entries[..entries.len().min(limit)];
+    if recent.is_empty() {
+        return String::new();
+    }
+    let mut rows = String::from("| Date | Title | Tags |\n|------|-------|------|");
+    for e in recent {
+        rows.push_str(&format!(
+            "\n| {} | [{}](../{}) | {} |",
+            e.date,
+            e.title,
+            e.file,
+            e.tags.join(", ")
+        ));
+    }
+    format!("## Recent Entries\n\n{rows}")
+}
+
+/// `## By Month`: entries grouped by month, months newest-first.
+fn render_chronological(entries: &[Entry]) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    // Entries arrive newest-first, so first-seen month order is newest-first.
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: BTreeMap<String, Vec<&Entry>> = BTreeMap::new();
+    for e in entries {
+        let label = month_label(&e.date);
+        if !groups.contains_key(&label) {
+            order.push(label.clone());
+        }
+        groups.entry(label).or_default().push(e);
+    }
+    let sections: Vec<String> = order
+        .iter()
+        .map(|label| {
+            let ents = &groups[label];
+            let noun = if ents.len() == 1 { "entry" } else { "entries" };
+            let bullets = ents
+                .iter()
+                .map(|e| bullet(e))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("### {label} ({} {noun})\n\n{bullets}", ents.len())
+        })
+        .collect();
+    format!("## By Month\n\n{}", sections.join("\n\n"))
+}
+
+/// `## By Type`: entries grouped by type, ordered by the `type` facet.
+fn render_by_type(entries: &[Entry], taxonomy: &Taxonomy) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    let mut groups: BTreeMap<String, Vec<&Entry>> = BTreeMap::new();
+    for e in entries {
+        groups.entry(e.entry_type.clone()).or_default().push(e);
+    }
+    let type_order = taxonomy.facets.get("type").cloned().unwrap_or_default();
+    let mut types: Vec<String> = groups.keys().cloned().collect();
+    types.sort_by(|a, b| {
+        let ai = type_order.iter().position(|t| t == a);
+        let bi = type_order.iter().position(|t| t == b);
+        match (ai, bi) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.cmp(b),
+        }
+    });
+    let sections: Vec<String> = types
+        .iter()
+        .map(|ty| {
+            let ents = &groups[ty];
+            let bullets = ents
+                .iter()
+                .map(|e| bullet(e))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("### {ty} ({})\n\n{bullets}", ents.len())
+        })
+        .collect();
+    format!("## By Type\n\n{}", sections.join("\n\n"))
+}
+
+/// `## By Tag (canonical only)`: canonical tags grouped by facet, with an
+/// emerging-tags details block for below-threshold tags.
+fn render_by_tag(entries: &[Entry], taxonomy: &Taxonomy, ticket_re: &Regex) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for e in entries {
+        for tag in &e.tags {
+            if !ticket_re.is_match(tag) {
+                *counts.entry(tag.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+    let canonical = compute_canonical(&counts, taxonomy);
+
+    // tag -> entries carrying it (scan order preserved: newest-first).
+    let mut tag_entries: BTreeMap<String, Vec<&Entry>> = BTreeMap::new();
+    for e in entries {
+        for tag in &e.tags {
+            if !ticket_re.is_match(tag) && canonical.contains(tag) {
+                tag_entries.entry(tag.clone()).or_default().push(e);
+            }
+        }
+    }
+
+    let facet_order: Vec<String> = taxonomy.facets.keys().cloned().collect();
+    let mut sections: Vec<String> = Vec::new();
+
+    let render_group = |tags: &mut Vec<(String, usize)>| -> String {
+        tags.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        tags.iter()
+            .map(|(tag, count)| {
+                let bullets = tag_entries
+                    .get(tag)
+                    .map(|ents| {
+                        ents.iter()
+                            .map(|e| bullet(e))
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    })
+                    .unwrap_or_default();
+                format!("#### {tag} ({count})\n\n{bullets}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    };
+
+    for facet in &facet_order {
+        let members = &taxonomy.facets[facet];
+        let mut in_facet: Vec<(String, usize)> = canonical
+            .iter()
+            .filter(|t| members.contains(t))
+            .map(|t| (t.clone(), counts.get(t).copied().unwrap_or(0)))
+            .collect();
+        if in_facet.is_empty() {
+            continue;
+        }
+        sections.push(format!("### {facet}\n\n{}", render_group(&mut in_facet)));
+    }
+
+    // Canonical tags in no facet.
+    let mut uncat: Vec<(String, usize)> = canonical
+        .iter()
+        .filter(|t| !facet_order.iter().any(|f| taxonomy.facets[f].contains(t)))
+        .map(|t| (t.clone(), counts.get(t).copied().unwrap_or(0)))
+        .collect();
+    if !uncat.is_empty() {
+        sections.push(format!("### Uncategorised\n\n{}", render_group(&mut uncat)));
+    }
+
+    // Emerging: counted but not canonical.
+    let mut emerging: Vec<(String, usize)> = counts
+        .iter()
+        .filter(|(t, _)| !canonical.contains(*t))
+        .map(|(t, c)| (t.clone(), *c))
+        .collect();
+    emerging.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    if !emerging.is_empty() {
+        let list = emerging
+            .iter()
+            .map(|(t, c)| format!("{t} ({c})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        sections.push(format!(
+            "<details><summary>Other tags (emerging)</summary>\n\n{list}\n\n</details>"
+        ));
+    }
+
+    if sections.is_empty() {
+        return String::new();
+    }
+    format!("## By Tag (canonical only)\n\n{}", sections.join("\n\n"))
+}
+
+/// `## By Ticket`: entries grouped by ticket key, tickets sorted ascending.
+fn render_by_ticket(entries: &[Entry]) -> String {
+    let mut ticket_entries: BTreeMap<String, Vec<&Entry>> = BTreeMap::new();
+    for e in entries {
+        for ticket in &e.tickets {
+            ticket_entries.entry(ticket.clone()).or_default().push(e);
+        }
+    }
+    if ticket_entries.is_empty() {
+        return String::new();
+    }
+    let sections: Vec<String> = ticket_entries
+        .iter()
+        .map(|(ticket, ents)| {
+            let bullets = ents
+                .iter()
+                .map(|e| bullet(e))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("### {ticket} ({})\n\n{bullets}", ents.len())
+        })
+        .collect();
+    format!("## By Ticket\n\n{}", sections.join("\n\n"))
+}
+
+/// Assemble the complete index document. `today` is a `YYYY-MM-DD` stamp for the
+/// header (injected so the output is deterministic in tests).
+pub fn render_index(entries: &[Entry], taxonomy: &Taxonomy, today: &str) -> Result<String> {
+    let ticket_re = taxonomy.ticket_regex()?;
+    let header = format!(
+        "# Journal Index\n\n> Auto-generated. Do not edit.\n> {} entries · last updated {}\n",
+        entries.len(),
+        today
+    );
+    let sections: Vec<String> = [
+        render_recent(entries, 15),
+        render_chronological(entries),
+        render_by_type(entries, taxonomy),
+        render_by_tag(entries, taxonomy, &ticket_re),
+        render_by_ticket(entries),
+    ]
+    .into_iter()
+    .filter(|s| !s.is_empty())
+    .collect();
+    Ok(format!("{header}\n\n{}\n", sections.join("\n\n")))
+}
+
+/// A record's normalised-tag shape: lowercase alphanumerics separated by `-`
+/// or `/` (the hierarchical-tag convention).
+fn tag_re() -> &'static Regex {
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^[a-z0-9]+(?:[-/][a-z0-9]+)*$").expect("valid tag regex"))
+}
+
+/// Validate NDJSON index text: parse each line, schema-check, then run
+/// cross-record invariants. `file_exists` probes whether an entry file is on
+/// disk (skipped when `None`). Returns human-readable errors; empty means valid.
+pub fn validate_ndjson(text: &str, file_exists: Option<&dyn Fn(&str) -> bool>) -> Vec<String> {
+    let mut errors: Vec<String> = Vec::new();
+    let mut records: Vec<IndexRecord> = Vec::new();
+    for (i, line) in text.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<IndexRecord>(line) {
+            Ok(r) => records.push(r),
+            Err(e) => errors.push(format!("record {i}: invalid JSON/schema: {e}")),
+        }
+    }
+
+    let date_re = Regex::new(r"^\d{4}-\d{2}-\d{2}$").expect("valid date regex");
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    for (i, r) in records.iter().enumerate() {
+        if r.file.is_empty() {
+            errors.push(format!("record {i}: empty file"));
+        }
+        if r.files.is_empty() {
+            errors.push(format!("record {i}: files must be non-empty"));
+        }
+        if !date_re.is_match(&r.date) {
+            errors.push(format!(
+                "record {i}: date \"{}\" must be YYYY-MM-DD",
+                r.date
+            ));
+        }
+        if !seen.insert(r.file.clone()) {
+            errors.push(format!("record {i}: duplicate file \"{}\"", r.file));
+        }
+        if r.slug.chars().take(10).collect::<String>() != r.date {
+            errors.push(format!(
+                "record {i}: date \"{}\" does not match slug prefix",
+                r.date
+            ));
+        }
+        for t in &r.tags {
+            if !tag_re().is_match(t) {
+                errors.push(format!("record {i}: tag \"{t}\" is not lowercase-hyphen"));
+            }
+        }
+        if let Some(probe) = file_exists {
+            if !probe(&r.file) {
+                errors.push(format!("record {i}: file \"{}\" does not exist", r.file));
+            }
+        }
+    }
+    errors
+}
+
+/// Build the index artifacts (ndjson + markdown) from scanned entries.
+/// Validates the ndjson before returning; errors surface uncommittable output.
+pub fn build_index(
+    entries: &[Entry],
+    taxonomy: &Taxonomy,
+    today: &str,
+) -> Result<(String, String)> {
+    let records: Vec<IndexRecord> = entries.iter().map(entry_to_record).collect();
+    let ndjson = records_to_ndjson(&records)?;
+    let errors = validate_ndjson(&ndjson, None);
+    if !errors.is_empty() {
+        return Err(Error::Config(format!(
+            "generated index failed validation:\n  {}",
+            errors.join("\n  ")
+        )));
+    }
+    let view = render_index(entries, taxonomy, today)?;
+    Ok((ndjson, view))
+}
+
+/// Load an entry path resolver bound to `root` for the `file_exists` probe.
+pub fn file_exists_under(root: &Path) -> impl Fn(&str) -> bool + '_ {
+    move |rel: &str| root.join(rel).exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::Entry;
+
+    fn tax() -> Taxonomy {
+        Taxonomy::from_json(
+            r#"{ "threshold": 2, "aliases": {}, "facets": { "type": ["troubleshooting", "general"], "tech": ["aws"] }, "pin": [], "suppress": [], "ticketPattern": "^x-[0-9]+$" }"#,
+            "test",
+        )
+        .unwrap()
+    }
+
+    fn entry(slug: &str, tags: &[&str], tickets: &[&str], ty: &str) -> Entry {
+        Entry {
+            file: format!("2026/07/{slug}.md"),
+            files: vec![format!("2026/07/{slug}.md")],
+            slug: slug.to_string(),
+            date: slug.chars().take(10).collect(),
+            title: "Title".to_string(),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            entry_type: ty.to_string(),
+            tickets: tickets.iter().map(|s| s.to_string()).collect(),
+            authors: vec![],
+            status: String::new(),
+            summary: String::new(),
+        }
+    }
+
+    #[test]
+    fn ndjson_is_compact_and_newline_terminated() {
+        let recs = vec![entry_to_record(&entry(
+            "2026-07-01-a",
+            &["aws"],
+            &[],
+            "general",
+        ))];
+        let out = records_to_ndjson(&recs).unwrap();
+        assert!(out.ends_with('\n'));
+        assert_eq!(out.lines().count(), 1);
+        assert!(out.contains("\"type\":\"general\""));
+        assert!(out.contains("\"file\":\"2026/07/2026-07-01-a.md\""));
+    }
+
+    #[test]
+    fn empty_records_yield_empty_ndjson() {
+        assert_eq!(records_to_ndjson(&[]).unwrap(), "");
+    }
+
+    #[test]
+    fn canonical_respects_threshold_pin_suppress() {
+        let mut counts = BTreeMap::new();
+        counts.insert("aws".to_string(), 3usize);
+        counts.insert("rare".to_string(), 1usize);
+        let mut t = tax();
+        t.pin = vec!["rare".to_string()];
+        t.suppress = vec!["aws".to_string()];
+        let canon = compute_canonical(&counts, &t);
+        assert!(canon.contains("rare")); // pinned despite low count
+        assert!(!canon.contains("aws")); // suppressed despite high count
+    }
+
+    #[test]
+    fn render_index_has_all_sections() {
+        let entries = vec![
+            entry(
+                "2026-07-09-b",
+                &["aws", "orphan"],
+                &["x-1"],
+                "troubleshooting",
+            ),
+            entry("2026-07-01-a", &["aws", "orphan"], &[], "general"),
+        ];
+        let view = render_index(&entries, &tax(), "2026-07-24").unwrap();
+        assert!(view.contains("# Journal Index"));
+        assert!(view.contains("2 entries · last updated 2026-07-24"));
+        assert!(view.contains("## Recent Entries"));
+        assert!(view.contains("## By Month"));
+        assert!(view.contains("## By Type"));
+        assert!(view.contains("## By Tag (canonical only)"));
+        assert!(view.contains("## By Ticket"));
+        assert!(view.contains("### x-1 (1)"));
+        // aws is faceted (tech); orphan is canonical-but-unfaceted.
+        assert!(view.contains("### tech"));
+        assert!(view.contains("### Uncategorised"));
+    }
+
+    #[test]
+    fn validate_flags_bad_records() {
+        // date/slug mismatch + uppercase tag + duplicate file.
+        let bad = r#"{"file":"2026/07/a.md","files":["2026/07/a.md"],"slug":"2026-07-01-a","date":"2026-07-02","title":"T","tags":["BadTag"],"type":"general","tickets":[],"authors":[],"status":"","summary":""}
+{"file":"2026/07/a.md","files":["2026/07/a.md"],"slug":"2026-07-01-a","date":"2026-07-01","title":"T","tags":[],"type":"general","tickets":[],"authors":[],"status":"","summary":""}"#;
+        let errors = validate_ndjson(bad, None);
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("does not match slug prefix")));
+        assert!(errors.iter().any(|e| e.contains("not lowercase-hyphen")));
+        assert!(errors.iter().any(|e| e.contains("duplicate file")));
+    }
+
+    #[test]
+    fn validate_accepts_clean_records() {
+        let recs = vec![entry_to_record(&entry(
+            "2026-07-01-a",
+            &["aws"],
+            &[],
+            "general",
+        ))];
+        let ndjson = records_to_ndjson(&recs).unwrap();
+        assert!(validate_ndjson(&ndjson, None).is_empty());
+    }
+}

--- a/crates/journal/src/lib.rs
+++ b/crates/journal/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod date;
 pub mod entry;
+pub mod index;
 pub mod install_cmd;
 pub mod lint;
 pub mod scan;

--- a/crates/journal/src/lint.rs
+++ b/crates/journal/src/lint.rs
@@ -194,7 +194,16 @@ mod tests {
     fn entry(file: &str, tags: &[&str]) -> Entry {
         Entry {
             file: file.to_string(),
+            files: vec![file.to_string()],
+            slug: String::new(),
+            date: String::new(),
+            title: String::new(),
             tags: tags.iter().map(|s| s.to_string()).collect(),
+            entry_type: "general".to_string(),
+            tickets: vec![],
+            authors: vec![],
+            status: String::new(),
+            summary: String::new(),
         }
     }
 

--- a/crates/journal/src/main.rs
+++ b/crates/journal/src/main.rs
@@ -8,6 +8,7 @@ use std::process;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use journal::date::Timestamp;
 use journal::entry::{EntrySpec, EntryType};
+use journal::index;
 use journal::install_cmd::{self, InstallOptions, Selection, UninstallOptions};
 use journal::lint;
 use journal::scan;
@@ -43,6 +44,8 @@ enum Command {
     },
     /// Lint corpus tags against the taxonomy (advisory).
     Lint(LintArgs),
+    /// Generate the browse index (NDJSON source of truth + markdown view).
+    Index(IndexArgs),
     /// Manage the bundled companion skill.
     Skill {
         #[command(subcommand)]
@@ -91,6 +94,29 @@ struct LintArgs {
     /// Exit non-zero when any suggestion or unfaceted tag is found (for CI).
     #[arg(long)]
     strict: bool,
+}
+
+#[derive(Args)]
+struct IndexArgs {
+    /// Journal root to scan for entries and a `taxonomy.json`.
+    #[arg(long, default_value = ".")]
+    root: PathBuf,
+    /// Explicit taxonomy file, overriding `<root>/taxonomy.json` and the default.
+    #[arg(long)]
+    taxonomy: Option<PathBuf>,
+    /// NDJSON output path (default: docs/journal-index.ndjson).
+    #[arg(long)]
+    data: Option<PathBuf>,
+    /// Markdown output path (default: docs/journal-index.md).
+    #[arg(long)]
+    view: Option<PathBuf>,
+    /// Print the generated index to stdout instead of writing files.
+    #[arg(long = "dry-run")]
+    dry_run: bool,
+    /// Validate the existing NDJSON against the schema and invariants; do not
+    /// regenerate.
+    #[arg(long)]
+    validate: bool,
 }
 
 #[derive(Subcommand)]
@@ -170,6 +196,7 @@ fn main() {
         Command::New(args) => run_new(args),
         Command::Validate { file } => run_validate(&file),
         Command::Lint(args) => run_lint(args),
+        Command::Index(args) => run_index(args),
         Command::Skill {
             action: SkillAction::Install(args),
         } => run_skill_install(args),
@@ -293,6 +320,72 @@ fn print_lint_report(
             );
         }
     }
+}
+
+/// Generate (or validate) the browse index: an NDJSON source of truth and a
+/// markdown view rendered from the same scanned entries.
+fn run_index(args: IndexArgs) -> std::result::Result<(), String> {
+    let (taxonomy, _source) = Taxonomy::resolve(&args.root, args.taxonomy.as_deref())
+        .map_err(|e| format!("cannot load taxonomy: {e}"))?;
+    let data = args
+        .data
+        .unwrap_or_else(|| PathBuf::from(index::INDEX_DATA_PATH));
+    let view = args
+        .view
+        .unwrap_or_else(|| PathBuf::from(index::INDEX_VIEW_PATH));
+
+    // Validate-only: check the committed NDJSON without regenerating.
+    if args.validate {
+        let text = std::fs::read_to_string(&data)
+            .map_err(|e| format!("cannot read {}: {e}", data.display()))?;
+        let probe = index::file_exists_under(&args.root);
+        let errors = index::validate_ndjson(&text, Some(&probe));
+        if !errors.is_empty() {
+            for e in &errors {
+                eprintln!("  x {e}");
+            }
+            return Err(format!(
+                "index validation failed with {} error(s)",
+                errors.len()
+            ));
+        }
+        let n = text.lines().filter(|l| !l.trim().is_empty()).count();
+        println!("OK: {} is valid ({n} records)", data.display());
+        return Ok(());
+    }
+
+    let scan = scan::scan_entries(&args.root, &taxonomy);
+    for err in &scan.errors {
+        eprintln!("  warning: {}: {}", err.file, err.error);
+    }
+    let today = Timestamp::now().date.iso();
+    let (ndjson, view_content) = index::build_index(&scan.entries, &taxonomy, &today)
+        .map_err(|e| format!("cannot build index: {e}"))?;
+
+    if args.dry_run {
+        print!("{ndjson}");
+        println!("{view_content}");
+        return Ok(());
+    }
+
+    for path in [&data, &view] {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("cannot create {}: {e}", parent.display()))?;
+            }
+        }
+    }
+    std::fs::write(&data, &ndjson).map_err(|e| format!("cannot write {}: {e}", data.display()))?;
+    std::fs::write(&view, &view_content)
+        .map_err(|e| format!("cannot write {}: {e}", view.display()))?;
+    println!(
+        "Wrote {} and {} ({} entries)",
+        data.display(),
+        view.display(),
+        scan.entries.len()
+    );
+    Ok(())
 }
 
 /// Install the bundled companion skill into agent directories.

--- a/crates/journal/src/scan.rs
+++ b/crates/journal/src/scan.rs
@@ -1,30 +1,51 @@
-//! Scan a journal corpus into logical entries with normalised tags.
+//! Scan a journal corpus into logical entries.
 //!
-//! Port of the journal CLI's `scan-entries.ts` plus the tag-extraction slice of
-//! `parse-frontmatter.ts`. Only the year directories (`20NN/`) are walked, which
-//! naturally excludes `node_modules`, `.git`, `docs`, and the like. A dated
-//! entry file and a sibling spike folder of the same slug collapse into one
-//! logical entry so their tags are not double-counted.
+//! Port of the journal CLI's `scan-entries.ts`, `parse-frontmatter.ts`,
+//! `extract-summary.ts`, `derive-type.ts`, and `derive-tickets.ts`. Only the
+//! year directories (`20NN/`) are walked, which naturally excludes
+//! `node_modules`, `.git`, `docs`, and the like. A dated entry file and a
+//! sibling spike folder of the same slug collapse into one logical entry so
+//! their tags are not double-counted.
 //!
-//! Frontmatter tags are extracted with a focused, dependency-light parser
-//! (matching how `validate.rs` hand-parses frontmatter) rather than a full YAML
-//! dependency. It understands the two shapes the corpus uses: a block sequence
-//! (`tags:` then `  - item` lines) and an inline flow sequence
-//! (`tags: [a, b]`).
+//! Frontmatter is parsed with a focused, dependency-light parser (matching how
+//! `validate.rs` hand-parses frontmatter) rather than a full YAML dependency. It
+//! understands the two shapes the corpus uses: a block sequence (`tags:` then
+//! `  - item` lines) and an inline flow sequence (`tags: [a, b]`).
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
+use regex::Regex;
+
 use crate::taxonomy::{normalise_tag, Taxonomy};
 
-/// A logical journal entry: its primary file and the union of normalised tags
-/// across every file grouped under it.
+/// One logical journal entry. A nested spike folder collapses to a single
+/// entry: `file` is the entry point, `files` lists every member. Tags are
+/// normalised; `entry_type` and `tickets` are derived from them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Entry {
     /// Repo-relative forward-slash path of the entry's primary file.
     pub file: String,
+    /// Every file grouped under this logical entry, sorted.
+    pub files: Vec<String>,
+    /// The `YYYY-MM-DD-slug` stem of the entry.
+    pub slug: String,
+    /// `YYYY-MM-DD` taken from the slug prefix.
+    pub date: String,
+    /// Frontmatter `title`, falling back to the body H1, else empty.
+    pub title: String,
     /// Sorted, de-duplicated, alias-normalised tags.
     pub tags: Vec<String>,
+    /// Derived entry type (a `type` facet tag, else `general`).
+    pub entry_type: String,
+    /// Ticket keys among the tags (matching the taxonomy `ticketPattern`).
+    pub tickets: Vec<String>,
+    /// Frontmatter `authors`, else empty.
+    pub authors: Vec<String>,
+    /// Frontmatter `status`, else empty.
+    pub status: String,
+    /// First paragraph under `## Session Overview`, else empty.
+    pub summary: String,
 }
 
 /// A file that could not be read, kept rather than silently dropped.
@@ -39,7 +60,7 @@ pub struct ScanError {
 /// The result of a corpus scan.
 #[derive(Debug, Clone, Default)]
 pub struct ScanResult {
-    /// Logical entries, sorted by file path for determinism.
+    /// Logical entries, newest first (date descending, then slug ascending).
     pub entries: Vec<Entry>,
     /// Files that could not be read.
     pub errors: Vec<ScanError>,
@@ -99,31 +120,44 @@ fn walk_md(dir: &Path, rel: &str, out: &mut Vec<String>) {
     }
 }
 
-/// Extract the raw frontmatter `tags` list from a markdown document. Returns an
-/// empty list when there is no frontmatter or no `tags` key.
-pub fn frontmatter_tags(content: &str) -> Vec<String> {
+/// The frontmatter fields the index cares about, parsed from a document.
+#[derive(Debug, Default, Clone)]
+pub struct Frontmatter {
+    /// `tags` as written (not yet normalised).
+    pub tags: Vec<String>,
+    /// `title` (trimmed), else empty.
+    pub title: String,
+    /// `authors` (trimmed, non-empty), else empty.
+    pub authors: Vec<String>,
+    /// `status` (trimmed), else empty.
+    pub status: String,
+}
+
+/// Split a document into its frontmatter block lines and body. Returns
+/// `(None, whole_document)` when there is no `---` fenced frontmatter.
+fn split_frontmatter(content: &str) -> (Option<Vec<&str>>, String) {
     if !content.starts_with("---") {
-        return Vec::new();
+        return (None, content.to_string());
     }
     let lines: Vec<&str> = content.split('\n').collect();
-    let mut end = None;
     for (i, line) in lines.iter().enumerate().skip(1) {
         if line.trim() == "---" {
-            end = Some(i);
-            break;
+            let block = lines[1..i].to_vec();
+            let body = lines[i + 1..].join("\n");
+            return (Some(block), body);
         }
     }
-    let Some(end) = end else {
-        return Vec::new();
-    };
+    (None, content.to_string())
+}
 
-    for (i, line) in lines[1..end].iter().enumerate() {
-        let trimmed = line.trim_start();
-        let Some(rest) = trimmed.strip_prefix("tags:") else {
+/// Extract an inline or block sequence for `key` from frontmatter block lines.
+fn fm_sequence(block: &[&str], key: &str) -> Vec<String> {
+    let prefix = format!("{key}:");
+    for (i, line) in block.iter().enumerate() {
+        let Some(rest) = line.trim_start().strip_prefix(&prefix) else {
             continue;
         };
         let rest = rest.trim();
-        // Inline flow sequence: tags: [a, b]
         if let Some(inner) = rest.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
             return inner
                 .split(',')
@@ -131,21 +165,107 @@ pub fn frontmatter_tags(content: &str) -> Vec<String> {
                 .filter(|t| !t.is_empty())
                 .collect();
         }
-        // Block sequence: subsequent `  - item` lines until dedent / next key.
-        let mut tags = Vec::new();
-        for follow in &lines[1 + i + 1..end] {
+        let mut items = Vec::new();
+        for follow in &block[i + 1..] {
             let ft = follow.trim();
             if let Some(item) = ft.strip_prefix("- ") {
-                tags.push(unquote(item));
+                items.push(unquote(item));
             } else if ft.is_empty() {
                 continue;
             } else {
                 break;
             }
         }
-        return tags.into_iter().filter(|t| !t.is_empty()).collect();
+        return items.into_iter().filter(|t| !t.is_empty()).collect();
     }
     Vec::new()
+}
+
+/// Extract an inline scalar value for `key` from frontmatter block lines.
+fn fm_scalar(block: &[&str], key: &str) -> String {
+    let prefix = format!("{key}:");
+    for line in block {
+        if let Some(rest) = line.trim_start().strip_prefix(&prefix) {
+            return unquote(rest);
+        }
+    }
+    String::new()
+}
+
+/// Parse the frontmatter fields the index needs, plus the body text.
+pub fn parse_frontmatter(content: &str) -> (Frontmatter, String) {
+    let (block, body) = split_frontmatter(content);
+    let Some(block) = block else {
+        return (Frontmatter::default(), body);
+    };
+    let fm = Frontmatter {
+        tags: fm_sequence(&block, "tags"),
+        title: fm_scalar(&block, "title"),
+        authors: fm_sequence(&block, "authors"),
+        status: fm_scalar(&block, "status"),
+    };
+    (fm, body)
+}
+
+/// The raw frontmatter `tags` list (kept for callers that only need tags).
+pub fn frontmatter_tags(content: &str) -> Vec<String> {
+    parse_frontmatter(content).0.tags
+}
+
+/// The first body H1 (`# Title`), trimmed, else empty.
+fn first_h1(body: &str) -> String {
+    for line in body.split('\n') {
+        if let Some(rest) = line.strip_prefix("# ") {
+            return rest.trim().to_string();
+        }
+    }
+    String::new()
+}
+
+/// Extract a one-line summary: the first paragraph under `## Session Overview`,
+/// its lines joined by spaces. Empty when there is no such section or prose.
+pub fn extract_summary(body: &str) -> String {
+    let lines: Vec<&str> = body.split('\n').collect();
+    let Some(start) = lines.iter().position(|l| l.trim() == "## Session Overview") else {
+        return String::new();
+    };
+    let mut paragraph: Vec<&str> = Vec::new();
+    for line in &lines[start + 1..] {
+        let t = line.trim();
+        if t.is_empty() {
+            if !paragraph.is_empty() {
+                break;
+            }
+            continue;
+        }
+        if t.starts_with('#') {
+            break;
+        }
+        paragraph.push(t);
+    }
+    paragraph.join(" ").trim().to_string()
+}
+
+/// Derive an entry's type: the first `type`-facet tag (in declared order, other
+/// than `general`) the entry carries, else `general`.
+pub fn derive_type(tags: &[String], type_facet: &[String]) -> String {
+    for candidate in type_facet {
+        if candidate != "general" && tags.iter().any(|t| t == candidate) {
+            return candidate.clone();
+        }
+    }
+    "general".to_string()
+}
+
+/// Derive ticket keys: tags matching `ticket_re`, sorted and de-duplicated.
+pub fn derive_tickets(tags: &[String], ticket_re: &Regex) -> Vec<String> {
+    let mut set: BTreeSet<String> = BTreeSet::new();
+    for tag in tags {
+        if ticket_re.is_match(tag) {
+            set.insert(tag.clone());
+        }
+    }
+    set.into_iter().collect()
 }
 
 /// Strip surrounding single/double quotes and whitespace from a scalar.
@@ -163,9 +283,14 @@ fn unquote(s: &str) -> String {
 }
 
 /// Scan every dated entry under `root`, grouping a nested spike folder into one
-/// logical entry. Tags are normalised through the taxonomy aliases.
+/// logical entry. Tags are normalised through the taxonomy aliases; type and
+/// tickets are derived. Entries are returned newest first.
 pub fn scan_entries(root: &Path, taxonomy: &Taxonomy) -> ScanResult {
     let all = list_markdown(root);
+    let ticket_re = taxonomy
+        .ticket_regex()
+        .unwrap_or_else(|_| Regex::new("$^").expect("empty regex compiles"));
+    let type_facet = taxonomy.facets.get("type").cloned().unwrap_or_default();
 
     // Key every file by its slug-stem path so a top-level `slug.md` and a
     // sibling `slug/` spike folder collapse into one logical entry.
@@ -195,6 +320,7 @@ pub fn scan_entries(root: &Path, taxonomy: &Taxonomy) -> ScanResult {
         files.sort();
         let mut tag_set: BTreeSet<String> = BTreeSet::new();
         let mut parsed_files: Vec<String> = Vec::new();
+        let mut fm_by_file: BTreeMap<String, (Frontmatter, String)> = BTreeMap::new();
         for rel in &files {
             let content = match std::fs::read_to_string(root.join(rel)) {
                 Ok(c) => c,
@@ -207,12 +333,14 @@ pub fn scan_entries(root: &Path, taxonomy: &Taxonomy) -> ScanResult {
                 }
             };
             parsed_files.push(rel.clone());
-            for raw in frontmatter_tags(&content) {
-                let n = normalise_tag(&raw, &taxonomy.aliases);
+            let (fm, body) = parse_frontmatter(&content);
+            for raw in &fm.tags {
+                let n = normalise_tag(raw, &taxonomy.aliases);
                 if !n.is_empty() {
                     tag_set.insert(n);
                 }
             }
+            fm_by_file.insert(rel.clone(), (fm, body));
         }
         if parsed_files.is_empty() {
             continue;
@@ -224,13 +352,36 @@ pub fn scan_entries(root: &Path, taxonomy: &Taxonomy) -> ScanResult {
             .or_else(|| parsed_files.iter().find(|f| f.contains("inventory")))
             .unwrap_or(&parsed_files[0])
             .clone();
+
+        let slug = key.split('/').next_back().unwrap_or(&key).to_string();
+        let date = slug.chars().take(10).collect::<String>();
+        let tags: Vec<String> = tag_set.into_iter().collect();
+        let (fm, body) = fm_by_file.get(&primary).cloned().unwrap_or_default();
+        let title = if fm.title.is_empty() {
+            first_h1(&body)
+        } else {
+            fm.title
+        };
+
         result.entries.push(Entry {
             file: primary,
-            tags: tag_set.into_iter().collect(),
+            files: parsed_files,
+            slug,
+            date,
+            title,
+            entry_type: derive_type(&tags, &type_facet),
+            tickets: derive_tickets(&tags, &ticket_re),
+            tags,
+            authors: fm.authors,
+            status: fm.status,
+            summary: extract_summary(&body),
         });
     }
 
-    result.entries.sort_by(|a, b| a.file.cmp(&b.file));
+    // Newest first: date descending, then slug ascending (mirrors the CLI).
+    result
+        .entries
+        .sort_by(|a, b| b.date.cmp(&a.date).then_with(|| a.slug.cmp(&b.slug)));
     result
 }
 
@@ -240,7 +391,7 @@ mod tests {
 
     fn tax() -> Taxonomy {
         Taxonomy::from_json(
-            r#"{ "threshold": 3, "aliases": { "teams": "ms-teams" }, "facets": {}, "ticketPattern": "^x-[0-9]+$" }"#,
+            r#"{ "threshold": 3, "aliases": { "teams": "ms-teams" }, "facets": { "type": ["troubleshooting", "general"] }, "ticketPattern": "^x-[0-9]+$" }"#,
             "test",
         )
         .unwrap()
@@ -259,30 +410,56 @@ mod tests {
     }
 
     #[test]
-    fn stops_at_next_key() {
-        let content = "---\ntags:\n  - alpha\nauthors:\n  - me\n---\n# T\n";
-        assert_eq!(frontmatter_tags(content), vec!["alpha"]);
+    fn parses_title_authors_status() {
+        let content = "---\ntitle: \"My Entry\"\nauthors:\n  - Alice\n  - Bob\nstatus: published\ntags:\n  - x\n---\n# Fallback\n";
+        let (fm, _body) = parse_frontmatter(content);
+        assert_eq!(fm.title, "My Entry");
+        assert_eq!(fm.authors, vec!["Alice", "Bob"]);
+        assert_eq!(fm.status, "published");
     }
 
     #[test]
-    fn no_frontmatter_no_tags() {
-        assert!(frontmatter_tags("# Just a heading\n").is_empty());
-        assert!(frontmatter_tags("---\ntitle: T\n---\n# T\n").is_empty());
+    fn title_falls_back_to_h1() {
+        let content = "---\ntags:\n  - x\n---\n\n# The Heading - July 1, 2026\n\ntext\n";
+        let (fm, body) = parse_frontmatter(content);
+        assert_eq!(fm.title, "");
+        assert_eq!(first_h1(&body), "The Heading - July 1, 2026");
     }
 
     #[test]
-    fn scan_normalises_and_dedupes_across_spike_folder() {
+    fn summary_from_session_overview() {
+        let body =
+            "# T\n\n## Session Overview\n\nFirst line.\nSecond line.\n\n## Next\n\nignored\n";
+        assert_eq!(extract_summary(body), "First line. Second line.");
+        assert_eq!(extract_summary("# T\n\nno overview\n"), "");
+    }
+
+    #[test]
+    fn derive_type_and_tickets() {
+        let type_facet = vec!["troubleshooting".to_string(), "general".to_string()];
+        let re = Regex::new("^x-[0-9]+$").unwrap();
+        assert_eq!(
+            derive_type(&["a".into(), "troubleshooting".into()], &type_facet),
+            "troubleshooting"
+        );
+        assert_eq!(derive_type(&["a".into()], &type_facet), "general");
+        assert_eq!(
+            derive_tickets(&["x-2".into(), "a".into(), "x-1".into(), "x-1".into()], &re),
+            vec!["x-1", "x-2"]
+        );
+    }
+
+    #[test]
+    fn scan_builds_full_entry_and_collapses_spike_folder() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         let month = root.join("2026/07");
         std::fs::create_dir_all(&month).unwrap();
-        // Top-level entry file.
         std::fs::write(
             month.join("2026-07-01-example.md"),
-            "---\ntags:\n  - Teams\n  - alpha\n---\n# Example - July 1, 2026\n",
+            "---\ntitle: Example\nauthors:\n  - Alice\nstatus: published\ntags:\n  - Teams\n  - alpha\n  - troubleshooting\n  - x-42\n---\n\n# Example - July 1, 2026\n\n## Session Overview\n\nA short summary.\n",
         )
         .unwrap();
-        // Sibling spike folder file for the same slug.
         let spike = month.join("2026-07-01-example");
         std::fs::create_dir_all(&spike).unwrap();
         std::fs::write(
@@ -293,15 +470,38 @@ mod tests {
 
         let result = scan_entries(root, &tax());
         assert!(result.errors.is_empty());
-        assert_eq!(
-            result.entries.len(),
-            1,
-            "spike folder collapses into one entry"
-        );
-        let entry = &result.entries[0];
-        assert_eq!(entry.file, "2026/07/2026-07-01-example.md");
-        // "Teams" -> "ms-teams" (alias + lowercase); alpha de-duplicated.
-        assert_eq!(entry.tags, vec!["alpha", "beta", "ms-teams"]);
+        assert_eq!(result.entries.len(), 1);
+        let e = &result.entries[0];
+        assert_eq!(e.file, "2026/07/2026-07-01-example.md");
+        assert_eq!(e.files.len(), 2);
+        assert_eq!(e.slug, "2026-07-01-example");
+        assert_eq!(e.date, "2026-07-01");
+        assert_eq!(e.title, "Example");
+        assert_eq!(e.authors, vec!["Alice"]);
+        assert_eq!(e.status, "published");
+        assert_eq!(e.summary, "A short summary.");
+        assert_eq!(e.entry_type, "troubleshooting");
+        assert_eq!(e.tickets, vec!["x-42"]);
+        // "Teams" -> "ms-teams" alias; alpha de-duplicated across files.
+        assert!(e.tags.contains(&"ms-teams".to_string()));
+        assert!(e.tags.contains(&"beta".to_string()));
+    }
+
+    #[test]
+    fn scan_sorts_newest_first() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("2026/07")).unwrap();
+        for (name, _) in [("2026-07-01-older", ()), ("2026-07-09-newer", ())] {
+            std::fs::write(
+                root.join(format!("2026/07/{name}.md")),
+                "---\ntags:\n  - x\n---\n# T\n",
+            )
+            .unwrap();
+        }
+        let result = scan_entries(root, &tax());
+        assert_eq!(result.entries[0].slug, "2026-07-09-newer");
+        assert_eq!(result.entries[1].slug, "2026-07-01-older");
     }
 
     #[test]

--- a/crates/journal/tests/index.rs
+++ b/crates/journal/tests/index.rs
@@ -1,0 +1,109 @@
+//! End-to-end checks for `pantheon-journal index`: dry-run output, writing the
+//! NDJSON + markdown pair, and the `--validate` gate.
+
+use std::path::Path;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_pantheon-journal");
+
+fn write(root: &Path, rel: &str, body: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+/// A small corpus with a taxonomy and two dated entries.
+fn build_corpus(root: &Path) {
+    std::fs::write(
+        root.join("taxonomy.json"),
+        r#"{ "threshold": 2, "aliases": {}, "facets": { "type": ["troubleshooting", "general"], "tech": ["aws"] }, "pin": [], "suppress": [], "ticketPattern": "^x-[0-9]+$" }"#,
+    )
+    .unwrap();
+    write(
+        root,
+        "2026/07/2026-07-09-newer.md",
+        "---\ntitle: Newer\ntags:\n  - aws\n  - troubleshooting\n  - x-42\n---\n\n# Newer - July 9, 2026\n\n## Session Overview\n\nA newer entry.\n",
+    );
+    write(
+        root,
+        "2026/07/2026-07-01-older.md",
+        "---\ntitle: Older\ntags:\n  - aws\n---\n\n# Older - July 1, 2026\n",
+    );
+}
+
+#[test]
+fn dry_run_prints_ndjson_and_markdown() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_corpus(tmp.path());
+
+    let out = Command::new(BIN)
+        .args(["index", "--dry-run", "--root"])
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // NDJSON: newest entry first, compact one-per-line.
+    assert!(stdout.contains(r#""file":"2026/07/2026-07-09-newer.md""#));
+    assert!(stdout.contains(r#""type":"troubleshooting""#));
+    // Markdown view sections.
+    assert!(stdout.contains("# Journal Index"));
+    assert!(stdout.contains("2 entries"));
+    assert!(stdout.contains("## Recent Entries"));
+    assert!(stdout.contains("## By Ticket"));
+    assert!(stdout.contains("### x-42 (1)"));
+}
+
+#[test]
+fn writes_and_then_validates_the_pair() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_corpus(tmp.path());
+    let data = tmp.path().join("out/index.ndjson");
+    let view = tmp.path().join("out/index.md");
+
+    let status = Command::new(BIN)
+        .args(["index", "--root"])
+        .arg(tmp.path())
+        .arg("--data")
+        .arg(&data)
+        .arg("--view")
+        .arg(&view)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(data.is_file() && view.is_file());
+    assert_eq!(std::fs::read_to_string(&data).unwrap().lines().count(), 2);
+
+    // The freshly written NDJSON validates clean (files resolve under --root).
+    let status = Command::new(BIN)
+        .args(["index", "--validate", "--root"])
+        .arg(tmp.path())
+        .arg("--data")
+        .arg(&data)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn validate_rejects_broken_ndjson() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_corpus(tmp.path());
+    let data = tmp.path().join("bad.ndjson");
+    // date does not match the slug prefix.
+    std::fs::write(
+        &data,
+        "{\"file\":\"2026/07/2026-07-01-older.md\",\"files\":[\"2026/07/2026-07-01-older.md\"],\"slug\":\"2026-07-01-older\",\"date\":\"2026-07-02\",\"title\":\"T\",\"tags\":[],\"type\":\"general\",\"tickets\":[],\"authors\":[],\"status\":\"\",\"summary\":\"\"}\n",
+    )
+    .unwrap();
+
+    let status = Command::new(BIN)
+        .args(["index", "--validate", "--root"])
+        .arg(tmp.path())
+        .arg("--data")
+        .arg(&data)
+        .status()
+        .unwrap();
+    assert!(!status.success(), "broken ndjson must fail validation");
+}

--- a/docs/src/pages/tools.astro
+++ b/docs/src/pages/tools.astro
@@ -72,6 +72,8 @@ const tools: Tool[] = [
     commands: [
       { usage: "pantheon-journal new --type <type> --title <title>", summary: "Create a new entry from one of the five template schemas." },
       { usage: "pantheon-journal validate <file>", summary: "Validate an existing entry for compliance." },
+      { usage: "pantheon-journal lint", summary: "Advisory tag lint against the taxonomy: alias suggestions and unfaceted tags." },
+      { usage: "pantheon-journal index", summary: "Generate the browse index (NDJSON source of truth + rendered markdown view)." },
       { usage: "pantheon-journal skill install", summary: "Register the bundled skill into detected agent directories." },
     ],
     bundledSkill: "journal-entry-creator",

--- a/skills/documentation/journal-entry-creator/SKILL.md
+++ b/skills/documentation/journal-entry-creator/SKILL.md
@@ -178,6 +178,14 @@ pantheon-journal lint --strict   # non-zero exit on findings (for CI)
 `lint` is advisory and never rewrites the taxonomy or an entry; it reports
 candidates for a human to fold into `taxonomy.json`.
 
+The corpus can also be indexed into a queryable NDJSON source of truth plus a
+rendered markdown browse view (grouped by recent, month, type, tag, and ticket):
+
+```bash
+pantheon-journal index            # writes docs/journal-index.{ndjson,md}
+pantheon-journal index --validate # check the committed index, do not regenerate
+```
+
 ### Code Block Language Specifiers
 
 ALL code blocks MUST have language identifiers. No bare triple backticks allowed.


### PR DESCRIPTION
### **User description**
## What

Slice 2 of the journal tooling roadmap: `pantheon-journal index` scans the corpus and writes an **NDJSON source of truth** (one record per logical entry) plus a **rendered markdown browse view**. The view is derived from the same scanned entries, so the two can never disagree. Ports the journal CLI's `index/` tree.

## Changes

- **`scan.rs`** enriched to build full entries: title (frontmatter or H1 fallback), authors, status, Session-Overview summary, derived type + tickets, sorted newest-first. Ports `parse-frontmatter`, `extract-summary`, `derive-type`, `derive-tickets`. `Entry` now carries the full record shape; `lint` consumes the file+tags subset unchanged.
- **`index.rs`**: `IndexRecord`, `records_to_ndjson` (compact, deterministic), `compute_canonical`, five renderers (recent, by month, by type, by tag with facet grouping + an emerging-tags block, by ticket), and `validate_ndjson` (schema + cross-record invariants: unique file, date == slug prefix, normalised tags, file exists).
- **`main.rs`**: `pantheon-journal index [--root] [--taxonomy] [--data] [--view] [--dry-run] [--validate]`. Regenerates by default; `--validate` gates the committed NDJSON without regenerating (for a pre-commit/CI hook).
- **SKILL.md** and the docs tools page document the command.

## Verification

- 68 lib tests + 3 index CLI integration tests + existing suites, all green. `cargo fmt` and `clippy` clean.
- Smoke-tested on the real corpus: **533 entries**, all sections rendered, zero read errors.
- The NDJSON record schema was verified **key-for-key against the existing Bun-generated `journal-index.ndjson`** — identical.

## Roadmap

Slices 1 (taxonomy + lint) and 2 (index) are now done. Remaining: backfill (gap 4) and any further derivation surface (gap 5, mostly already ported here). The parity-gate re-architecture in `.context/plans/skill-distribution.md` section 7 remains a separate recommended follow-up.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add `pantheon-journal index` command for corpus indexing.

- Enrich entry scanning with metadata extraction.

- Implement NDJSON validation and markdown rendering.

- Update documentation and add comprehensive tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Scan["Scan Corpus"] -- "Extract Metadata" --> Parse["Parse Frontmatter & Body"]
  Parse -- "Generate" --> Index["Build Index"]
  Index -- "Deterministic Output" --> NDJSON["docs/journal-index.ndjson"]
  Index -- "Deterministic Output" --> Markdown["docs/journal-index.md"]
  NDJSON -- "Validate" --> Verification["Invariants & Schema Check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>index.rs</strong><dd><code>Implement NDJSON serialization, markdown rendering, and validation</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/254/files#diff-3afb3bbe56cf4c9661c792f0c0406572104969896a9d598802a22ef33b7e085d">+552/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Expose the new index module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/254/files#diff-98e20dd96d5baed608bbe28c30acd7c97a95d9932bdd4d4e5014453b6a09235e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.rs</strong><dd><code>Add index subcommand and CLI execution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/254/files#diff-a65255ca4f4b16fd5f54f054a26bd6f037f065dd6e6dc91b166a91c3cfc1f2c5">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scan.rs</strong><dd><code>Enrich entry scanning with metadata extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/254/files#diff-4bcd57925ac4217f285bcffe67e79870229431f2fabe75b17d481e60d0abc98c">+258/-58</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>lint.rs</strong><dd><code>Update test helpers for expanded Entry struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/254/files#diff-d69374ee836206ad7408aa7d995f332c28513aa3308737b47cb4367de84d55a3">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.rs</strong><dd><code>Add integration tests for index command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/254/files#diff-79fd1beec3a781112185a45dd763163dfc94b786df9fbf7c7d59266d0dde29cb">+109/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>tools.astro</strong><dd><code>Update tools documentation page with new commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/254/files#diff-ad915b696237feb208a8fa985e6ce5de24e48b0af46e7ce9bd1770cb1d6eb4b8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong><dd><code>Document the new indexing command and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/254/files#diff-398f7626c674ad2850efcc8eaadf628833ce8b57a67eb0e7d8b971001c0d11d9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

