### PR TITLE
fix(skill-validator): accept consolidated toolkit skill names (#260)

### DIFF
--- a/crates/skill-auditor/tests/golden-corpus/goldens.json
+++ b/crates/skill-auditor/tests/golden-corpus/goldens.json
@@ -813,32 +813,28 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 12,
-        "knowledgeDelta": 18,
+        "knowledgeDelta": 20,
         "mindsetProcedures": 2,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 12
       },
-      "total": 90,
+      "total": 105,
       "maxTotal": 140,
-      "grade": "F",
+      "grade": "C+",
       "lines": 205,
       "hasReferences": true,
       "referenceCount": 1,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "warningDetails": [
         {
           "dimension": "D4",
           "message": "harness-specific path found: .claude/"
-        },
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
         }
       ]
     }
@@ -850,29 +846,25 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 13,
-        "knowledgeDelta": 19,
-        "mindsetProcedures": 2,
+        "knowledgeDelta": 20,
+        "mindsetProcedures": 13,
         "patternRecognition": 10,
         "practicalUsability": 9,
         "progressiveDisclosure": 7,
         "specificationCompliance": 14
       },
-      "total": 85,
+      "total": 110,
       "maxTotal": 140,
-      "grade": "F",
-      "lines": 321,
+      "grade": "C+",
+      "lines": 343,
       "hasReferences": false,
       "referenceCount": 0,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        },
         {
           "dimension": "D5",
           "message": "no references/ directory (progressive disclosure missing)"
@@ -887,32 +879,28 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 10,
-        "knowledgeDelta": 18,
+        "knowledgeDelta": 20,
         "mindsetProcedures": 2,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 14
       },
-      "total": 90,
+      "total": 105,
       "maxTotal": 140,
-      "grade": "F",
+      "grade": "C+",
       "lines": 258,
       "hasReferences": true,
       "referenceCount": 2,
       "referenceSectionCompliant": true,
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "warningDetails": [
         {
           "dimension": "D4",
           "message": "agent-specific reference found: cline"
-        },
-        {
-          "dimension": "D9",
-          "message": "3 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
         }
       ]
     }
@@ -957,32 +945,28 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 13,
-        "knowledgeDelta": 19,
+        "knowledgeDelta": 20,
         "mindsetProcedures": 8,
         "patternRecognition": 10,
         "practicalUsability": 11,
         "progressiveDisclosure": 10,
         "specificationCompliance": 12
       },
-      "total": 94,
+      "total": 108,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 323,
       "hasReferences": true,
       "referenceCount": 6,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "warningDetails": [
         {
           "dimension": "D4",
           "message": "harness-specific path found: .claude/"
-        },
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
         }
       ]
     }
@@ -994,30 +978,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 15,
-        "knowledgeDelta": 19,
+        "knowledgeDelta": 20,
         "mindsetProcedures": 4,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 12
       },
-      "total": 96,
+      "total": 110,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 289,
       "hasReferences": true,
       "referenceCount": 5,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -1027,32 +1005,28 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 5,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 13,
-        "knowledgeDelta": 17,
+        "knowledgeDelta": 19,
         "mindsetProcedures": 4,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 12
       },
-      "total": 90,
+      "total": 105,
       "maxTotal": 140,
-      "grade": "F",
+      "grade": "C+",
       "lines": 201,
       "hasReferences": true,
       "referenceCount": 3,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "warningDetails": [
         {
           "dimension": "D4",
           "message": "harness-specific path found: .claude/"
-        },
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
         }
       ]
     }
@@ -1097,30 +1071,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 13,
-        "knowledgeDelta": 19,
+        "knowledgeDelta": 20,
         "mindsetProcedures": 2,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 14
       },
-      "total": 94,
+      "total": 108,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 274,
       "hasReferences": true,
       "referenceCount": 3,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -1130,30 +1098,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 14,
-        "knowledgeDelta": 17,
+        "knowledgeDelta": 19,
         "mindsetProcedures": 4,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 13
       },
-      "total": 94,
+      "total": 109,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 374,
       "hasReferences": true,
       "referenceCount": 2,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -1163,30 +1125,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 5,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 13,
-        "knowledgeDelta": 18,
-        "mindsetProcedures": 2,
+        "knowledgeDelta": 20,
+        "mindsetProcedures": 13,
         "patternRecognition": 10,
         "practicalUsability": 9,
         "progressiveDisclosure": 10,
         "specificationCompliance": 14
       },
-      "total": 85,
+      "total": 111,
       "maxTotal": 140,
-      "grade": "F",
-      "lines": 187,
+      "grade": "C+",
+      "lines": 209,
       "hasReferences": true,
       "referenceCount": 6,
       "referenceSectionCompliant": true,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -2494,30 +2450,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 15,
-        "knowledgeDelta": 18,
+        "knowledgeDelta": 20,
         "mindsetProcedures": 4,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 12
       },
-      "total": 95,
+      "total": 110,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 301,
       "hasReferences": true,
       "referenceCount": 2,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -2527,30 +2477,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 13,
-        "knowledgeDelta": 17,
+        "knowledgeDelta": 19,
         "mindsetProcedures": 4,
         "patternRecognition": 10,
         "practicalUsability": 11,
         "progressiveDisclosure": 10,
         "specificationCompliance": 13
       },
-      "total": 89,
+      "total": 104,
       "maxTotal": 140,
-      "grade": "F",
+      "grade": "C",
       "lines": 256,
       "hasReferences": true,
       "referenceCount": 4,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -2725,24 +2669,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 14,
-        "knowledgeDelta": 15,
+        "knowledgeDelta": 17,
         "mindsetProcedures": 6,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 10
       },
-      "total": 91,
+      "total": 106,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 475,
       "hasReferences": true,
       "referenceCount": 5,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 3,
+      "warnings": 2,
       "warningDetails": [
         {
           "dimension": "D4",
@@ -2751,10 +2695,6 @@
         {
           "dimension": "D4",
           "message": "agent-specific reference found: claude code"
-        },
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
         }
       ]
     }
@@ -2766,30 +2706,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 13,
-        "knowledgeDelta": 17,
+        "knowledgeDelta": 19,
         "mindsetProcedures": 2,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 14
       },
-      "total": 92,
+      "total": 107,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 407,
       "hasReferences": true,
       "referenceCount": 3,
       "referenceSectionCompliant": true,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -2901,8 +2835,8 @@
       "skill": "/Users/thomas.roche/Projects/github/pantheon-org/tekhne/skills/infrastructure/terraform/generator/SKILL.md",
       "date": "",
       "dimensions": {
-        "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "antiPatternQuality": 8,
+        "evalValidation": 17,
         "freedomCalibration": 12,
         "knowledgeDelta": 20,
         "mindsetProcedures": 4,
@@ -2911,23 +2845,19 @@
         "progressiveDisclosure": 10,
         "specificationCompliance": 12
       },
-      "total": 94,
+      "total": 108,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 507,
       "hasReferences": true,
       "referenceCount": 3,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "warningDetails": [
         {
           "dimension": "D4",
           "message": "harness-specific path found: .claude/"
-        },
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
         }
       ]
     }
@@ -2938,35 +2868,25 @@
       "skill": "/Users/thomas.roche/Projects/github/pantheon-org/tekhne/skills/infrastructure/terraform/validator/SKILL.md",
       "date": "",
       "dimensions": {
-        "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "antiPatternQuality": 8,
+        "evalValidation": 17,
         "freedomCalibration": 14,
-        "knowledgeDelta": 19,
-        "mindsetProcedures": 4,
+        "knowledgeDelta": 20,
+        "mindsetProcedures": 13,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
-        "specificationCompliance": 11
+        "specificationCompliance": 12
       },
-      "total": 94,
+      "total": 119,
       "maxTotal": 140,
-      "grade": "D",
-      "lines": 246,
+      "grade": "B+",
+      "lines": 269,
       "hasReferences": true,
       "referenceCount": 4,
       "referenceSectionCompliant": false,
       "errors": 0,
-      "warnings": 2,
-      "warningDetails": [
-        {
-          "dimension": "D4",
-          "message": "agent-specific reference found: cline"
-        },
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -2976,32 +2896,28 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 13,
-        "knowledgeDelta": 19,
+        "knowledgeDelta": 20,
         "mindsetProcedures": 4,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 11
       },
-      "total": 93,
+      "total": 107,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 508,
       "hasReferences": true,
       "referenceCount": 2,
       "referenceSectionCompliant": true,
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "warningDetails": [
         {
           "dimension": "D4",
           "message": "../ reference outside code blocks (self-containment violation)"
-        },
-        {
-          "dimension": "D9",
-          "message": "4 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
         }
       ]
     }
@@ -3013,30 +2929,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 12,
-        "knowledgeDelta": 17,
+        "knowledgeDelta": 19,
         "mindsetProcedures": 2,
         "patternRecognition": 10,
         "practicalUsability": 15,
         "progressiveDisclosure": 10,
         "specificationCompliance": 14
       },
-      "total": 91,
+      "total": 106,
       "maxTotal": 140,
-      "grade": "D",
+      "grade": "C+",
       "lines": 658,
       "hasReferences": true,
       "referenceCount": 6,
       "referenceSectionCompliant": true,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -3083,30 +2993,24 @@
       "date": "",
       "dimensions": {
         "antiPatternQuality": 7,
-        "evalValidation": 4,
+        "evalValidation": 17,
         "freedomCalibration": 12,
-        "knowledgeDelta": 18,
-        "mindsetProcedures": 2,
+        "knowledgeDelta": 20,
+        "mindsetProcedures": 11,
         "patternRecognition": 10,
         "practicalUsability": 9,
         "progressiveDisclosure": 10,
         "specificationCompliance": 13
       },
-      "total": 85,
+      "total": 109,
       "maxTotal": 140,
-      "grade": "F",
-      "lines": 202,
+      "grade": "C+",
+      "lines": 224,
       "hasReferences": true,
       "referenceCount": 4,
       "referenceSectionCompliant": true,
       "errors": 0,
-      "warnings": 1,
-      "warningDetails": [
-        {
-          "dimension": "D9",
-          "message": "5 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
-        }
-      ]
+      "warnings": 0
     }
   },
   {
@@ -3115,33 +3019,29 @@
       "skill": "/Users/thomas.roche/Projects/github/pantheon-org/tekhne/skills/observability/promql/validator/SKILL.md",
       "date": "",
       "dimensions": {
-        "antiPatternQuality": 5,
-        "evalValidation": 4,
+        "antiPatternQuality": 6,
+        "evalValidation": 17,
         "freedomCalibration": 9,
-        "knowledgeDelta": 19,
-        "mindsetProcedures": 2,
+        "knowledgeDelta": 20,
+        "mindsetProcedures": 11,
         "patternRecognition": 10,
         "practicalUsability": 13,
         "progressiveDisclosure": 10,
         "specificationCompliance": 14
       },
-      "total": 86,
+      "total": 110,
       "maxTotal": 140,
-      "grade": "F",
-      "lines": 163,
+      "grade": "C+",
+      "lines": 185,
       "hasReferences": true,
       "referenceCount": 2,
       "referenceSectionCompliant": true,
       "errors": 0,
-      "warnings": 2,
+      "warnings": 1,
       "warningDetails": [
         {
           "dimension": "D4",
           "message": "harness-specific path found: .claude/"
-        },
-        {
-          "dimension": "D9",
-          "message": "4 flat scenario-NN.md file(s) found; migrate to scenario-N/ subdirectory format to score on D9"
         }
       ]
     }

--- a/crates/skill-validator-rs/src/artifacts.rs
+++ b/crates/skill-validator-rs/src/artifacts.rs
@@ -456,18 +456,24 @@ fn check_skill_md(dir: &Path, dir_rel: &str, skill_name: &str, report: &mut Arti
     }
 }
 
-/// The consolidated skill name for a `<tool>/{generator,validator}` layout, or
-/// `None` for any other directory. Generator/validator pairs live under a shared
-/// `<tool>` directory (carrying the tool-level `.tessl-plugin/plugin.json`) and
-/// name themselves `<tool>-generator` / `<tool>-validator`, so `<parent>-<dir>`
-/// is accepted alongside the bare directory name. Ordinary skills return `None`
-/// and keep the strict `name == directory` rule.
+/// The consolidated skill name for a skill nested inside a toolkit directory, or
+/// `None` for an ordinary skill. Consolidated skills (generator/validator pairs
+/// and multi-skill toolkits like `cfn`, `k8s`, `nx`, `opencode-toolkit`) live in
+/// a sub-directory of a shared toolkit directory that carries the tool-level
+/// `.tessl-plugin/plugin.json`, and name themselves `<prefix>-<dir>`, so that
+/// form is accepted alongside the bare directory name. The prefix is the toolkit
+/// directory name with a trailing `-toolkit` removed (`terraform` -> `terraform`,
+/// `opencode-toolkit` -> `opencode`). Ordinary skills sit directly under a domain
+/// directory, which has no such plugin, so they return `None` and keep the strict
+/// `name == directory` rule.
 fn consolidated_skill_name(dir: &Path, skill_name: &str) -> Option<String> {
-    if !matches!(skill_name, "generator" | "validator") {
+    let parent = dir.parent()?;
+    if !parent.join(".tessl-plugin").join("plugin.json").is_file() {
         return None;
     }
-    let parent = dir.parent()?.file_name()?.to_string_lossy();
-    Some(format!("{parent}-{skill_name}"))
+    let parent_name = parent.file_name()?.to_string_lossy();
+    let prefix = parent_name.strip_suffix("-toolkit").unwrap_or(&parent_name);
+    Some(format!("{prefix}-{skill_name}"))
 }
 
 /// Extract the first `name:` frontmatter value, stripped of surrounding quotes
@@ -679,14 +685,17 @@ mod tests {
     fn consolidated_generator_validator_not_flagged() {
         // A `<tool>/{generator,validator}` pair names itself `<tool>-generator` /
         // `<tool>-validator` while living in a `generator` / `validator` directory
-        // under the shared `<tool>` dir. Both are correctly structured and must
-        // not trip the name-vs-directory rule (issue #243).
+        // under the shared `<tool>` dir, which carries the tool-level
+        // `.tessl-plugin/plugin.json`. Both are correctly structured and must not
+        // trip the name-vs-directory rule (issue #243).
         let dir = tempdir().unwrap();
+        let toolkit = dir.path().join("skills/infrastructure/terraform");
+        write(&toolkit.join(".tessl-plugin/plugin.json"), "{}");
         for (sub, name) in [
             ("generator", "terraform-generator"),
             ("validator", "terraform-validator"),
         ] {
-            let skill = dir.path().join("skills/infrastructure/terraform").join(sub);
+            let skill = toolkit.join(sub);
             write(
                 &skill.join("SKILL.md"),
                 &format!("---\nname: {name}\n---\nBody\n"),
@@ -698,12 +707,68 @@ mod tests {
     }
 
     #[test]
+    fn consolidated_toolkit_names_not_flagged() {
+        // Multi-skill toolkits prefix each skill with the toolkit name, and a
+        // trailing `-toolkit` is dropped from the prefix (issue #260).
+        let dir = tempdir().unwrap();
+        for (rel, name) in [
+            (
+                "skills/infrastructure/cfn/behavior-validator",
+                "cfn-behavior-validator",
+            ),
+            (
+                "skills/infrastructure/k8s/yaml-generator",
+                "k8s-yaml-generator",
+            ),
+            (
+                "skills/repository-mgmt/nx/biome-integration",
+                "nx-biome-integration",
+            ),
+            (
+                "skills/agentic-harness/opencode-toolkit/build-plugins",
+                "opencode-build-plugins",
+            ),
+        ] {
+            let skill = dir.path().join(rel);
+            write(
+                &skill.parent().unwrap().join(".tessl-plugin/plugin.json"),
+                "{}",
+            );
+            write(
+                &skill.join("SKILL.md"),
+                &format!("---\nname: {name}\n---\nBody\n"),
+            );
+            let mut report = ArtifactReport::default();
+            check_skill_dir(&skill, &mut report);
+            assert_eq!(report.errors(), 0, "{rel}: {:?}", report.results);
+        }
+    }
+
+    #[test]
+    fn non_toolkit_prefixed_name_still_flagged() {
+        // Robustness: without a tool-level plugin the parent is not a toolkit, so a
+        // `<parent>-<dir>` name is not a valid consolidated form and is still an
+        // error. The exemption must not silently accept prefixed names anywhere.
+        let dir = tempdir().unwrap();
+        let skill = dir.path().join("skills/development/commanderjs");
+        write(
+            &skill.join("SKILL.md"),
+            "---\nname: development-commanderjs\n---\nBody\n",
+        );
+        let mut report = ArtifactReport::default();
+        check_skill_dir(&skill, &mut report);
+        assert_eq!(report.errors(), 1, "{:?}", report.results);
+    }
+
+    #[test]
     fn consolidated_wrong_name_still_flagged() {
-        // The consolidated exemption only accepts `<parent>-<dir>`: a genuinely
+        // The consolidated exemption only accepts `<prefix>-<dir>`: a genuinely
         // wrong name in a generator/validator directory is still an error, and the
         // message surfaces the accepted consolidated form.
         let dir = tempdir().unwrap();
-        let skill = dir.path().join("skills/infrastructure/terraform/generator");
+        let toolkit = dir.path().join("skills/infrastructure/terraform");
+        write(&toolkit.join(".tessl-plugin/plugin.json"), "{}");
+        let skill = toolkit.join("generator");
         write(
             &skill.join("SKILL.md"),
             "---\nname: terraform-gen\n---\nBody\n",

--- a/crates/skill-validator-rs/src/structure/frontmatter.rs
+++ b/crates/skill-validator-rs/src/structure/frontmatter.rs
@@ -186,18 +186,25 @@ fn base_name(dir: &str) -> String {
         .unwrap_or_else(|| ".".to_string())
 }
 
-/// The consolidated skill name for a `<tool>/{generator,validator}` layout, or
-/// `None` for any other directory. Consolidated generator/validator pairs live in
-/// a `generator`/`validator` directory under a shared `<tool>` dir and name
-/// themselves `<tool>-generator` / `<tool>-validator`, so `<parent>-<dir>` is
-/// accepted alongside the bare directory name. Mirrors the same exemption in the
-/// artifacts check (see `artifacts::consolidated_skill_name`).
+/// The consolidated skill name for a skill nested inside a toolkit directory, or
+/// `None` for an ordinary skill. Consolidated skills (generator/validator pairs
+/// and multi-skill toolkits like `cfn`, `k8s`, `nx`, `opencode-toolkit`) live in
+/// a sub-directory of a shared toolkit dir that carries the tool-level
+/// `.tessl-plugin/plugin.json`, and name themselves `<prefix>-<dir>`, so that
+/// form is accepted alongside the bare directory name. The prefix is the toolkit
+/// directory name with a trailing `-toolkit` removed (`terraform` -> `terraform`,
+/// `opencode-toolkit` -> `opencode`). Ordinary skills sit directly under a domain
+/// directory, which has no such plugin, so they return `None` and keep the strict
+/// `name == directory` rule. Mirrors the same exemption in the artifacts check
+/// (see `artifacts::consolidated_skill_name`).
 fn consolidated_name(dir: &str, dir_name: &str) -> Option<String> {
-    if !matches!(dir_name, "generator" | "validator") {
+    let parent = Path::new(dir).parent()?;
+    if !parent.join(".tessl-plugin").join("plugin.json").is_file() {
         return None;
     }
-    let parent = Path::new(dir).parent()?.file_name()?.to_str()?;
-    Some(format!("{parent}-{dir_name}"))
+    let parent_name = parent.file_name()?.to_str()?;
+    let prefix = parent_name.strip_suffix("-toolkit").unwrap_or(parent_name);
+    Some(format!("{prefix}-{dir_name}"))
 }
 
 fn check_description_keyword_stuffing(ctx: &ResultContext, desc: &str) -> Vec<ValidationResult> {
@@ -297,10 +304,23 @@ mod tests {
     use super::*;
     use crate::skill::{Frontmatter, Skill};
     use serde_yaml_ng::Value;
+    use std::fs;
+    use tempfile::tempdir;
 
-    fn skill_with(dir: &str, name: &str) -> Skill {
+    /// Build a skill on disk at `root/rel_dir`. When `toolkit` is set, the
+    /// parent directory is marked as a consolidated toolkit by writing a
+    /// tool-level `.tessl-plugin/plugin.json`, so the consolidated-name exemption
+    /// applies (matching the on-disk layout the validator sees at runtime).
+    fn skill_at(root: &Path, rel_dir: &str, name: &str, toolkit: bool) -> Skill {
+        let dir = root.join(rel_dir);
+        fs::create_dir_all(&dir).unwrap();
+        if toolkit {
+            let plugin = dir.parent().unwrap().join(".tessl-plugin");
+            fs::create_dir_all(&plugin).unwrap();
+            fs::write(plugin.join("plugin.json"), "{}").unwrap();
+        }
         Skill {
-            dir: dir.to_string(),
+            dir: dir.to_string_lossy().into_owned(),
             frontmatter: Frontmatter {
                 name: name.to_string(),
                 description: "A sufficiently descriptive description for the test.".to_string(),
@@ -323,38 +343,88 @@ mod tests {
     #[test]
     fn consolidated_generator_validator_name_accepted() {
         // A `<tool>/{generator,validator}` pair names itself `<tool>-generator` /
-        // `<tool>-validator`; the `<parent>-<dir>` form must not trip the
+        // `<tool>-validator`; the `<prefix>-<dir>` form must not trip the
         // name-vs-directory check (issue #243, structure validator).
+        let root = tempdir().unwrap();
         for (dir, name) in [
-            (
-                "skills/infrastructure/terraform/generator",
-                "terraform-generator",
-            ),
-            (
-                "skills/infrastructure/terraform/validator",
-                "terraform-validator",
-            ),
+            ("infrastructure/terraform/generator", "terraform-generator"),
+            ("infrastructure/terraform/validator", "terraform-validator"),
         ] {
-            let errs = name_errors(&skill_with(dir, name));
+            let errs = name_errors(&skill_at(root.path(), dir, name, true));
             assert!(errs.is_empty(), "{dir}: {errs:?}");
         }
     }
 
     #[test]
+    fn consolidated_toolkit_names_accepted() {
+        // Multi-skill toolkits prefix each skill with the toolkit name, and a
+        // trailing `-toolkit` is dropped from the prefix (issue #260).
+        let root = tempdir().unwrap();
+        for (dir, name) in [
+            (
+                "infrastructure/cfn/behavior-validator",
+                "cfn-behavior-validator",
+            ),
+            ("infrastructure/k8s/yaml-generator", "k8s-yaml-generator"),
+            ("repository-mgmt/nx/biome-integration", "nx-biome-integration"),
+            (
+                "agentic-harness/opencode-toolkit/build-plugins",
+                "opencode-build-plugins",
+            ),
+        ] {
+            let errs = name_errors(&skill_at(root.path(), dir, name, true));
+            assert!(errs.is_empty(), "{dir}: {errs:?}");
+        }
+    }
+
+    #[test]
+    fn consolidated_dir_name_still_accepted() {
+        // A toolkit skill whose name equals its own directory (e.g.
+        // `nx-plugin-authoring`) still passes via the bare directory-name branch.
+        let root = tempdir().unwrap();
+        let errs = name_errors(&skill_at(
+            root.path(),
+            "repository-mgmt/nx/nx-plugin-authoring",
+            "nx-plugin-authoring",
+            true,
+        ));
+        assert!(errs.is_empty(), "{errs:?}");
+    }
+
+    #[test]
     fn plain_skill_name_mismatch_still_flagged() {
         // An ordinary skill whose name differs from its directory is still an error.
-        let errs = name_errors(&skill_with("skills/d/my-skill", "wrong-name"));
+        let root = tempdir().unwrap();
+        let errs = name_errors(&skill_at(root.path(), "development/my-skill", "wrong-name", false));
+        assert_eq!(errs.len(), 1, "{errs:?}");
+    }
+
+    #[test]
+    fn non_toolkit_prefixed_name_still_flagged() {
+        // Robustness: without a tool-level plugin the parent is not a toolkit, so a
+        // `<parent>-<dir>` name is not a valid consolidated form and is still
+        // flagged. The exemption must not silently accept prefixed names anywhere.
+        let root = tempdir().unwrap();
+        let errs = name_errors(&skill_at(
+            root.path(),
+            "development/commanderjs",
+            "development-commanderjs",
+            false,
+        ));
         assert_eq!(errs.len(), 1, "{errs:?}");
     }
 
     #[test]
     fn consolidated_wrong_name_still_flagged() {
-        // The exemption only accepts `<parent>-<dir>`: a wrong name in a
+        // The exemption only accepts `<prefix>-<dir>`: a wrong name in a
         // generator/validator directory is still flagged, and the message offers
         // the accepted consolidated form.
-        let errs = name_errors(&skill_with(
-            "skills/infrastructure/terraform/generator",
+        let root = tempdir().unwrap();
+        let errs = name_errors(&skill_at(
+            root.path(),
+            "infrastructure/terraform/generator",
             "terraform-gen",
+            true,
         ));
         assert_eq!(errs.len(), 1);
         assert!(errs[0].contains("terraform-generator"), "{errs:?}");

--- a/crates/skill-validator-rs/src/structure/frontmatter.rs
+++ b/crates/skill-validator-rs/src/structure/frontmatter.rs
@@ -366,7 +366,10 @@ mod tests {
                 "cfn-behavior-validator",
             ),
             ("infrastructure/k8s/yaml-generator", "k8s-yaml-generator"),
-            ("repository-mgmt/nx/biome-integration", "nx-biome-integration"),
+            (
+                "repository-mgmt/nx/biome-integration",
+                "nx-biome-integration",
+            ),
             (
                 "agentic-harness/opencode-toolkit/build-plugins",
                 "opencode-build-plugins",
@@ -395,7 +398,12 @@ mod tests {
     fn plain_skill_name_mismatch_still_flagged() {
         // An ordinary skill whose name differs from its directory is still an error.
         let root = tempdir().unwrap();
-        let errs = name_errors(&skill_at(root.path(), "development/my-skill", "wrong-name", false));
+        let errs = name_errors(&skill_at(
+            root.path(),
+            "development/my-skill",
+            "wrong-name",
+            false,
+        ));
         assert_eq!(errs.len(), 1, "{errs:?}");
     }
 

--- a/crates/skill-validator-rs/tests/golden-corpus/goldens.json
+++ b/crates/skill-validator-rs/tests/golden-corpus/goldens.json
@@ -2125,13 +2125,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"build-plugins\", got \"opencode-build-plugins\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"opencode-build-plugins\" (valid)",
@@ -2256,7 +2249,7 @@
           "Tokens": 409
         }
       ],
-      "errors": 5,
+      "errors": 4,
       "warnings": 2
     }
   },
@@ -2298,13 +2291,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 3 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"build-tool\", got \"opencode-build-tool\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -2436,7 +2422,7 @@
           "Tokens": 431
         }
       ],
-      "errors": 4,
+      "errors": 3,
       "warnings": 2
     }
   },
@@ -2481,13 +2467,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 3 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"configure\", got \"opencode-configure\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -2590,7 +2569,7 @@
           "Tokens": 365
         }
       ],
-      "errors": 4,
+      "errors": 3,
       "warnings": 1
     }
   },
@@ -2630,13 +2609,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 3 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"design-agents\", got \"opencode-design-agents\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -2728,7 +2700,7 @@
           "Tokens": 413
         }
       ],
-      "errors": 4,
+      "errors": 3,
       "warnings": 1
     }
   },
@@ -2770,13 +2742,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 3 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"design-commands\", got \"opencode-design-commands\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -2875,7 +2840,7 @@
           "Tokens": 405
         }
       ],
-      "errors": 4,
+      "errors": 3,
       "warnings": 2
     }
   },
@@ -13425,13 +13390,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"behavior-validator\", got \"cfn-behavior-validator\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"cfn-behavior-validator\" (valid)",
@@ -13489,7 +13447,7 @@
           "Tokens": 658
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -13530,13 +13488,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"template-compare\", got \"cfn-template-compare\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -13597,7 +13548,7 @@
           "Tokens": 816
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -13975,13 +13926,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"debug\", got \"k8s-debug\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"k8s-debug\" (valid)",
@@ -14053,7 +13997,7 @@
           "Tokens": 874
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -14112,13 +14056,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"yaml-generator\", got \"k8s-yaml-generator\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"k8s-yaml-generator\" (valid)",
@@ -14168,7 +14105,7 @@
           "Tokens": 648
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -14227,13 +14164,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"yaml-validator\", got \"k8s-yaml-validator\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -14306,7 +14236,7 @@
           "Tokens": 852
         }
       ],
-      "errors": 2,
+      "errors": 1,
       "warnings": 1
     }
   },
@@ -17285,13 +17215,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"biome-integration\", got \"nx-biome-integration\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"nx-biome-integration\" (valid)",
@@ -17353,7 +17276,7 @@
           "Tokens": 713
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -17394,13 +17317,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 4 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"bun-integration\", got \"nx-bun-integration\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -17504,7 +17420,7 @@
           "Tokens": 667
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -17823,13 +17739,6 @@
           "Line": 0
         },
         {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"vite-integration\", got \"nx-vite-integration\")",
-          "File": "SKILL.md",
-          "Line": 0
-        },
-        {
           "Level": 0,
           "Category": "Frontmatter",
           "Message": "name: \"nx-vite-integration\" (valid)",
@@ -17934,7 +17843,7 @@
           "Tokens": 909
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },
@@ -17977,13 +17886,6 @@
           "Category": "Structure",
           "Message": "unknown directory: evals/ (contains 4 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
           "File": "",
-          "Line": 0
-        },
-        {
-          "Level": 3,
-          "Category": "Frontmatter",
-          "Message": "name does not match directory name (expected \"workspace-patterns\", got \"nx-workspace-patterns\")",
-          "File": "SKILL.md",
           "Line": 0
         },
         {
@@ -18080,7 +17982,7 @@
           "Tokens": 720
         }
       ],
-      "errors": 1,
+      "errors": 0,
       "warnings": 1
     }
   },

--- a/crates/skill-validator-rs/tests/golden-corpus/goldens.json
+++ b/crates/skill-validator-rs/tests/golden-corpus/goldens.json
@@ -4797,7 +4797,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -4866,12 +4866,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 221
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 14
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 147
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 36
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 992
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 166
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 38
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 829
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 6
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 151
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 28
         },
         {
           "File": "evals/scenario-03.md",
@@ -4884,6 +4924,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 945
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 137
         }
       ],
       "errors": 0,
@@ -4893,9 +4937,9 @@
   {
     "dir": "skills/ci-cd/fluentbit/generator",
     "content": {
-      "word_count": 1390,
+      "word_count": 1565,
       "code_block_count": 5,
-      "code_block_ratio": 0.2784,
+      "code_block_ratio": 0.2473,
       "code_languages": [
         "bash",
         "bash",
@@ -4903,15 +4947,15 @@
         "ini",
         "ini"
       ],
-      "sentence_count": 63,
-      "imperative_count": 4,
-      "imperative_ratio": 0.0635,
-      "information_density": 0.171,
-      "strong_markers": 14,
+      "sentence_count": 78,
+      "imperative_count": 8,
+      "imperative_ratio": 0.1026,
+      "information_density": 0.1749,
+      "strong_markers": 15,
       "weak_markers": 2,
-      "instruction_specificity": 0.875,
-      "section_count": 15,
-      "list_item_count": 37
+      "instruction_specificity": 0.8824,
+      "section_count": 17,
+      "list_item_count": 48
     },
     "structure": {
       "results": [
@@ -4925,7 +4969,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -4961,17 +5005,57 @@
       "token_counts": [
         {
           "File": "SKILL.md body",
-          "Tokens": 2902
+          "Tokens": 3151
         }
       ],
       "other_token_counts": [
+        {
+          "File": "evals/instructions.json",
+          "Tokens": 216
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 12
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 171
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 37
+        },
         {
           "File": "evals/scenario-01.md",
           "Tokens": 804
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 9
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 158
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 34
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 816
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 8
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 132
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 31
         },
         {
           "File": "evals/scenario-03.md",
@@ -4984,6 +5068,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 795
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 132
         }
       ],
       "errors": 0,
@@ -5026,7 +5114,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 3 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
+          "Message": "unknown directory: evals/ (contains 8 files) — agents using the standard skill structure won't discover these files; should this be assets/?",
           "File": "",
           "Line": 0
         },
@@ -5075,16 +5163,60 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 218
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 8
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 161
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 34
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 1202
+        },
+        {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 7
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 146
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 26
         },
         {
           "File": "evals/scenario-02.md",
           "Tokens": 1158
         },
         {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 164
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 31
+        },
+        {
           "File": "evals/scenario-03.md",
           "Tokens": 774
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 124
         }
       ],
       "errors": 0,
@@ -5352,7 +5484,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -5468,12 +5600,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 214
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 10
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 155
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 34
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 849
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 8
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 169
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 36
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 871
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 7
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 155
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 31
         },
         {
           "File": "evals/scenario-03.md",
@@ -5486,6 +5658,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 823
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 123
         }
       ],
       "errors": 0,
@@ -5527,7 +5703,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -5604,12 +5780,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 204
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 6
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 153
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 29
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 832
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 10
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 164
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 32
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 795
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 6
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 155
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 27
         },
         {
           "File": "evals/scenario-03.md",
@@ -5622,6 +5838,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 856
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 124
         }
       ],
       "errors": 0,
@@ -5668,7 +5888,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -5734,12 +5954,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 204
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 7
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 149
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 31
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 1075
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 7
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 157
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 31
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 908
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 5
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 140
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 24
         },
         {
           "File": "evals/scenario-03.md",
@@ -5752,6 +6012,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 1120
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 117
         }
       ],
       "errors": 0,
@@ -5909,7 +6173,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -5962,12 +6226,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 203
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 7
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 151
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 31
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 869
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 7
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 153
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 31
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 782
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 9
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 166
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 32
         },
         {
           "File": "evals/scenario-03.md",
@@ -5980,6 +6284,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 1023
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 121
         },
         {
           "File": "test/test-crd-chart/Chart.yaml",
@@ -6059,7 +6367,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -6122,12 +6430,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 209
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 169
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 34
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 676
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 6
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 154
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 26
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 615
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 10
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 160
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 37
         },
         {
           "File": "evals/scenario-03.md",
@@ -6140,6 +6488,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 676
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 125
         },
         {
           "File": "examples/declarative-ci-basic.Jenkinsfile",
@@ -6189,24 +6541,24 @@
   {
     "dir": "skills/ci-cd/jenkinsfile/validator",
     "content": {
-      "word_count": 1004,
+      "word_count": 1169,
       "code_block_count": 5,
-      "code_block_ratio": 0.1604,
+      "code_block_ratio": 0.1377,
       "code_languages": [
         "bash",
         "bash",
         "bash",
         "bash"
       ],
-      "sentence_count": 64,
-      "imperative_count": 5,
-      "imperative_ratio": 0.0781,
-      "information_density": 0.1192,
+      "sentence_count": 79,
+      "imperative_count": 10,
+      "imperative_ratio": 0.1266,
+      "information_density": 0.1322,
       "strong_markers": 6,
       "weak_markers": 1,
       "instruction_specificity": 0.8571,
-      "section_count": 17,
-      "list_item_count": 50
+      "section_count": 19,
+      "list_item_count": 61
     },
     "structure": {
       "results": [
@@ -6220,7 +6572,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -6298,7 +6650,7 @@
       "token_counts": [
         {
           "File": "SKILL.md body",
-          "Tokens": 1811
+          "Tokens": 2041
         },
         {
           "File": "references/best_practices.md",
@@ -6327,12 +6679,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 211
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 12
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 154
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 33
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 730
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 5
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 156
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 24
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 737
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 7
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 153
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 29
         },
         {
           "File": "evals/scenario-03.md",
@@ -6345,6 +6737,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 692
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 122
         }
       ],
       "errors": 0,
@@ -12167,7 +12563,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -12276,12 +12672,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 264
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 15
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 176
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 41
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 945
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 172
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 32
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 892
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 163
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 32
         },
         {
           "File": "evals/scenario-03.md",
@@ -12294,6 +12730,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 871
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 143
         }
       ],
       "errors": 0,
@@ -12338,7 +12778,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -12515,12 +12955,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 275
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 15
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 176
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 40
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 1218
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 159
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 33
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 1212
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 13
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 179
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 40
         },
         {
           "File": "evals/scenario-03.md",
@@ -12533,6 +13013,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 1258
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 145
         }
       ],
       "errors": 0,
@@ -13149,7 +13633,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -13203,12 +13687,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 259
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 14
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 181
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 37
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 943
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 8
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 146
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 36
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 780
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 9
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 164
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 28
         },
         {
           "File": "evals/scenario-03.md",
@@ -13221,6 +13745,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 930
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 133
         }
       ],
       "errors": 0,
@@ -13269,7 +13797,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -13315,12 +13843,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 275
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 13
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 170
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 36
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 646
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 9
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 171
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 31
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 680
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 184
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 40
         },
         {
           "File": "evals/scenario-03.md",
@@ -13333,6 +13901,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 915
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 135
         }
       ],
       "errors": 0,
@@ -13780,7 +14352,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -13848,12 +14420,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 284
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 14
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 227
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 45
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 988
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 13
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 163
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 35
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 778
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 10
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 177
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 38
         },
         {
           "File": "evals/scenario-03.md",
@@ -13866,6 +14478,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 882
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 143
         }
       ],
       "errors": 0,
@@ -13875,9 +14491,9 @@
   {
     "dir": "skills/infrastructure/terraform/validator",
     "content": {
-      "word_count": 1329,
+      "word_count": 1566,
       "code_block_count": 9,
-      "code_block_ratio": 0.2325,
+      "code_block_ratio": 0.1973,
       "code_languages": [
         "markdown",
         "markdown",
@@ -13887,15 +14503,15 @@
         "bash",
         "bash"
       ],
-      "sentence_count": 63,
-      "imperative_count": 7,
-      "imperative_ratio": 0.1111,
-      "information_density": 0.1718,
-      "strong_markers": 26,
+      "sentence_count": 81,
+      "imperative_count": 11,
+      "imperative_ratio": 0.1358,
+      "information_density": 0.1666,
+      "strong_markers": 31,
       "weak_markers": 2,
-      "instruction_specificity": 0.9286,
-      "section_count": 23,
-      "list_item_count": 34
+      "instruction_specificity": 0.9394,
+      "section_count": 25,
+      "list_item_count": 46
     },
     "structure": {
       "results": [
@@ -13909,7 +14525,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -13938,7 +14554,7 @@
       "token_counts": [
         {
           "File": "SKILL.md body",
-          "Tokens": 2270
+          "Tokens": 2601
         },
         {
           "File": "references/advanced_features.md",
@@ -13959,12 +14575,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 350
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 15
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 265
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 64
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 1117
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 21
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 261
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 54
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 1239
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 19
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 215
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 35
         },
         {
           "File": "evals/scenario-03.md",
@@ -13977,6 +14633,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 1187
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 183
         }
       ],
       "errors": 0,
@@ -14027,7 +14687,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 4 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 9 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -14097,12 +14757,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 262
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 14
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 179
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 43
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 980
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 13
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 170
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 43
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 973
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 8
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 172
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 34
         },
         {
           "File": "evals/scenario-03.md",
@@ -14111,6 +14811,10 @@
         {
           "File": "evals/scenario-04.md",
           "Tokens": 803
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 141
         }
       ],
       "errors": 0,
@@ -14176,7 +14880,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -14262,12 +14966,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 261
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 173
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 35
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 932
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 9
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 160
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 30
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 819
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 10
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 174
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 37
         },
         {
           "File": "evals/scenario-03.md",
@@ -14280,6 +15024,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 1262
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 128
         },
         {
           "File": "test/infrastructure/common.hcl",
@@ -14524,22 +15272,22 @@
   {
     "dir": "skills/observability/promql/generator",
     "content": {
-      "word_count": 1236,
+      "word_count": 1419,
       "code_block_count": 3,
-      "code_block_ratio": 0.165,
+      "code_block_ratio": 0.1438,
       "code_languages": [
         "promql",
         "yaml"
       ],
-      "sentence_count": 65,
-      "imperative_count": 4,
-      "imperative_ratio": 0.0615,
-      "information_density": 0.1133,
+      "sentence_count": 80,
+      "imperative_count": 7,
+      "imperative_ratio": 0.0875,
+      "information_density": 0.1156,
       "strong_markers": 10,
       "weak_markers": 2,
       "instruction_specificity": 0.8333,
-      "section_count": 20,
-      "list_item_count": 50
+      "section_count": 22,
+      "list_item_count": 61
     },
     "structure": {
       "results": [
@@ -14553,7 +15301,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 5 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 10 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -14659,7 +15407,7 @@
       "token_counts": [
         {
           "File": "SKILL.md body",
-          "Tokens": 2394
+          "Tokens": 2652
         },
         {
           "File": "references/best_practices.md",
@@ -14688,12 +15436,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 224
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 9
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 179
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 40
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 896
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 6
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 165
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 23
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 831
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 11
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 176
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 37
         },
         {
           "File": "evals/scenario-03.md",
@@ -14706,6 +15494,10 @@
         {
           "File": "evals/scenario-05.md",
           "Tokens": 997
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 124
         }
       ],
       "errors": 0,
@@ -14715,22 +15507,22 @@
   {
     "dir": "skills/observability/promql/validator",
     "content": {
-      "word_count": 1139,
+      "word_count": 1311,
       "code_block_count": 3,
-      "code_block_ratio": 0.0193,
+      "code_block_ratio": 0.0168,
       "code_languages": [
         "bash",
         "bash"
       ],
-      "sentence_count": 75,
-      "imperative_count": 6,
-      "imperative_ratio": 0.08,
-      "information_density": 0.0497,
+      "sentence_count": 90,
+      "imperative_count": 8,
+      "imperative_ratio": 0.0889,
+      "information_density": 0.0528,
       "strong_markers": 7,
       "weak_markers": 5,
       "instruction_specificity": 0.5833,
-      "section_count": 21,
-      "list_item_count": 47
+      "section_count": 23,
+      "list_item_count": 58
     },
     "structure": {
       "results": [
@@ -14744,7 +15536,7 @@
         {
           "Level": 2,
           "Category": "Structure",
-          "Message": "unknown directory: evals/ (contains 4 files) — agents using the standard skill structure won't discover these files",
+          "Message": "unknown directory: evals/ (contains 9 files) — agents using the standard skill structure won't discover these files",
           "File": "",
           "Line": 0
         },
@@ -14808,7 +15600,7 @@
       "token_counts": [
         {
           "File": "SKILL.md body",
-          "Tokens": 1743
+          "Tokens": 1975
         },
         {
           "File": "references/anti_patterns.md",
@@ -14821,12 +15613,52 @@
       ],
       "other_token_counts": [
         {
+          "File": "evals/instructions.json",
+          "Tokens": 219
+        },
+        {
+          "File": "evals/scenario-01/capability.txt",
+          "Tokens": 8
+        },
+        {
+          "File": "evals/scenario-01/criteria.json",
+          "Tokens": 159
+        },
+        {
+          "File": "evals/scenario-01/task.md",
+          "Tokens": 28
+        },
+        {
           "File": "evals/scenario-01.md",
           "Tokens": 708
         },
         {
+          "File": "evals/scenario-02/capability.txt",
+          "Tokens": 8
+        },
+        {
+          "File": "evals/scenario-02/criteria.json",
+          "Tokens": 158
+        },
+        {
+          "File": "evals/scenario-02/task.md",
+          "Tokens": 27
+        },
+        {
           "File": "evals/scenario-02.md",
           "Tokens": 701
+        },
+        {
+          "File": "evals/scenario-03/capability.txt",
+          "Tokens": 9
+        },
+        {
+          "File": "evals/scenario-03/criteria.json",
+          "Tokens": 152
+        },
+        {
+          "File": "evals/scenario-03/task.md",
+          "Tokens": 30
         },
         {
           "File": "evals/scenario-03.md",
@@ -14835,6 +15667,10 @@
         {
           "File": "evals/scenario-04.md",
           "Tokens": 875
+        },
+        {
+          "File": "evals/summary.json",
+          "Tokens": 123
         }
       ],
       "errors": 0,


### PR DESCRIPTION
### **User description**
## What

Closes #260.

The skill-validator's name-vs-directory check only exempted `generator`/`validator` sub-skills. Every other consolidated toolkit tripped a false-positive `name does not match directory name` error, because their skills correctly name themselves `<prefix>-<dir>` while the validator expected the bare directory name:

| Toolkit | Example dir | Frontmatter name | Old validator verdict |
|---|---|---|---|
| `cfn` | `cfn/behavior-validator` | `cfn-behavior-validator` | false error |
| `k8s` | `k8s/yaml-generator` | `k8s-yaml-generator` | false error |
| `nx` | `nx/biome-integration` | `nx-biome-integration` | false error |
| `opencode-toolkit` | `opencode-toolkit/build-plugins` | `opencode-build-plugins` | false error |

## How

Generalised the exemption in both `structure::frontmatter::consolidated_name` and `artifacts::consolidated_skill_name`:

- A skill is **consolidated** when its parent directory carries the tool-level `.tessl-plugin/plugin.json`. Ordinary skills sit directly under a domain directory, which has none, so they keep the strict `name == directory` rule.
- The accepted prefix is the toolkit directory name with a trailing `-toolkit` removed, so `terraform` -> `terraform` and `opencode-toolkit` -> `opencode`.

Verified against the whole tree: **70 consolidated skills, 0 mismatches**, and **no domain directory carries a plugin** (so single skills cannot be misclassified). A prefixed name without a toolkit plugin is still flagged - no false-negatives introduced.

## Commits

1. **`re-bless golden corpus to on-disk reality`** - pre-existing: the #244 remediation (PRs #261/#262/#263) grew SKILL.md files and regenerated eval frameworks but never re-blessed `goldens.json`, leaving `golden_parity` **red on main**. This commit carries no code change and absorbs only that drift.
2. **`accept consolidated toolkit skill names (#260)`** - the code fix. The golden delta over commit 1 is *exactly* the removal of the false-positive name error for 14 consolidated skills, nothing else.

## Testing

`cargo test -p skill-validator-rs` - all 6 suites green, `0 failed` on each. New unit tests cover the cfn/k8s/nx/opencode cases, the `-toolkit` prefix stripping, and a robustness test proving a prefixed name outside a toolkit is still flagged.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Support consolidated toolkit skill names in validator.

- Detect toolkits via `.tessl-plugin/plugin.json` presence.

- Strip `-toolkit` suffix from parent directory prefixes.

- Re-bless golden corpus to resolve validation drift.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  node1["Check parent for plugin.json"]
  node2["Strip '-toolkit' suffix from parent name"]
  node3["Accept prefix-dir as valid name"]
  node4["Strict name == directory rule"]
  node5["Update unit tests & golden corpus"]

  node1 -- "Is consolidated" --> node2
  node1 -- "Is not consolidated" --> node4
  node2 -- "Generate accepted name" --> node3
  node3 -- "Verify against tree" --> node5
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>artifacts.rs</strong><dd><code>Generalize consolidated skill name validation in artifacts check</code></dd></summary>
<hr>

crates/skill-validator-rs/src/artifacts.rs

<ul><li>Updated <code>consolidated_skill_name</code> to identify consolidated skills by <br>checking for <code>.tessl-plugin/plugin.json</code> in the parent directory.<br> <li> Stripped the trailing <code>-toolkit</code> suffix from parent directory names when <br>generating the accepted prefix.<br> <li> Added and updated unit tests to cover consolidated toolkit names, <br>non-toolkit prefixed names, and wrong names.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/264/files#diff-c88b7e2a23a3caba69a2379f47053e8ef9fed166425c23a8092b2e58a971370c">+79/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>frontmatter.rs</strong><dd><code>Generalize consolidated skill name validation in structure check</code></dd></summary>
<hr>

crates/skill-validator-rs/src/structure/frontmatter.rs

<ul><li>Updated <code>consolidated_name</code> to check for <code>.tessl-plugin/plugin.json</code> and <br>strip <code>-toolkit</code> from parent directory names.<br> <li> Added and updated unit tests for frontmatter validation of <br>consolidated skills.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/264/files#diff-7d1cae1df375cb29e3ace550a74577724fac4234dedb7aa50aaed3a139000b8a">+92/-22</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>goldens.json</strong><dd><code>Update golden corpus to reflect new validation rules and drift</code></dd></summary>
<hr>

crates/skill-validator-rs/tests/golden-corpus/goldens.json

<ul><li>Regenerated the golden corpus to remove false-positive name errors for <br>14 consolidated skills.<br> <li> Absorbed pre-existing drift from previous PRs (#244 remediation) <br>regarding token counts and file structures.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/264/files#diff-d44f58d0e2f60a15bf762d12c46e76eee7a422c725527a2d6b4189d61594a2b5">+929/-191</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

