### PR TITLE
fix(create-context-file): write singular type in frontmatter

### DIFF
--- a/skills/project-mgmt/create-context-file/evals/scenario-02.md
+++ b/skills/project-mgmt/create-context-file/evals/scenario-02.md
@@ -18,7 +18,8 @@ The file must:
 2. Use the date-prefixed filename `2026-03-16-feature-flag-rollout.md` with the
    specific slug `feature-flag-rollout` (not a generic slug).
 3. Start with valid YAML frontmatter containing `title: "Feature Flag Rollout"`,
-   `type: plans`, `date: 2026-03-16`, `status: active`, and `tags`.
+   `type: plan` (singular - the folder is `plans`, but the frontmatter field is
+   singular), `date: 2026-03-16`, `status: active`, and `tags`.
 4. Follow the frontmatter with a `# Feature Flag Rollout` heading.
 5. Contain the three rollout steps as the body content.
 
@@ -28,7 +29,7 @@ The file must:
 2. Name the file `2026-03-16-feature-flag-rollout.md` (date prefix + specific
    slug, not a generic term like `notes` or `plan`)
 3. Begin with valid YAML frontmatter including `date: 2026-03-16` (ISO 8601),
-   `type: plans`, and a formatted `title`
+   `type: plan` (singular), and a formatted `title`
 4. Include a `# Feature Flag Rollout` top-level heading after the frontmatter
 5. Include all three rollout steps in the body: SDK addition, feature flag gate,
    and canary rollout
@@ -39,7 +40,7 @@ The file must:
 - **Date-prefixed filename**: the filename is `2026-03-16-feature-flag-rollout.md`
   (ISO date prefix + specific slug)
 - **Valid frontmatter with ISO date and type**: frontmatter contains
-  `date: 2026-03-16`, `type: plans`, and a formatted `title`
+  `date: 2026-03-16`, `type: plan` (singular), and a formatted `title`
 - **Title heading present**: a `# Feature Flag Rollout` heading follows the
   frontmatter
 - **Content includes all three steps**: the body contains SDK addition, feature

--- a/skills/project-mgmt/create-context-file/references/typologies.md
+++ b/skills/project-mgmt/create-context-file/references/typologies.md
@@ -18,6 +18,15 @@ stays mostly static but may evolve deliberately.
 | `notes` | General working notes | Prune when stale |
 | `research` | Longer-running research logs | Keep while active |
 
+## Frontmatter `type:` is singular, the folder is plural
+
+The typology above names the subfolder and is plural (`plans`, `follow-ups`,
+`decisions`, ...). The generated file's frontmatter `type:` field is the
+singular form (`plan`, `follow-up`, `decision`, ...) — that's what consuming
+tooling (e.g. an index generator's type-to-group lookup) matches against. The
+script's `singular_of()` holds the curated mapping; don't assume the two
+strings are interchangeable when writing or reading a context file by hand.
+
 ## Selection rule
 
 Pick the typology by **what the artifact is**, not by how long it will live. An
@@ -31,5 +40,8 @@ inventing a new folder. Introduce a new typology only when it will recur.
 
 The generator validates the requested typology against `KNOWN_TYPES` in
 `scripts/create-context-file.sh`. To add a permanent typology, add it to that
-list. For a genuine one-off, pass `--allow-new-type` instead of editing the
-list, which keeps the curated set intentional.
+list **and** add its singular form to `singular_of()` in the same script — the
+fallback there (strip a trailing `s`) is correct for every typology in the set
+today, but check it holds for whatever you add. For a genuine one-off, pass
+`--allow-new-type` instead of editing the list, which keeps the curated set
+intentional.

--- a/skills/project-mgmt/create-context-file/scripts/create-context-file.sh
+++ b/skills/project-mgmt/create-context-file/scripts/create-context-file.sh
@@ -50,6 +50,27 @@ type_known() {
 	return 1
 }
 
+# The typology (and the subfolder it maps to) is plural, e.g. "follow-ups".
+# The frontmatter `type:` field is the singular form, e.g. "follow-up" - that's
+# what downstream consumers (regenerate-context-index.sh's type_group_key)
+# match against. Curated pairs for KNOWN_TYPES; a typology added later via
+# --allow-new-type falls back to stripping a trailing "s", which is correct
+# for every typology in the set today.
+singular_of() {
+	case "$1" in
+		findings)       echo "finding" ;;
+		plans)          echo "plan" ;;
+		guides)         echo "guide" ;;
+		follow-ups)     echo "follow-up" ;;
+		merge-requests) echo "merge-request" ;;
+		tickets)        echo "ticket" ;;
+		decisions)      echo "decision" ;;
+		notes)          echo "note" ;;
+		research)       echo "research" ;;
+		*)              printf '%s' "$1" | sed 's/s$//' ;;
+	esac
+}
+
 type=""
 title=""
 slug=""
@@ -122,7 +143,7 @@ fi
 
 body="---
 title: \"${title}\"
-type: ${type}
+type: $(singular_of "$type")
 date: ${date}
 status: active
 ${tags_block}


### PR DESCRIPTION
## What

The context-file generator was writing the plural folder name into the
file's `type:` field instead of the singular form — for example, a file
saved under `.context/follow-ups/` got `type: follow-ups` instead of
`type: follow-up`. This happened for every typology the generator
supports, not just follow-ups.

The generator now converts to the singular form before writing it, and an
eval scenario that had the bug baked in as its expected output has been
corrected.

## Why

Tools that read these files to build a status summary or index match on
the singular `type` value. With the plural written instead, files were
silently miscategorised and dropped out of that summary — discovered
after the same typo turned up twice, in 11 files total, across a
downstream project.

## Notes

Verified with a dry run across several typologies, including one added
on the fly to confirm the fallback path works. Pre-push hooks (unit +
integration tests) passed.