### PR TITLE
docs(proof-of-work): check for project-specific evidence location first

### DIFF
--- a/skills/documentation/proof-of-work/skills/proof-of-work/references/artifact-storage.md
+++ b/skills/documentation/proof-of-work/skills/proof-of-work/references/artifact-storage.md
@@ -1,8 +1,12 @@
 # Artifact Storage Reference
 
-## Default Storage Location
+## Check for a Project-Specific Convention First
 
-All proof-of-work artifacts are stored under `.context/evidence/` in the repository root.
+Before defaulting to `.context/evidence/`, check whether the project already has its own established location for evidence tied to a specific document (a journal entry, a report, a ticket write-up). A generic cross-cutting bucket is wrong for evidence that belongs to one specific artifact — e.g. a project that documents work as dated entries may already store an entry's supporting files in a directory named after that entry (`<entry-slug>/assets/`), sitting next to it, rather than in a shared `.context/evidence/` folder. Look for an existing sibling directory pattern near similar past documents before assuming the default below applies, and check that project's own skill/instruction docs for an explicit convention.
+
+## Default Storage Location (no project-specific convention found)
+
+Otherwise, proof-of-work artifacts are stored under `.context/evidence/` in the repository root.
 
 ```
 .context/


### PR DESCRIPTION
## Summary
- `.context/evidence/` is a reasonable cross-cutting default for proof-of-work artifacts, but it's the wrong choice for evidence tied to one specific document.
- Adds a "Check for a Project-Specific Convention First" section to `references/artifact-storage.md` instructing agents to look for an existing sibling-directory pattern (e.g. a journal-style project storing an entry's assets in `<entry-slug>/assets/` next to the entry) before falling back to the generic bucket.
- Retitles "Default Storage Location" to make explicit it only applies when no project-specific convention is found.

## Test plan
- [x] `markdownlint-cli2` passes on the changed file (pre-commit hook)
- [x] `skill-validator-rs validate artifacts` passes on the changed file (pre-commit hook)
- [x] `bun test scripts/` — 101 passed, 0 failed (pre-push hook)
- [x] `bunx cucumber-js` — 4 scenarios, 14 steps, all passed (pre-push hook)