### PR TITLE
feat(journal): frontmatter backfill (pantheon-journal backfill)

### DIFF
--- a/crates/journal/src/backfill.rs
+++ b/crates/journal/src/backfill.rs
@@ -1,0 +1,254 @@
+//! Backfill missing YAML frontmatter (`title`, `date`) across existing entries.
+//!
+//! Port of the journal CLI's `backfill/` tree. For every dated entry file it
+//! ensures a `title:` and `date:` frontmatter key exist: a file with no
+//! frontmatter gets a full block prepended (`title`, `date`, `tags: []`); a file
+//! with frontmatter that lacks either key has the missing lines spliced in after
+//! the opening fence. The `title` is taken from existing frontmatter or the body
+//! H1; the `date` from the filename prefix. Existing keys are never overwritten.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use common::Result;
+use regex::Regex;
+
+use crate::scan::{first_h1, is_dated, list_markdown, parse_frontmatter};
+
+/// The outcome of a backfill pass.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BackfillReport {
+    /// Number of dated files examined.
+    pub processed: usize,
+    /// Number of files a `title:` line was injected into.
+    pub titles_injected: usize,
+    /// Number of files a `date:` line was injected into.
+    pub dates_injected: usize,
+    /// Dated files that carry no frontmatter tags (for the caller to warn).
+    pub missing_tags: Vec<String>,
+    /// Read/write failures, kept rather than aborting the whole pass.
+    pub warnings: Vec<String>,
+}
+
+/// Escape double quotes so a title is a valid double-quoted YAML scalar.
+fn escape_quotes(s: &str) -> String {
+    s.replace('"', "\\\"")
+}
+
+/// The frontmatter block lines and closing-fence line index, or `None` when
+/// there is no `---` fenced block with a closing fence.
+fn frontmatter_block(content: &str) -> Option<(Vec<&str>, usize)> {
+    if !content.starts_with("---") {
+        return None;
+    }
+    let lines: Vec<&str> = content.split('\n').collect();
+    for (i, line) in lines.iter().enumerate().skip(1) {
+        if line.trim() == "---" {
+            return Some((lines[1..i].to_vec(), i));
+        }
+    }
+    None
+}
+
+/// The top-level keys present in a frontmatter block.
+fn block_keys(block: &[&str]) -> BTreeSet<String> {
+    let key_re = Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_]*):").expect("valid key regex");
+    let mut keys = BTreeSet::new();
+    for line in block {
+        if let Some(caps) = key_re.captures(line) {
+            keys.insert(caps[1].to_string());
+        }
+    }
+    keys
+}
+
+/// Inject `title:` and/or `date:` into a document's frontmatter, adding only the
+/// keys that are absent. A document without frontmatter gets a fresh block.
+pub fn inject_frontmatter(content: &str, title: &str, date: &str) -> String {
+    let Some((block, _)) = frontmatter_block(content) else {
+        // The blank line before the closing fence stops markdownlint (which does
+        // not parse YAML) from reading `tags: []` + `---` as a setext heading.
+        return format!(
+            "---\ntitle: \"{}\"\ndate: {}\ntags: []\n\n---\n\n{}",
+            escape_quotes(title),
+            date,
+            content
+        );
+    };
+    let keys = block_keys(&block);
+    let mut to_add: Vec<String> = Vec::new();
+    if !keys.contains("title") {
+        to_add.push(format!("title: \"{}\"", escape_quotes(title)));
+    }
+    if !keys.contains("date") {
+        to_add.push(format!("date: {date}"));
+    }
+    if to_add.is_empty() {
+        return content.to_string();
+    }
+    // Splice the new lines directly after the opening `---`.
+    let mut lines: Vec<String> = content.split('\n').map(str::to_string).collect();
+    for (offset, line) in to_add.into_iter().enumerate() {
+        lines.insert(1 + offset, line);
+    }
+    lines.join("\n")
+}
+
+/// True when `content` has no top-level `title:` / `date:` line anywhere.
+fn missing_key(content: &str, key: &str) -> bool {
+    let re = Regex::new(&format!(r"(?m)^\s*{key}:")).expect("valid key regex");
+    !re.is_match(content)
+}
+
+/// The `YYYY-MM-DD` date prefix of a dated file's basename.
+fn filename_date(rel: &str) -> String {
+    let base = rel.rsplit('/').next().unwrap_or(rel);
+    base.chars().take(10).collect()
+}
+
+/// True when a file's basename is a `YYYY-MM-DD-` dated stem.
+fn is_dated_file(rel: &str) -> bool {
+    let base = rel.rsplit('/').next().unwrap_or(rel);
+    is_dated(base)
+}
+
+/// Run the backfill over every dated entry under `root`. When `dry_run` is set,
+/// nothing is written but the report still reflects what would change.
+pub fn backfill(root: &Path, dry_run: bool) -> Result<BackfillReport> {
+    let files = list_markdown(root);
+    let mut report = BackfillReport::default();
+
+    for rel in files.into_iter().filter(|f| is_dated_file(f)) {
+        report.processed += 1;
+        let content = match std::fs::read_to_string(root.join(&rel)) {
+            Ok(c) => c,
+            Err(e) => {
+                report.warnings.push(format!("failed to read {rel}: {e}"));
+                continue;
+            }
+        };
+
+        let (fm, body) = parse_frontmatter(&content);
+        if fm.tags.is_empty() {
+            report.missing_tags.push(rel.clone());
+        }
+
+        let title_missing = missing_key(&content, "title");
+        let date_missing = missing_key(&content, "date");
+        if !title_missing && !date_missing {
+            continue;
+        }
+
+        let title = if fm.title.is_empty() {
+            first_h1(&body)
+        } else {
+            fm.title.clone()
+        };
+        let date = filename_date(&rel);
+        let new_content = inject_frontmatter(&content, &title, &date);
+
+        if title_missing {
+            report.titles_injected += 1;
+        }
+        if date_missing {
+            report.dates_injected += 1;
+        }
+
+        if new_content != content && !dry_run {
+            if let Err(e) = std::fs::write(root.join(&rel), &new_content) {
+                report.warnings.push(format!("failed to write {rel}: {e}"));
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_full_block_when_no_frontmatter() {
+        let out = inject_frontmatter("# Heading\n\nbody\n", "My Title", "2026-07-01");
+        assert!(out.starts_with("---\ntitle: \"My Title\"\ndate: 2026-07-01\ntags: []\n\n---\n\n"));
+        assert!(out.contains("# Heading"));
+    }
+
+    #[test]
+    fn splices_missing_keys_into_existing_block() {
+        let content = "---\ntags:\n  - x\n---\n\n# T\n";
+        let out = inject_frontmatter(content, "The Title", "2026-07-02");
+        assert!(out.contains("title: \"The Title\""));
+        assert!(out.contains("date: 2026-07-02"));
+        // Existing tags preserved.
+        assert!(out.contains("tags:"));
+        // New keys sit right after the opening fence.
+        let lines: Vec<&str> = out.split('\n').collect();
+        assert_eq!(lines[0], "---");
+        assert!(lines[1].starts_with("title:") || lines[1].starts_with("date:"));
+    }
+
+    #[test]
+    fn leaves_content_untouched_when_both_present() {
+        let content = "---\ntitle: X\ndate: 2026-07-01\n---\n\n# T\n";
+        assert_eq!(
+            inject_frontmatter(content, "ignored", "2026-01-01"),
+            content
+        );
+    }
+
+    #[test]
+    fn escapes_quotes_in_title() {
+        let out = inject_frontmatter("body\n", "A \"quoted\" title", "2026-07-01");
+        assert!(out.contains(r#"title: "A \"quoted\" title""#));
+    }
+
+    #[test]
+    fn backfill_applies_and_reports() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("2026/07")).unwrap();
+        // No frontmatter at all; H1 supplies the title.
+        std::fs::write(
+            root.join("2026/07/2026-07-01-alpha.md"),
+            "# Alpha Entry\n\ntext\n",
+        )
+        .unwrap();
+        // Frontmatter present but missing title/date; also no tags.
+        std::fs::write(
+            root.join("2026/07/2026-07-02-beta.md"),
+            "---\nstatus: draft\n---\n\n# Beta\n",
+        )
+        .unwrap();
+
+        let report = backfill(root, false).unwrap();
+        assert_eq!(report.processed, 2);
+        assert_eq!(report.titles_injected, 2);
+        assert_eq!(report.dates_injected, 2);
+        assert_eq!(report.missing_tags.len(), 2);
+        assert!(report.warnings.is_empty());
+
+        let alpha = std::fs::read_to_string(root.join("2026/07/2026-07-01-alpha.md")).unwrap();
+        assert!(alpha.contains("title: \"Alpha Entry\""));
+        assert!(alpha.contains("date: 2026-07-01"));
+
+        let beta = std::fs::read_to_string(root.join("2026/07/2026-07-02-beta.md")).unwrap();
+        assert!(beta.contains("date: 2026-07-02"));
+        assert!(beta.contains("status: draft"));
+    }
+
+    #[test]
+    fn dry_run_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("2026/07")).unwrap();
+        let path = root.join("2026/07/2026-07-01-alpha.md");
+        std::fs::write(&path, "# Alpha\n").unwrap();
+
+        let report = backfill(root, true).unwrap();
+        assert_eq!(report.titles_injected, 1);
+        // File is unchanged on disk.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "# Alpha\n");
+    }
+}

--- a/crates/journal/src/lib.rs
+++ b/crates/journal/src/lib.rs
@@ -8,6 +8,7 @@
 //! at build time and can be installed into agent directories via the shared
 //! `skill-install` crate. No network or LLM access is involved.
 
+pub mod backfill;
 pub mod date;
 pub mod entry;
 pub mod index;

--- a/crates/journal/src/main.rs
+++ b/crates/journal/src/main.rs
@@ -1,11 +1,13 @@
-//! `journal` CLI: create structured entries (`new`), check them
-//! (`validate <file>`), lint corpus tags against the taxonomy (`lint`), and
-//! install the bundled companion skill (`skill install`).
+//! `pantheon-journal` CLI: create structured entries (`new`), check them
+//! (`validate <file>`), lint corpus tags against the taxonomy (`lint`),
+//! generate the browse index (`index`), backfill missing frontmatter
+//! (`backfill`), and install the bundled companion skill (`skill install`).
 
 use std::path::{Path, PathBuf};
 use std::process;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use journal::backfill;
 use journal::date::Timestamp;
 use journal::entry::{EntrySpec, EntryType};
 use journal::index;
@@ -46,6 +48,8 @@ enum Command {
     Lint(LintArgs),
     /// Generate the browse index (NDJSON source of truth + markdown view).
     Index(IndexArgs),
+    /// Backfill missing frontmatter (title, date) across existing entries.
+    Backfill(BackfillArgs),
     /// Manage the bundled companion skill.
     Skill {
         #[command(subcommand)]
@@ -117,6 +121,16 @@ struct IndexArgs {
     /// regenerate.
     #[arg(long)]
     validate: bool,
+}
+
+#[derive(Args)]
+struct BackfillArgs {
+    /// Journal root to scan for dated entries.
+    #[arg(long, default_value = ".")]
+    root: PathBuf,
+    /// Preview changes without writing any files.
+    #[arg(long = "dry-run")]
+    dry_run: bool,
 }
 
 #[derive(Subcommand)]
@@ -197,6 +211,7 @@ fn main() {
         Command::Validate { file } => run_validate(&file),
         Command::Lint(args) => run_lint(args),
         Command::Index(args) => run_index(args),
+        Command::Backfill(args) => run_backfill(args),
         Command::Skill {
             action: SkillAction::Install(args),
         } => run_skill_install(args),
@@ -385,6 +400,34 @@ fn run_index(args: IndexArgs) -> std::result::Result<(), String> {
         view.display(),
         scan.entries.len()
     );
+    Ok(())
+}
+
+/// Backfill missing `title` / `date` frontmatter across dated entries.
+fn run_backfill(args: BackfillArgs) -> std::result::Result<(), String> {
+    let report = backfill::backfill(&args.root, args.dry_run)
+        .map_err(|e| format!("backfill failed: {e}"))?;
+
+    for w in &report.warnings {
+        eprintln!("  warning: {w}");
+    }
+
+    let verb = if args.dry_run {
+        "would inject"
+    } else {
+        "injected"
+    };
+    println!(
+        "Processed {} file(s): {verb} {} title(s), {} date(s)",
+        report.processed, report.titles_injected, report.dates_injected
+    );
+
+    if !report.missing_tags.is_empty() {
+        eprintln!("\n{} file(s) have no tags:", report.missing_tags.len());
+        for f in &report.missing_tags {
+            eprintln!("  {f}");
+        }
+    }
     Ok(())
 }
 

--- a/crates/journal/src/scan.rs
+++ b/crates/journal/src/scan.rs
@@ -67,7 +67,7 @@ pub struct ScanResult {
 }
 
 /// True when a path segment is a `YYYY-MM-DD-` dated stem.
-fn is_dated(segment: &str) -> bool {
+pub(crate) fn is_dated(segment: &str) -> bool {
     let b = segment.as_bytes();
     b.len() >= 11
         && b[0..4].iter().all(u8::is_ascii_digit)
@@ -86,7 +86,7 @@ fn is_year_dir(name: &str) -> bool {
 
 /// Collect repo-relative forward-slash paths of every `.md` file under the
 /// corpus's year directories.
-fn list_markdown(root: &Path) -> Vec<String> {
+pub(crate) fn list_markdown(root: &Path) -> Vec<String> {
     let mut out = Vec::new();
     let Ok(top) = std::fs::read_dir(root) else {
         return out;
@@ -213,7 +213,7 @@ pub fn frontmatter_tags(content: &str) -> Vec<String> {
 }
 
 /// The first body H1 (`# Title`), trimmed, else empty.
-fn first_h1(body: &str) -> String {
+pub(crate) fn first_h1(body: &str) -> String {
     for line in body.split('\n') {
         if let Some(rest) = line.strip_prefix("# ") {
             return rest.trim().to_string();

--- a/crates/journal/tests/backfill.rs
+++ b/crates/journal/tests/backfill.rs
@@ -1,0 +1,59 @@
+//! End-to-end checks for `pantheon-journal backfill`: it injects missing
+//! frontmatter into dated entries and honours `--dry-run`.
+
+use std::path::Path;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_pantheon-journal");
+
+fn write(root: &Path, rel: &str, body: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+#[test]
+fn injects_missing_frontmatter() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    // No frontmatter; the H1 supplies the title, the filename supplies the date.
+    write(
+        root,
+        "2026/07/2026-07-01-alpha.md",
+        "# Alpha Entry\n\ntext\n",
+    );
+
+    let status = Command::new(BIN)
+        .args(["backfill", "--root"])
+        .arg(root)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let out = std::fs::read_to_string(root.join("2026/07/2026-07-01-alpha.md")).unwrap();
+    assert!(out.starts_with("---\n"));
+    assert!(out.contains("title: \"Alpha Entry\""));
+    assert!(out.contains("date: 2026-07-01"));
+    assert!(out.contains("# Alpha Entry"));
+}
+
+#[test]
+fn dry_run_leaves_files_untouched() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let original = "# Beta\n";
+    write(root, "2026/07/2026-07-02-beta.md", original);
+
+    let out = Command::new(BIN)
+        .args(["backfill", "--dry-run", "--root"])
+        .arg(root)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).contains("would inject"));
+    // Unchanged on disk.
+    assert_eq!(
+        std::fs::read_to_string(root.join("2026/07/2026-07-02-beta.md")).unwrap(),
+        original
+    );
+}

--- a/docs/src/pages/tools.astro
+++ b/docs/src/pages/tools.astro
@@ -74,6 +74,7 @@ const tools: Tool[] = [
       { usage: "pantheon-journal validate <file>", summary: "Validate an existing entry for compliance." },
       { usage: "pantheon-journal lint", summary: "Advisory tag lint against the taxonomy: alias suggestions and unfaceted tags." },
       { usage: "pantheon-journal index", summary: "Generate the browse index (NDJSON source of truth + rendered markdown view)." },
+      { usage: "pantheon-journal backfill", summary: "Inject missing title/date frontmatter across existing dated entries." },
       { usage: "pantheon-journal skill install", summary: "Register the bundled skill into detected agent directories." },
     ],
     bundledSkill: "journal-entry-creator",

--- a/skills/documentation/journal-entry-creator/SKILL.md
+++ b/skills/documentation/journal-entry-creator/SKILL.md
@@ -44,7 +44,7 @@ Use journal-entry-creator when:
 **Do NOT use for:**
 - Quick markdown notes without frontmatter (use simple file creation instead)
 - External documentation systems (Confluence, Notion) — this skill is for local .md files only
-- Retrospective backdating of dozens of old entries — use batch import scripts instead
+- Retrospective backfilling of frontmatter across many old entries: use `pantheon-journal backfill` for that one-pass batch repair instead
 
 ## Entry Type Selection
 


### PR DESCRIPTION
### **User description**
## What

Slice 3 (the last roadmap feature): `pantheon-journal backfill` scans every dated entry and ensures `title:` and `date:` frontmatter keys exist. Ports the journal CLI's `backfill/` tree.

- A file with **no frontmatter** gets a full block prepended (`title`, `date`, `tags: []`, with the markdownlint blank-line workaround).
- A file whose frontmatter **lacks either key** has the missing lines spliced in after the opening fence.
- **Existing keys are never overwritten.** Title comes from existing frontmatter or the body H1; date from the filename prefix.

## Changes

- **`backfill.rs`**: pure `inject_frontmatter` (ported line-for-line, including quote escaping) plus the corpus pass returning a report (processed / titles / dates / missing-tags / warnings).
- **`main.rs`**: `pantheon-journal backfill [--root] [--dry-run]`. Applies by default; `--dry-run` previews without writing.
- **`scan.rs`**: `is_dated` / `list_markdown` / `first_h1` exposed as `pub(crate)` so backfill reuses the walk and title logic instead of duplicating it.
- **SKILL.md / docs**: the "do not use for" bullet now points batch frontmatter repair at this command; docs tools page lists it.

## Verification

74 lib + 2 backfill CLI integration tests + existing suites, all green. `cargo fmt` and `clippy` clean. Dry-run smoke-tested on the real corpus: 537 files, would inject 2 titles + 1 date, corpus left untouched.

## Roadmap complete

Slices 1 (taxonomy + lint), 2 (index), and 3 (backfill) are now all done, plus the derivation helpers (gap 5) that came along with the index. The `pantheon-journal` CLI now matches the private Bun CLI's command surface: `config`-equivalent taxonomy resolution, `lint`, `index`, `backfill`.

The parity-gate re-architecture (`.context/plans/skill-distribution.md` §7) remains the one recommended follow-up.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Introduces the `pantheon-journal backfill` command to automatically inject missing `title` and `date` frontmatter keys.

- Implements robust frontmatter injection logic that preserves existing keys and escapes quotes.

- Adds a `--dry-run` option to preview changes without modifying files.

- Exposes internal scanning helpers and adds comprehensive unit and integration tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["pantheon-journal backfill"] -- "Scans files" --> Scan["Scan dated markdown files"]
  Scan -- "Parses content" --> Parse["Parse frontmatter & H1"]
  Parse -- "Splicing" --> Inject["Inject missing title/date"]
  Inject -- "Saves changes" --> Write["Write to disk (or dry-run)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>backfill.rs</strong><dd><code>Implement frontmatter injection and backfill logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/255/files#diff-6c0fd48d05f254d2420ba72ee35d80a03385d966529b9597372790b5f94c0678">+254/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Expose the new backfill module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/255/files#diff-98e20dd96d5baed608bbe28c30acd7c97a95d9932bdd4d4e5014453b6a09235e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.rs</strong><dd><code>Add backfill subcommand to the CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/255/files#diff-a65255ca4f4b16fd5f54f054a26bd6f037f065dd6e6dc91b166a91c3cfc1f2c5">+46/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scan.rs</strong><dd><code>Expose scanning and parsing helpers internally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/255/files#diff-4bcd57925ac4217f285bcffe67e79870229431f2fabe75b17d481e60d0abc98c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>backfill.rs</strong><dd><code>Add integration tests for backfill command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/255/files#diff-616d28c283e88ac6f573b2c23aefa28b7fd00590db9615db85814def8f9dbb6b">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>tools.astro</strong><dd><code>Document the backfill command in tools page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/255/files#diff-ad915b696237feb208a8fa985e6ce5de24e48b0af46e7ce9bd1770cb1d6eb4b8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong><dd><code>Update skill guidelines to reference backfill command</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/255/files#diff-398f7626c674ad2850efcc8eaadf628833ce8b57a67eb0e7d8b971001c0d11d9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

