### PR TITLE
Add blocks/blocked-by dependency links + a computed ready-list script

### DIFF
--- a/skills/project-mgmt/context-index/SKILL.md
+++ b/skills/project-mgmt/context-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-index
-description: "Regenerates the project's context index (index.yaml) from the YAML frontmatter across every context file, grouping entries by typology (findings/plans/guides/follow-ups/merge-requests/tickets/decisions/notes/research), and validates that each file carries the required frontmatter fields. Use when the index is stale, context files were added, renamed, or removed, or a pre-commit gate blocks a commit because a context file is missing frontmatter. Do not use it to create new context files (use create-context-file instead), to hand-edit the index, or as a substitute for fixing frontmatter at the source."
+description: "Regenerates the project's context index (index.yaml) from the YAML frontmatter across every context file, grouping entries by typology (findings/plans/guides/follow-ups/merge-requests/tickets/decisions/notes/research), and validates that each file carries the required frontmatter fields. Also computes which active files are ready to work on, from optional typed `blocks`/`blocked-by` dependency links (scripts/context-ready.sh). Use when the index is stale, context files were added, renamed, or removed, a pre-commit gate blocks a commit because a context file is missing frontmatter, or someone asks what's ready/unblocked/blocked across the context backlog. Do not use it to create new context files (use create-context-file instead), to hand-edit the index, or as a substitute for fixing frontmatter at the source."
 ---
 
 # Context Index
@@ -65,6 +65,10 @@ status: active | done
 tags: []
 related:
   - ../relative/path/to/related.md # omit the whole key if there is nothing related
+blocks:
+  - ../relative/path/to/dependent.md # omit if this file blocks nothing
+blocked-by:
+  - ../relative/path/to/blocker.md # omit if nothing blocks this file
 ---
 ```
 
@@ -72,8 +76,9 @@ related:
 under (`findings/` → `finding`, `follow-ups/` → `follow-up`, `research/` →
 `research`). The index groups entries back into the plural form for display.
 `title`, `type`, `status`, and `date` are required for a file to appear in
-the index; `tags` and `related` are optional and only rendered when
-non-empty.
+the index; `tags`, `related`, `blocks`, and `blocked-by` are optional and
+only rendered when non-empty. `blocked-by` is read by `scripts/context-ready.sh`
+to compute which active files have zero open blockers.
 
 ## Procedure
 
@@ -129,6 +134,21 @@ Expected result: `context filenames OK`, or a list of naming violations.
 Expected result: a notice listing entries older than the threshold (default
 60 days via `CONTEXT_STALENESS_THRESHOLD_DAYS`), or no output. Always exits 0
 — this is a nudge, not a gate.
+
+```bash
+# What's ready to work on right now, computed from blocked-by
+./scripts/context-ready.sh
+
+# What's blocked, and by what
+./scripts/context-ready.sh --blocked
+```
+
+Expected result: a list of active files with zero open blockers (or a notice
+that none are), read straight from the index — no mutation, always exits 0.
+A blocker is "open" when the file it points at is missing from the index or
+not `status: done`; an unresolvable reference fails closed rather than being
+treated as satisfied. Run `regenerate-context-index.sh` first if the index
+might be stale (this script warns, but does not regenerate, on a mismatch).
 
 ## Anti-Patterns
 
@@ -193,4 +213,5 @@ looks, which is functionally the same as it not existing.
 | Topic | Reference | When to Use |
 | --- | --- | --- |
 | Technical details, parsing rules, exit codes, and CI integration | [Regeneration Reference](references/regeneration-reference.md) | Debugging index regeneration, wiring the check into a pre-commit hook, or writing a new script against the same frontmatter shape |
+| `blocks`/`blocked-by` semantics and `context-ready.sh`'s readiness computation | [Regeneration Reference](references/regeneration-reference.md) | Modelling a dependency between two context files, or debugging why a file is (or isn't) reported ready |
 | Typology catalog and the plural-folder / singular-`type:` mapping | The `create-context-file` skill's typologies reference (companion skill) | Choosing or extending the typology set this skill indexes against |

--- a/skills/project-mgmt/context-index/references/regeneration-reference.md
+++ b/skills/project-mgmt/context-index/references/regeneration-reference.md
@@ -7,8 +7,10 @@ Technical details and edge cases for the scripts in `scripts/`.
 1. Recursively finds every `.md` file under `.context/`.
 2. Parses YAML frontmatter (the text between the opening and closing `---`
    delimiters) from each file.
-3. Extracts `title`, `type`, `status`, `date`, plus `tags` and `related` when
-   present.
+3. Extracts `title`, `type`, `status`, `date`, plus `tags`, `related`,
+   `blocks`, and `blocked-by` when present. `blocked-by` is what
+   `scripts/context-ready.sh` reads to compute which active files have zero
+   open blockers.
 4. Skips files with missing or malformed frontmatter, printing them to
    stderr.
 5. Groups the remaining entries by typology (the plural directory name) and
@@ -60,11 +62,18 @@ findings:
     date: "2026-06-30"
     related:
       - "../plans/add-structured-logging.md"
+    blocked-by:
+      - "../plans/add-structured-logging.md"
 ```
 
-`tags` and `related` are only emitted when the source file's frontmatter has
-at least one item; an empty `tags: []` in the source produces no `tags:` key
-in the index entry.
+`tags`, `related`, `blocks`, and `blocked-by` are only emitted when the
+source file's frontmatter has at least one item; an empty `tags: []` in the
+source produces no `tags:` key in the index entry, and `blocks`/`blocked-by`
+are never emitted empty at all (see the frontmatter schema's `minItems: 1`).
+`blocks`/`blocked-by` values are carried through exactly as authored --
+relative to the *source file's own directory*, the same convention `related`
+already uses. Resolving them against the repo root (to check whether a
+blocker is `done`) is `context-ready.sh`'s job, not this script's.
 
 ## Exit Codes
 
@@ -80,6 +89,8 @@ in the index entry.
 | `check-context-filenames.sh` | 0 | Every file in a known typology directory follows the naming convention |
 | `check-context-filenames.sh` | 1 | At least one filename or date mismatch found |
 | `check-plan-staleness.sh` | 0 | Always — this check is advisory, never blocking |
+| `context-ready.sh` | 0 | Always (even with an unresolvable blocker, a stale index, or a missing index) — this is a read-only query, never a gate |
+| `context-ready.sh` | 2 | Called with an argument other than `--blocked` |
 
 ## Common Issues
 

--- a/skills/project-mgmt/context-index/scripts/context-ready.sh
+++ b/skills/project-mgmt/context-index/scripts/context-ready.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# shell: bash
+# context-ready.sh - list every ACTIVE .context/ file with zero open
+# blockers, computed from the `blocked-by` frontmatter field that
+# regenerate-context-index.sh carries into .context/index.yaml.
+#
+# Deliberately a query, not a gate: it only reads the index and never writes
+# anything, so it is safe to run at any time with no side effects.
+#
+# A blocker is "open" when the referenced file is missing from the index
+# entirely, or present with any status other than `done`. Resolution fails
+# closed (an unresolvable blocker counts as still-blocking) rather than
+# silently treating a bad reference as satisfied.
+#
+# `blocked-by` values are resolved the same way `related` already is:
+# relative to the REFERENCING file's own directory, not the repo root.
+#
+# Usage:
+#   context-ready.sh            # list active items with zero open blockers
+#   context-ready.sh --blocked  # list active items that are NOT ready, with
+#                                # each open blocker named
+set -euo pipefail
+
+MODE="ready"
+if [ "${1:-}" = "--blocked" ]; then
+  MODE="blocked"
+elif [ "${1:-}" != "" ]; then
+  echo "usage: context-ready.sh [--blocked]" >&2
+  exit 2
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+INDEX="$ROOT/.context/index.yaml"
+
+if [ ! -f "$INDEX" ]; then
+  echo "NOTICE: $INDEX not found -- run regenerate-context-index.sh first" >&2
+  exit 0
+fi
+
+# Freshness nudge (advisory only, same spirit as the follow-up skill's Rule
+# 4): a stale index would silently under- or over-report open blockers. This
+# script never regenerates the index itself -- it only reads it, matching
+# every sibling script in this family.
+ACTUAL_COUNT="$(find "$ROOT/.context" -name '*.md' | wc -l | tr -d ' ')"
+HEADER_COUNT="$(sed -n 's/^# \([0-9]\{1,\}\) entries:.*/\1/p' "$INDEX" | head -1)"
+if [ -n "$HEADER_COUNT" ] && [ "$HEADER_COUNT" != "$ACTUAL_COUNT" ]; then
+  echo "WARNING: index reports $HEADER_COUNT entries but $ACTUAL_COUNT .md file(s) exist under .context/ -- it may be stale. Run regenerate-context-index.sh first." >&2
+fi
+
+python3 - "$INDEX" "$MODE" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+from posixpath import normpath
+
+index_path = Path(sys.argv[1])
+mode = sys.argv[2]
+text = index_path.read_text()
+
+# Tolerant line-based parse of the machine-generated index, the same
+# approach check-plan-staleness.sh already uses -- no YAML library needed
+# for a shape this script fully controls.
+entries = []
+current_section = None
+current = {}
+list_key = None  # tags | related | blocks | blocked-by | None
+
+
+def flush():
+    global current
+    if current:
+        entries.append((current_section, current))
+        current = {}
+
+
+for line in text.splitlines():
+    section_match = re.match(r"^([a-z-]+):\s*$", line)
+    if section_match:
+        flush()
+        current_section = section_match.group(1)
+        list_key = None
+        continue
+    if current_section is None:
+        continue
+    m = re.match(r"^\s*- path: (.+)$", line)
+    if m:
+        flush()
+        current = {"path": m.group(1).strip().strip('"')}
+        list_key = None
+        continue
+    m = re.match(r"^\s*title: (.+)$", line)
+    if m:
+        current["title"] = m.group(1).strip().strip('"')
+        continue
+    m = re.match(r"^\s*status: (.+)$", line)
+    if m:
+        current["status"] = m.group(1).strip().strip('"')
+        continue
+    m = re.match(r"^\s*date: (\S+)", line)
+    if m:
+        current["date"] = m.group(1)
+        continue
+    m = re.match(r"^\s*(tags|related|blocks|blocked-by):\s*$", line)
+    if m:
+        list_key = m.group(1)
+        current.setdefault(list_key, [])
+        continue
+    m = re.match(r"^\s*- (.+)$", line)
+    if m and list_key:
+        current[list_key].append(m.group(1).strip().strip('"'))
+        continue
+flush()
+
+by_path = {e["path"]: e for _, e in entries if "path" in e}
+
+
+def resolve(from_path, ref):
+    base_dir = str(Path(from_path).parent)
+    return normpath(f"{base_dir}/{ref}")
+
+
+active = [(section, e) for section, e in entries if e.get("status") == "active"]
+
+ready = []
+blocked = []
+for section, e in active:
+    open_blockers = []
+    for ref in e.get("blocked-by", []):
+        target_path = resolve(e["path"], ref)
+        target = by_path.get(target_path)
+        if target is None:
+            open_blockers.append(f"{ref} (not found in index at {target_path} -- treated as open)")
+        elif target.get("status") != "done":
+            open_blockers.append(f"{ref} (status: {target.get('status', 'unknown')})")
+    if open_blockers:
+        blocked.append((section, e, open_blockers))
+    else:
+        ready.append((section, e))
+
+if mode == "ready":
+    if not ready:
+        print(
+            "No active items are ready -- either nothing is active, or every "
+            "active item has an open blocker (see: context-ready.sh --blocked)."
+        )
+    else:
+        print(f"{len(ready)} ready item(s) (active, zero open blockers):")
+        for section, e in sorted(ready, key=lambda x: x[1]["path"]):
+            print(f"  [{section}] {e['path']}: \"{e.get('title', '')}\"")
+else:
+    if not blocked:
+        print("No active items have an open blocker.")
+    else:
+        print(f"{len(blocked)} active item(s) with an open blocker:")
+        for section, e, open_blockers in sorted(blocked, key=lambda x: x[1]["path"]):
+            print(f"  [{section}] {e['path']}: \"{e.get('title', '')}\"")
+            for ob in open_blockers:
+                print(f"      blocked by: {ob}")
+PYEOF

--- a/skills/project-mgmt/context-index/scripts/regenerate-context-index.sh
+++ b/skills/project-mgmt/context-index/scripts/regenerate-context-index.sh
@@ -108,6 +108,12 @@ for md in sorted(context_dir.rglob("*.md")):
     related = parse_list_block(fm["_raw"], "related")
     if related:
         entry["related"] = related
+    blocks = parse_list_block(fm["_raw"], "blocks")
+    if blocks:
+        entry["blocks"] = blocks
+    blocked_by = parse_list_block(fm["_raw"], "blocked-by")
+    if blocked_by:
+        entry["blocked-by"] = blocked_by
     entries.append(entry)
 
 if missing:
@@ -229,6 +235,14 @@ for t in type_order:
             lines.append("    related:")
             for r in e["related"]:
                 lines.append(f"      - {emit_scalar(r)}")
+        if e.get("blocks"):
+            lines.append("    blocks:")
+            for b in e["blocks"]:
+                lines.append(f"      - {emit_scalar(b)}")
+        if e.get("blocked-by"):
+            lines.append("    blocked-by:")
+            for b in e["blocked-by"]:
+                lines.append(f"      - {emit_scalar(b)}")
     lines.append("")
 
 output = "\n".join(lines) + "\n"

--- a/skills/project-mgmt/create-context-file/SKILL.md
+++ b/skills/project-mgmt/create-context-file/SKILL.md
@@ -75,6 +75,20 @@ list; when no `--related` is given, the key is omitted entirely rather than
 written as `related: []`.
 
 ```bash
+# Follow-up that can't start until a plan lands
+./scripts/create-context-file.sh --type follow-ups --title "Wire up token refresh" \
+  --blocked-by "../plans/2026-03-16-auth-rollout.md"
+```
+
+Expected result: a dated follow-up file whose frontmatter includes a
+`blocked-by:` list, in the same "omitted when empty" style as `related`. The
+`context-index` skill's `scripts/context-ready.sh` reads this field across
+every context file to report which active files have zero open blockers —
+set `--blocks` on the file being depended on, `--blocked-by` on the file
+doing the depending, or both if the relationship is worth recording from
+either side.
+
+```bash
 # Multi-line body via heredoc
 ./scripts/create-context-file.sh --type plans --title "Retriever rollout" << 'EOF'
 ## Phase 1
@@ -140,17 +154,36 @@ repositories.
 
 **Consequence:** broken chronological ordering plus frontmatter parse failures.
 
-### NEVER emit `related: []` when there are no related files
+### NEVER emit `related: []`, `blocks: []`, or `blocked-by: []` when there is nothing to list
 
 **WHY:** an empty list is noise; the field should be absent when there is
 nothing to link.
 
-**BAD:** `related: []` in the frontmatter.
-**GOOD:** omit the `related` key entirely; pass `--related` only when there is
-at least one path to list.
+**BAD:** `related: []` (or `blocks: []` / `blocked-by: []`) in the frontmatter.
+**GOOD:** omit the key entirely; pass `--related`/`--blocks`/`--blocked-by`
+only when there is at least one path to list.
 
 **Consequence:** frontmatter clutter that trains readers (and tooling) to
 ignore the field, masking the times it actually carries a link.
+
+### NEVER set `blocked-by` on a file whose blocker is unlikely to ever reach `status: done`
+
+**WHY:** `context-ready.sh` fails closed — an unresolvable blocker path, or
+one that sits at a status other than `done` indefinitely, keeps the
+dependent file reported as blocked forever, with no automatic timeout.
+
+**BAD:** pointing `blocked-by` at a typology whose typical lifecycle is "keep
+indefinitely" or "keep while active" rather than a discrete close (see the
+lifecycle column in [Typologies](references/typologies.md)) — e.g. a
+`guide` or `research` file nobody plans to ever mark `done`.
+**GOOD:** point `blocked-by` at a typology whose lifecycle is a real
+close event (`plan` retiring, `follow-up` closing, `ticket` tracked to
+resolution, `merge-request` retiring after merge) — or record the
+relationship in prose instead if it isn't really "done-or-not-done" shaped.
+
+**Consequence:** a file that can never actually be reported ready, with
+nothing in `context-ready.sh`'s output explaining that the blocker itself is
+the problem rather than the work.
 
 ### NEVER invent a new typology for a one-off
 
@@ -165,4 +198,4 @@ ignore the field, masking the times it actually carries a link.
 
 - [Typologies](references/typologies.md) — the curated catalog, selection rule, and how to extend the set; load when choosing or adding a typology.
 - [CLI reference](references/cli.md) — full generator flags, behavior, and examples; load when you need an option beyond the Quick Commands.
-- [Frontmatter schema](assets/schemas/context-frontmatter.schema.json) — the JSON Schema for `title`, `type`, `date`, `status`, `tags`, and `related`; load when validating a context file's frontmatter or wiring a lint check.
+- [Frontmatter schema](assets/schemas/context-frontmatter.schema.json) — the JSON Schema for `title`, `type`, `date`, `status`, `tags`, `related`, `blocks`, and `blocked-by`; load when validating a context file's frontmatter or wiring a lint check.

--- a/skills/project-mgmt/create-context-file/assets/schemas/context-frontmatter.schema.json
+++ b/skills/project-mgmt/create-context-file/assets/schemas/context-frontmatter.schema.json
@@ -53,6 +53,24 @@
         "minLength": 1
       },
       "description": "Relative paths to related .context files. Omit the field entirely if there are no related files -- never emit related: []."
+    },
+    "blocks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Relative paths to other .context files that cannot be considered ready until THIS file reaches status: done. Inverse of blocked-by; the two are not auto-reconciled, so set both sides when the relationship is known. Paths are relative to this file's own directory, the same convention as related. Omit the field entirely if nothing is blocked -- never emit blocks: []."
+    },
+    "blocked-by": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Relative paths to other .context files that must reach status: done before THIS file is considered ready. Inverse of blocks. Paths are relative to this file's own directory, the same convention as related. Read by context-index's scripts/context-ready.sh to compute which active files have zero open blockers. Omit the field entirely if nothing blocks this file -- never emit blocked-by: []."
     }
   }
 }

--- a/skills/project-mgmt/create-context-file/references/cli.md
+++ b/skills/project-mgmt/create-context-file/references/cli.md
@@ -19,6 +19,8 @@ scripts/create-context-file.sh --type <typology> --title "<title>" [options]
 | `-s`, `--slug` | `SLUG` | Override the auto-derived slug. |
 | `-g`, `--tags` | `TAGS` | Comma-separated tags for frontmatter. |
 | `-R`, `--related` | `PATHS` | Comma-separated relative paths to related `.context` files. Omitted entirely from frontmatter when empty — never written as `related: []`. |
+| `-b`, `--blocks` | `PATHS` | Comma-separated relative paths to `.context` files that cannot be ready until **this** file is done. Same omit-when-empty rule as `--related`. |
+| `-k`, `--blocked-by` | `PATHS` | Comma-separated relative paths to `.context` files that must be done before **this** file is ready. Same omit-when-empty rule as `--related`. Read by the `context-index` skill's `scripts/context-ready.sh`. |
 | `-d`, `--date` | `DATE` | Override the date (`YYYY-MM-DD`); defaults to today. |
 | `-r`, `--root` | `DIR` | Context root; defaults to `.context`. |
 | `-A`, `--allow-new-type` | | Permit a typology not in `KNOWN_TYPES`. |
@@ -46,6 +48,10 @@ scripts/create-context-file.sh --type findings --title "Auth token analysis" \
 # Finding that references an existing plan
 scripts/create-context-file.sh --type findings --title "Auth token analysis" \
   --related "../plans/2026-03-16-auth-rollout.md"
+
+# Follow-up that can't start until a plan is done
+scripts/create-context-file.sh --type follow-ups --title "Wire up token refresh" \
+  --blocked-by "../plans/2026-03-16-auth-rollout.md"
 
 # Plan with a heredoc body
 scripts/create-context-file.sh --type plans --title "Retriever rollout" << 'EOF'

--- a/skills/project-mgmt/create-context-file/scripts/create-context-file.sh
+++ b/skills/project-mgmt/create-context-file/scripts/create-context-file.sh
@@ -23,6 +23,13 @@
 #   -R, --related PATHS    Comma-separated relative paths to related .context
 #                          files. Omitted entirely from frontmatter when empty
 #                          -- never emitted as `related: []`.
+#   -b, --blocks     PATHS Comma-separated relative paths to .context files
+#                          that cannot be ready until THIS file is done.
+#                          Same omit-when-empty rule as --related.
+#   -k, --blocked-by PATHS Comma-separated relative paths to .context files
+#                          that must be done before THIS file is ready. Same
+#                          omit-when-empty rule as --related. Read by
+#                          context-index's scripts/context-ready.sh.
 #   -d, --date    DATE     Override the date (YYYY-MM-DD). Defaults to today.
 #   -r, --root    DIR      Context root. Defaults to .context.
 #   -A, --allow-new-type   Permit a typology not in KNOWN_TYPES.
@@ -79,6 +86,8 @@ title=""
 slug=""
 tags=""
 related=""
+blocks=""
+blocked_by=""
 date=""
 root=".context"
 allow_new=0
@@ -92,6 +101,8 @@ while [ $# -gt 0 ]; do
 		-s|--slug)           slug="${2:-}"; shift 2 ;;
 		-g|--tags)           tags="${2:-}"; shift 2 ;;
 		-R|--related)        related="${2:-}"; shift 2 ;;
+		-b|--blocks)         blocks="${2:-}"; shift 2 ;;
+		-k|--blocked-by)     blocked_by="${2:-}"; shift 2 ;;
 		-d|--date)           date="${2:-}"; shift 2 ;;
 		-r|--root)           root="${2:-}"; shift 2 ;;
 		-A|--allow-new-type) allow_new=1; shift ;;
@@ -146,25 +157,41 @@ else
 	tags_block="tags: []"
 fi
 
-# Build related block. Unlike tags, an empty related list is omitted
-# entirely from the frontmatter -- never emitted as `related: []`.
-related_block=""
-if [ -n "$related" ]; then
-	_ifs="$IFS"; IFS=','
-	for _rel in $related; do
-		_rel="$(printf '%s' "$_rel" | sed 's/^[[:space:]]\{1,\}//; s/[[:space:]]\{1,\}$//')"
-		if [ -n "$_rel" ]; then
-			if [ -z "$related_block" ]; then
-				related_block="related:
-  - ${_rel}"
-			else
-				related_block="${related_block}
-  - ${_rel}"
+# Build a path-list block for a frontmatter key from a comma-separated value,
+# e.g. build_path_list_block related "../plans/x.md,../plans/y.md" prints:
+#   related:
+#     - ../plans/x.md
+#     - ../plans/y.md
+# Unlike tags, these keys are omitted entirely from the frontmatter when
+# empty -- never emitted as `related: []` / `blocks: []` / `blocked-by: []`.
+# Shared by --related, --blocks, and --blocked-by, which all follow the same
+# file-relative-path, omit-when-empty convention.
+build_path_list_block() {
+	_key="$1"
+	_value="$2"
+	_block=""
+	if [ -n "$_value" ]; then
+		_ifs="$IFS"; IFS=','
+		for _item in $_value; do
+			_item="$(printf '%s' "$_item" | sed 's/^[[:space:]]\{1,\}//; s/[[:space:]]\{1,\}$//')"
+			if [ -n "$_item" ]; then
+				if [ -z "$_block" ]; then
+					_block="${_key}:
+  - ${_item}"
+				else
+					_block="${_block}
+  - ${_item}"
+				fi
 			fi
-		fi
-	done
-	IFS="$_ifs"
-fi
+		done
+		IFS="$_ifs"
+	fi
+	printf '%s' "$_block"
+}
+
+related_block="$(build_path_list_block related "$related")"
+blocks_block="$(build_path_list_block blocks "$blocks")"
+blocked_by_block="$(build_path_list_block blocked-by "$blocked_by")"
 
 body="---
 title: \"${title}\"
@@ -173,10 +200,12 @@ date: ${date}
 status: active
 ${tags_block}"
 
-if [ -n "$related_block" ]; then
-	body="${body}
-${related_block}"
-fi
+for _pl_block in "$related_block" "$blocks_block" "$blocked_by_block"; do
+	if [ -n "$_pl_block" ]; then
+		body="${body}
+${_pl_block}"
+	fi
+done
 
 body="${body}
 ---


### PR DESCRIPTION
## What

Adds two optional frontmatter fields to context files, `blocks` and
`blocked-by`, and a new script, `context-index/scripts/context-ready.sh`,
that reports which active context files have zero open blockers (and, with
`--blocked`, which ones do and what's blocking them).

- `create-context-file` gained matching `--blocks`/`--blocked-by` CLI flags
  (same "omit when empty, never emit `[]`" convention already used for
  `--related`).
- `context-index`'s `regenerate-context-index.sh` now carries both fields
  into `index.yaml` so `context-ready.sh` has something to read.
- Both skills' docs (`SKILL.md`, `references/cli.md`,
  `references/regeneration-reference.md`) were updated to match, including
  two new anti-patterns for the create-context-file skill.

## Why

Neither skill had a way to say "this can't start until that's done," or to
ask "what's actually unblocked right now" across the whole context backlog
— only a manual, judgment-call read of the files. This closes that gap with
plain frontmatter and one more script: no new binary, no new storage engine,
nothing else in either skill's shape changes.

## Notes

- Verified with a synthetic `.context/` fixture covering: a satisfied
  blocker (done), an open blocker (still active), and an unresolvable
  blocker reference (fails closed rather than assumed satisfied) — plus the
  stale-index warning and missing-index paths.
- `shellcheck` clean on both scripts; `skill-validator-rs` reports 0 errors
  on both skills (pre-existing warnings on `create-context-file` --
  `CHANGELOG.md` presence, `assets/schemas/` nesting, a keyword-list-style
  description -- are unrelated to this change).
- No new eval scenarios were added for either skill; flagging that as a gap
  rather than silently skipping it.