### PR TITLE
fix(skill-validator): accept consolidated names in structure validator (#243 follow-up)

### DIFF
--- a/crates/skill-validator-rs/src/structure/frontmatter.rs
+++ b/crates/skill-validator-rs/src/structure/frontmatter.rs
@@ -61,10 +61,16 @@ pub fn check_frontmatter(s: &Skill, opts: &Options) -> Vec<ValidationResult> {
             )));
         }
         let dir_name = base_name(&s.dir);
-        if name != &dir_name {
+        let consolidated = consolidated_name(&s.dir, &dir_name);
+        let name_ok = name == &dir_name || consolidated.as_deref() == Some(name.as_str());
+        if !name_ok {
+            let expected = match &consolidated {
+                Some(alt) => format!("{} or {}", go_quote(&dir_name), go_quote(alt)),
+                None => go_quote(&dir_name),
+            };
             results.push(ctx.error(format!(
                 "name does not match directory name (expected {}, got {})",
-                go_quote(&dir_name),
+                expected,
                 go_quote(name)
             )));
         }
@@ -180,6 +186,20 @@ fn base_name(dir: &str) -> String {
         .unwrap_or_else(|| ".".to_string())
 }
 
+/// The consolidated skill name for a `<tool>/{generator,validator}` layout, or
+/// `None` for any other directory. Consolidated generator/validator pairs live in
+/// a `generator`/`validator` directory under a shared `<tool>` dir and name
+/// themselves `<tool>-generator` / `<tool>-validator`, so `<parent>-<dir>` is
+/// accepted alongside the bare directory name. Mirrors the same exemption in the
+/// artifacts check (see `artifacts::consolidated_skill_name`).
+fn consolidated_name(dir: &str, dir_name: &str) -> Option<String> {
+    if !matches!(dir_name, "generator" | "validator") {
+        return None;
+    }
+    let parent = Path::new(dir).parent()?.file_name()?.to_str()?;
+    Some(format!("{parent}-{dir_name}"))
+}
+
 fn check_description_keyword_stuffing(ctx: &ResultContext, desc: &str) -> Vec<ValidationResult> {
     // Heuristic 1: many quoted strings with little surrounding prose.
     let quote_count = QUOTED_STRING.find_iter(desc).count();
@@ -275,14 +295,75 @@ fn split_sentences(text: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::skill::{Frontmatter, Skill};
+    use serde_yaml_ng::Value;
+
+    fn skill_with(dir: &str, name: &str) -> Skill {
+        Skill {
+            dir: dir.to_string(),
+            frontmatter: Frontmatter {
+                name: name.to_string(),
+                description: "A sufficiently descriptive description for the test.".to_string(),
+                ..Frontmatter::default()
+            },
+            raw_frontmatter: Value::Null,
+            body: String::new(),
+            raw_content: String::new(),
+        }
+    }
+
+    fn name_errors(s: &Skill) -> Vec<String> {
+        check_frontmatter(s, &Options::default())
+            .into_iter()
+            .filter(|r| r.message.contains("does not match directory name"))
+            .map(|r| r.message)
+            .collect()
+    }
+
+    #[test]
+    fn consolidated_generator_validator_name_accepted() {
+        // A `<tool>/{generator,validator}` pair names itself `<tool>-generator` /
+        // `<tool>-validator`; the `<parent>-<dir>` form must not trip the
+        // name-vs-directory check (issue #243, structure validator).
+        for (dir, name) in [
+            (
+                "skills/infrastructure/terraform/generator",
+                "terraform-generator",
+            ),
+            (
+                "skills/infrastructure/terraform/validator",
+                "terraform-validator",
+            ),
+        ] {
+            let errs = name_errors(&skill_with(dir, name));
+            assert!(errs.is_empty(), "{dir}: {errs:?}");
+        }
+    }
+
+    #[test]
+    fn plain_skill_name_mismatch_still_flagged() {
+        // An ordinary skill whose name differs from its directory is still an error.
+        let errs = name_errors(&skill_with("skills/d/my-skill", "wrong-name"));
+        assert_eq!(errs.len(), 1, "{errs:?}");
+    }
+
+    #[test]
+    fn consolidated_wrong_name_still_flagged() {
+        // The exemption only accepts `<parent>-<dir>`: a wrong name in a
+        // generator/validator directory is still flagged, and the message offers
+        // the accepted consolidated form.
+        let errs = name_errors(&skill_with(
+            "skills/infrastructure/terraform/generator",
+            "terraform-gen",
+        ));
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("terraform-generator"), "{errs:?}");
+    }
 
     #[test]
     fn split_sentences_protects_abbrev_and_numbers() {
-        // Matches the Go TestSplitSentences cases: the abbreviation and the
-        // version-number periods do not create sentence boundaries. Go protects
-        // only the first period of "e.g."; the boundary regex additionally
-        // requires a capital letter after the period, so "e.g. vector" never
-        // splits regardless.
+        // Go TestSplitSentences parity: abbreviation and version-number periods do not
+        // create sentence boundaries ("e.g. vector" never splits, needing a capital after).
         let s = split_sentences("Use for e.g. vector search and embeddings. Next sentence here.");
         assert_eq!(
             s,

--- a/crates/skill-validator-rs/tests/golden-corpus/goldens.json
+++ b/crates/skill-validator-rs/tests/golden-corpus/goldens.json
@@ -4641,13 +4641,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"azure-pipelines-generator\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"azure-pipelines-generator\" (valid)",
@@ -4760,7 +4753,7 @@
           "Tokens": 1296
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 3
     }
   },
@@ -4813,13 +4806,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: assets/examples/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"azure-pipelines-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -4900,7 +4886,7 @@
           "Tokens": 945
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -4948,13 +4934,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: references/output/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"fluentbit-generator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -5007,7 +4986,7 @@
           "Tokens": 795
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -5056,13 +5035,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: references/test-fixtures/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"fluentbit-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -5115,7 +5087,7 @@
           "Tokens": 774
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -5172,13 +5144,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: assets/templates/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"github-actions-generator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -5342,7 +5307,7 @@
           "Tokens": 757
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 4
     }
   },
@@ -5389,13 +5354,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"github-actions-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -5530,7 +5488,7 @@
           "Tokens": 823
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -5578,13 +5536,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: assets/templates/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"gitlab-ci-generator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -5673,7 +5624,7 @@
           "Tokens": 856
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -5719,13 +5670,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"gitlab-ci-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -5810,7 +5754,7 @@
           "Tokens": 1120
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -5849,13 +5793,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"helm-generator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -5927,7 +5864,7 @@
           "Tokens": 1105
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -5981,13 +5918,6 @@
           "Category": "Structure",
           "Message": "unknown directory: test/ (contains 1 file) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"helm-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -6076,7 +6006,7 @@
           "Tokens": 28
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -6152,13 +6082,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: scripts/lib/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"jenkinsfile-generator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -6259,7 +6182,7 @@
           "Tokens": 362
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 4
     }
   },
@@ -6306,13 +6229,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: assets/examples/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"jenkinsfile-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -6431,7 +6347,7 @@
           "Tokens": 692
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -7400,13 +7316,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"bash-script-generator\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"bash-script-generator\" (valid)",
@@ -7472,7 +7381,7 @@
           "Tokens": 787
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -7513,13 +7422,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"bash-script-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -7604,7 +7506,7 @@
           "Tokens": 805
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -7666,13 +7568,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: assets/templates/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"makefile-generator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -7753,7 +7648,7 @@
           "Tokens": 857
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -7794,13 +7689,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"makefile-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -7886,7 +7774,7 @@
           "Tokens": 928
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -12291,13 +12179,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"ansible-generator\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"ansible-generator\" (valid)",
@@ -12415,7 +12296,7 @@
           "Tokens": 871
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -12466,13 +12347,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: assets/test/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"ansible-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -12661,7 +12535,7 @@
           "Tokens": 1258
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 2
     }
   },
@@ -13280,13 +13154,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"dockerfile-generator\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"dockerfile-generator\" (valid)",
@@ -13356,7 +13223,7 @@
           "Tokens": 930
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -13404,13 +13271,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"dockerfile-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -13475,7 +13335,7 @@
           "Tokens": 915
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -13932,13 +13792,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"terraform-generator\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"terraform-generator\" (valid)",
@@ -14015,7 +13868,7 @@
           "Tokens": 882
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 3
     }
   },
@@ -14058,13 +13911,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"terraform-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -14133,7 +13979,7 @@
           "Tokens": 1187
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -14190,13 +14036,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: assets/templates/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"terragrunt-generator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -14274,7 +14113,7 @@
           "Tokens": 803
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 4
     }
   },
@@ -14353,13 +14192,6 @@
           "Category": "Structure",
           "Message": "deep nesting detected: assets/test/",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"terragrunt-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -14542,7 +14374,7 @@
           "Tokens": 335
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 5
     }
   },
@@ -14726,13 +14558,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"generator\", got \"promql-generator\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"promql-generator\" (valid)",
@@ -14883,7 +14708,7 @@
           "Tokens": 997
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -14921,13 +14746,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 4 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"validator\", got \"promql-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -15019,7 +14837,7 @@
           "Tokens": 875
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },


### PR DESCRIPTION
### **User description**
## What

Apply the consolidated `<tool>/{generator,validator}` name exemption to the **structure** validator (`validate structure`), completing the fix started in #243/#257.

## Why — #243 was incomplete

#243 (PR #257) fixed the name-vs-directory false positive in the `validate artifacts` check. But the identical rule lives independently in `validate structure` (`structure/frontmatter.rs`), which the **`skill-validate` pre-commit hook** runs. So editing a consolidated generator/validator skill's `SKILL.md` still tripped a required gate:

```
skill-validate: [ERROR] Frontmatter: name does not match directory name
  (expected "validator", got "terraform-validator")
```

This was discovered while starting #244 (the first `SKILL.md` edit was blocked at commit). The artifacts gate passed; the structure gate did not.

## How

- `consolidated_name` helper mirrors `artifacts::consolidated_skill_name`: a `generator`/`validator` directory accepts the `<parent>-<dir>` form alongside the bare directory name. Ordinary skills keep the strict rule.
- The mismatch message now offers the accepted consolidated form (`expected "generator" or "terraform-generator"`).
- Regenerated the skill-validator golden corpus (`BLESS_GOLDENS=1`): removes the 26 now-obsolete name-mismatch errors across the 13 generator/validator tools (ci-cd, infrastructure, observability, scripting).

## Scope note

Broader consolidated tools — `cfn/{behavior-validator,template-compare}`, `k8s/{debug,yaml-generator,yaml-validator}`, `nx/*`, `opencode-toolkit/*` — follow a similar `<parent>-<dir>` naming and remain flagged. That is the **same false-positive class but outside generator/validator scope**; keeping this fix narrow matches #257. Filing a follow-up to generalise.

## Verification

- `cargo test -p skill-validator-rs` — every suite `0 failed` (73 tests; 3 new: `consolidated_generator_validator_name_accepted`, `plain_skill_name_mismatch_still_flagged`, `consolidated_wrong_name_still_flagged`).
- Golden parity passes after re-bless; diff is -208/+26, exclusively the 26 obsolete name errors (genuine `Wrong-Name` fixtures still flagged).
- `cargo fmt --check` and `cargo clippy` clean; `goldens.json` is biome-ignored.
- Confirmed `skill-validate` now passes on `terraform-validator`.

Refs #243. Unblocks #244.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes false-positives in the structure validator for consolidated generator/validator skills.

- Adds a `consolidated_name` helper to allow `<parent>-<dir>` naming.

- Updates mismatch error messages to suggest the consolidated name.

- Regenerates the golden corpus, removing obsolete errors.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Validation ["Structure Validation Flow"]
    A["check_frontmatter"] -- "Extracts" --> B["name"]
    A -- "Resolves layout" --> C["consolidated_name"]
    B --> D{"Matches directory or consolidated name?"}
    C --> D
    D -- "Yes" --> E["Validation Passes"]
    D -- "No" --> F["Validation Fails (Error)"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontmatter.rs</strong><dd><code>Support consolidated generator/validator names in structure validator</code></dd></summary>
<hr>

crates/skill-validator-rs/src/structure/frontmatter.rs

<ul><li>Modifies <code>check_frontmatter</code> to accept frontmatter names matching either <br>the directory name or the consolidated <code><parent>-<dir></code> format.<br> <li> Implements the <code>consolidated_name</code> helper function to handle <br><code><tool>/{generator,validator}</code> layouts.<br> <li> Adds unit tests to cover accepted consolidated names, plain <br>mismatches, and wrong consolidated names.<br> <li> Tightens a verbose test comment for clarity.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/259/files#diff-7d1cae1df375cb29e3ace550a74577724fac4234dedb7aa50aaed3a139000b8a">+88/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>goldens.json</strong><dd><code>Regenerate golden corpus to remove obsolete errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/skill-validator-rs/tests/golden-corpus/goldens.json

<ul><li>Regenerates the golden corpus to remove 26 obsolete name-mismatch <br>errors across 13 generator/validator tools.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/259/files#diff-d44f58d0e2f60a15bf762d12c46e76eee7a422c725527a2d6b4189d61594a2b5">+26/-208</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

