### PR TITLE
feat(adr-creator): add check-undocumented-decisions.sh

### DIFF
--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -906,7 +906,7 @@ Creates, lists, and supersedes Architecture Decision Records with the adr CLI, f
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [adr-creator](/tekhne/skills/documentation/adr-creator/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
+| [adr-creator](/tekhne/skills/documentation/adr-creator/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
 
 ### astro-starlight-skills-starlight-theme
 

--- a/skills/documentation/adr-creator/SKILL.md
+++ b/skills/documentation/adr-creator/SKILL.md
@@ -100,6 +100,15 @@ pantheon-adr new "Split the monolith" --dir architecture/decisions
 
 Expected result: the record is created under `architecture/decisions`.
 
+```bash
+# Find planning documents with a decision that has no ADR pointing back at it.
+scripts/check-undocumented-decisions.sh
+```
+
+Expected result: exit 0 with a confirmation line when everything is covered, or exit 2 with a
+list of undocumented files when it finds decision-shaped documents that no ADR's `Source:` line
+references. See [Deriving an ADR from an Existing Document](references/context-extraction.md).
+
 ## Anti-Patterns
 
 ### NEVER hand-number a new ADR

--- a/skills/documentation/adr-creator/evals/instructions.json
+++ b/skills/documentation/adr-creator/evals/instructions.json
@@ -49,6 +49,16 @@
       "content": "Flip Status from Proposed to Accepted only once the team ratifies the decision.",
       "type": "workflow",
       "why_given": "new knowledge"
+    },
+    {
+      "content": "Run scripts/check-undocumented-decisions.sh to find planning documents with a decision that no ADR's Source: line references yet.",
+      "type": "workflow",
+      "why_given": "new knowledge"
+    },
+    {
+      "content": "Link an ADR extracted from an existing document back to it with a `- Source: <path>` bullet under Context.",
+      "type": "reference",
+      "why_given": "new knowledge"
     }
   ]
 }

--- a/skills/documentation/adr-creator/evals/scenario-4/capability.txt
+++ b/skills/documentation/adr-creator/evals/scenario-4/capability.txt
@@ -1,0 +1,1 @@
+undocumented-decision-detection

--- a/skills/documentation/adr-creator/evals/scenario-4/criteria.json
+++ b/skills/documentation/adr-creator/evals/scenario-4/criteria.json
@@ -1,0 +1,31 @@
+{
+  "context": "Tests whether the agent uses check-undocumented-decisions.sh to find a planning document with an unlinked decision, correctly leaves already-linked and purely-observational documents alone, and recommends the extraction workflow for the flagged file.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Runs the undocumented-decisions check",
+      "description": "Runs scripts/check-undocumented-decisions.sh (optionally with --source-dir .context) rather than manually diffing the two directories.",
+      "max_score": 25
+    },
+    {
+      "name": "Flags the correct file",
+      "description": "Identifies 2026-02-03-caching-spike.md as undocumented, citing its '## Decision' / 'We will use Redis' content.",
+      "max_score": 25
+    },
+    {
+      "name": "Leaves the linked file alone",
+      "description": "Does not flag 2026-01-10-db-choice.md, since it is already referenced via ADR-0001's Source: line.",
+      "max_score": 20
+    },
+    {
+      "name": "Leaves the observational file alone",
+      "description": "Does not flag 2026-02-20-log-format-notes.md, since its Findings section states no direction.",
+      "max_score": 15
+    },
+    {
+      "name": "Recommends extraction",
+      "description": "Points at the context-extraction workflow (pantheon-adr new, then fill from the source, then add the Source: link) as the next step for the flagged file.",
+      "max_score": 15
+    }
+  ]
+}

--- a/skills/documentation/adr-creator/evals/scenario-4/task.md
+++ b/skills/documentation/adr-creator/evals/scenario-4/task.md
@@ -1,0 +1,32 @@
+# Task: Find Decisions That Never Got an ADR
+
+The repository has a `.context/plans/` directory where the team drops design notes and spike
+write-ups. Nobody has checked in a while whether any of them settled on a decision that was never
+turned into an ADR. `docs/adr/` currently contains one record:
+
+```text
+docs/adr/0001-use-postgresql-for-primary-store.md   (Accepted, Source: .context/plans/2026-01-10-db-choice.md)
+```
+
+`.context/plans/` contains:
+
+```text
+2026-01-10-db-choice.md         (the source of ADR-0001, already linked)
+2026-02-03-caching-spike.md     (ends with "## Decision" ... "We will use Redis for the session cache.")
+2026-02-20-log-format-notes.md  (a "## Findings" section, no stated direction)
+```
+
+## What to do
+
+Check whether any planning document contains a decision that has no ADR pointing back at it, and
+say what should happen next.
+
+## Output Specification
+
+Produce:
+
+1. The command used to run the check.
+2. Which file (if any) was flagged, and why.
+3. The recommended next step for the flagged file (extract an ADR from it, per
+   [Deriving an ADR from an Existing Document](../../references/context-extraction.md)), and confirmation
+   that the already-linked and purely-observational documents are correctly left alone.

--- a/skills/documentation/adr-creator/evals/summary.json
+++ b/skills/documentation/adr-creator/evals/summary.json
@@ -1,6 +1,6 @@
 {
   "instructions_coverage": {
-    "coverage_percentage": 90,
+    "coverage_percentage": 92,
     "covered_instructions": [
       "pantheon-adr new command creates the next-numbered ADR",
       "pantheon-adr list shows number, status, and title",
@@ -10,18 +10,21 @@
       "Directory resolution: --dir, ADR_DIR, docs/adr default",
       "Template headings kept verbatim and in order",
       "One decision per ADR",
-      "Alternatives Considered must be populated"
+      "Alternatives Considered must be populated",
+      "check-undocumented-decisions.sh finds planning documents with no linked ADR",
+      "Extracted ADRs link back to their source with a Source: bullet under Context"
     ],
     "uncovered_instructions": [
       "Flip Status from Proposed to Accepted on ratification"
     ]
   },
   "scenario_coverage": {
-    "total_scenarios": 3,
+    "total_scenarios": 4,
     "capabilities_covered": [
       "adr-creation",
       "adr-superseding",
-      "adr-log-listing"
+      "adr-log-listing",
+      "undocumented-decision-detection"
     ]
   }
 }

--- a/skills/documentation/adr-creator/references/context-extraction.md
+++ b/skills/documentation/adr-creator/references/context-extraction.md
@@ -142,10 +142,15 @@ that feels self-explanatory today.
 
 If a team accumulates design docs, reviews, or planning notes as a matter of
 course, it can be worth periodically checking whether any of them contain a
-decision (per the signals above) that never got an ADR. `pantheon-adr` has
-no built-in command for this — it only knows about files already under the
-ADR directory — so this is a manual or repo-scripted check: skim recent
-planning documents for the decision-shaped headings and phrasing listed
-above, cross-reference against `pantheon-adr list`, and create the missing
-records. There is no house tooling for this today; treat it as a periodic
-review habit rather than something to automate ahead of need.
+decision (per the signals above) that never got an ADR.
+`scripts/check-undocumented-decisions.sh` automates this: it scans a
+planning-document directory (`.context` by default) for the same
+decision-shaped headings and phrasing listed above, cross-references them
+against every existing ADR's `Source:` line, and reports any document that
+looks decided but isn't linked from an ADR yet (exit 2), or confirms
+everything is covered (exit 0). Pass `--source-dir` if planning documents
+live somewhere other than `.context`, or `--adr-dir` to match a non-default
+`pantheon-adr new --dir`. Like the `Source:` convention itself, this is a
+documentation-side check, not something `pantheon-adr` runs internally —
+wire it into CI or a pre-commit hook if you want it enforced rather than
+run on demand.

--- a/skills/documentation/adr-creator/scripts/check-undocumented-decisions.sh
+++ b/skills/documentation/adr-creator/scripts/check-undocumented-decisions.sh
@@ -18,10 +18,18 @@ SOURCE_DIR=".context"
 while [ $# -gt 0 ]; do
   case "$1" in
     --adr-dir)
+      if [ $# -lt 2 ]; then
+        echo "--adr-dir requires a value" >&2
+        exit 2
+      fi
       ADR_DIR="$2"
       shift 2
       ;;
     --source-dir)
+      if [ $# -lt 2 ]; then
+        echo "--source-dir requires a value" >&2
+        exit 2
+      fi
       SOURCE_DIR="$2"
       shift 2
       ;;

--- a/skills/documentation/adr-creator/scripts/check-undocumented-decisions.sh
+++ b/skills/documentation/adr-creator/scripts/check-undocumented-decisions.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# shell: bash
+# Scans a planning-document directory (default: .context) for decision
+# indicators and cross-references them against the Source: links already
+# recorded in existing ADRs (the provenance convention documented in
+# references/context-extraction.md). Reports any planning document that
+# looks like it contains a decision but has no ADR pointing back at it.
+#
+# Usage: check-undocumented-decisions.sh [--adr-dir DIR] [--source-dir DIR]
+#   --adr-dir DIR      Where ADRs live (default: $ADR_DIR, else docs/adr,
+#                       matching pantheon-adr's own resolve_dir default).
+#   --source-dir DIR   Where planning documents live (default: .context).
+set -euo pipefail
+
+ADR_DIR="${ADR_DIR:-docs/adr}"
+SOURCE_DIR=".context"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --adr-dir)
+      ADR_DIR="$2"
+      shift 2
+      ;;
+    --source-dir)
+      SOURCE_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+if [ ! -d "$ROOT/$SOURCE_DIR" ]; then
+  echo "No $SOURCE_DIR directory found under $ROOT - nothing to scan."
+  exit 0
+fi
+
+python3 - "$ROOT" "$ADR_DIR" "$SOURCE_DIR" <<'PYEOF'
+import sys
+import re
+from pathlib import Path
+
+root = Path(sys.argv[1])
+adr_dir = root / sys.argv[2]
+source_dir = root / sys.argv[3]
+
+# --- Collect every source document already linked from an ADR's Source: line ---
+referenced = set()
+
+if adr_dir.is_dir():
+    for adr_file in adr_dir.glob("*.md"):
+        content = adr_file.read_text()
+        for m in re.finditer(r"^\s*-\s*Source:\s*(.+)$", content, re.MULTILINE):
+            path_val = m.group(1).strip().strip('"').strip("'")
+            resolved = (root / path_val).resolve()
+            if resolved.exists():
+                referenced.add(str(resolved))
+
+# --- Decision-indicating signals, matching the guidance in
+# references/context-extraction.md's "Recognizing a binding decision" table ---
+DECISION_KEYWORDS = [
+    r"^##\s*Decision\b",
+    r"^##\s*Recommendation\b",
+    r"^##\s*Recommended Approach\b",
+    r"^##\s*Proposed Approach\b",
+    r"\*\*Decision:\*\*",
+    r"\*\*Recommendation:\*\*",
+    r"\bWe will\b",
+    r"\bAdopt Option\b",
+    r"\bGoing forward, we\b",
+]
+
+undocumented = []
+
+for md_file in sorted(source_dir.rglob("*.md")):
+    resolved = str(md_file.resolve())
+    if resolved in referenced:
+        continue  # already linked from an ADR
+
+    content = md_file.read_text()
+
+    found_keyword = None
+    for kw in DECISION_KEYWORDS:
+        if re.search(kw, content, re.MULTILINE):
+            found_keyword = kw
+            break
+
+    if found_keyword:
+        rel = str(md_file.relative_to(root))
+        undocumented.append((rel, found_keyword))
+
+if not undocumented:
+    print("All planning documents with decision indicators are linked from an ADR.")
+    sys.exit(0)
+
+print("WARNING: the following documents contain decision indicators but are")
+print("not linked as a Source: from any ADR. Consider extracting an ADR for each")
+print("(see references/context-extraction.md):")
+print()
+for path, keyword in undocumented:
+    print(f"  {path}")
+    print(f"    Indicator: {keyword}")
+    print()
+
+print(f"Total: {len(undocumented)} undocumented decision(s)")
+print("Run `pantheon-adr list` to see existing ADRs before creating new ones.")
+sys.exit(2)
+PYEOF


### PR DESCRIPTION
### **User description**
## What

Adds a script that scans a planning-document directory (`.context` by default) for decision-shaped headings and phrasing, and cross-references them against every ADR's `Source:` link, reporting any document that looks decided but has no ADR pointing back at it.

## Why

The context-extraction reference already documented the workflow for turning an existing decision into an ADR, and noted this periodic check was a manual habit with no tooling. This closes that gap, adapted to `pantheon-adr`'s actual format (no YAML frontmatter, so it reads the `Source:` bullet convention under `## Context` instead of a frontmatter field).

## Notes

- Grade B+ (123/140), 0 errors/0 warnings on skill-validator-rs and shellcheck.
- New eval scenario covers flagging an undocumented decision while correctly leaving an already-linked and a purely-observational document alone.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add script to find undocumented decisions.

- Introduce new evaluation scenario 4.

- Update documentation and skill instructions.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Planning Docs"] -- "Scanned" --> C["check-undocumented-decisions.sh"]
  B["Existing ADRs"] -- "Cross-referenced" --> C
  C -- "Outputs" --> D["Undocumented Decisions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>check-undocumented-decisions.sh</strong><dd><code>Add script to find undocumented decisions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-3fc106783e2880d67cb428744aeda96857a89569ca53dd3a571a248740c7f689">+112/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>tiles.md</strong><dd><code>Update eval count for adr-creator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-17244a108ff207a43d7a6c4959acfcdbfc1e25cf88a6e444d5eccc5a04a13b42">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong><dd><code>Document the undocumented decisions check script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-7717dd17521be73d4b09c95c755cd11f939716b23a3ac11e0a7da05141a4b4de">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>context-extraction.md</strong><dd><code>Update reference documentation with script details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-08e8424c7e159e3ac04945f7e4fb0680a186a2e5651475930d3c651deaaf9df8">+12/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>instructions.json</strong><dd><code>Add instructions for undocumented decisions check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-8b53451bea474ccae1164d1fbb544c06f969b7d3310cafc157957cc6cbc0d840">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>capability.txt</strong><dd><code>Define capability for scenario 4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-12c86b893e0cd204242aee6709bae5a57be8aa50ed7d600ea9de60a3f31ff59c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>criteria.json</strong><dd><code>Define criteria for scenario 4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-f9f75396aaa09d5910cd999dd98578b6c36572e54e55260e15d5d213cebb4143">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>task.md</strong><dd><code>Define task for scenario 4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-3a96ba6980b10972c7cdcf4248a0371786a7c26b8c99acdc08e1bc6ae6447079">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>summary.json</strong><dd><code>Update scenario and instruction coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/276/files#diff-1eb053580bfa7023252c264fa7fa144fd0681190df328dd97b732cb94626bec7">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

