### PR TITLE
feat(skills): add interview + gap-detection to jira-ticket-readyup

### DIFF
--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -120,7 +120,7 @@ Comprehensive toolkit for validating, linting, testing, and automating Terraform
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [terraform-validator](/tekhne/skills/infrastructure/terraform/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
+| [terraform-validator](/tekhne/skills/infrastructure/terraform/validator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-07-24 | 8 |
 
 ### terraform-generator
 
@@ -1146,7 +1146,7 @@ Creates a structured, date-stamped context file filed by typology (findings, pla
 
 ### issue-tracker-toolkit-jira-ticket-readyup
 
-Ready up Jira tickets for refinement by gathering context from linked incidents,...
+Ready up Jira tickets for refinement, including brand-new not-yet-keyed backlog ...
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |

--- a/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/SKILL.md
+++ b/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: jira-ticket-readyup
-description: "Ready up Jira tickets for refinement by gathering context from linked incidents, populating a YAML template following the project's 'ready for refinement' standard, validating against a JSON schema, and generating a structured markdown document. Use when asked to 'ready up', 'ready a ticket', 'prepare for refinement', or 'write up PROJ-NNN'. Keywords: jira, ticket, refinement, ready, backlog, YAML template, JSON schema, context, conditions of satisfaction, acceptance criteria."
+description: "Ready up Jira tickets for refinement, including brand-new not-yet-keyed backlog items, by gathering context from linked incidents or interviewing the user when no incident exists, populating a YAML template against the project's 'ready for refinement' standard, validating it against a JSON schema plus gap-detection heuristics for testability and vagueness, and generating a structured markdown document. Use when asked to ready up, prepare for refinement, draft a new backlog ticket, or write up a specific ticket key."
 ---
 
 # jira-ticket-readyup
 
-Turn a sparse Jira backlog ticket into a fully-structured "ready for refinement" document by gathering incident context, applying the standard template, and validating the output.
+Turn a sparse Jira backlog ticket — or a brand-new item with no key yet — into a fully-structured "ready for refinement" document by gathering incident context (or interviewing the user when no source material answers a required question), applying the standard template, and validating the output against both the schema and gap-detection heuristics.
 
 ## When to Use This Skill
 
@@ -13,9 +13,9 @@ Use jira-ticket-readyup when:
 - User asks to "ready up" or "prepare for refinement" one or more Jira tickets
 - A ticket exists but lacks Context, Conditions of Satisfaction, or Acceptance Criteria
 - User wants to promote a follow-up ticket (spawned from an incident) into a proper backlog item
+- User wants to draft a brand-new backlog ticket that has no Jira key yet (set `ticket.new_ticket: true` — see Step 2a)
 
 **Do NOT use for:**
-- Creating new Jira tickets from scratch (use Jira MCP tools directly)
 - Tickets that are already in "Ready for Refinement" status with full descriptions
 
 ## What a Good Ticket Looks Like
@@ -44,9 +44,9 @@ skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/assets/templates/r
 
 Do NOT generate a ticket data file without loading this template.
 
-### Step 2 — Gather context from Jira
+### Step 2 — Gather context
 
-For each ticket to ready up:
+**For an existing ticket** (has a Jira key):
 
 1. Fetch the ticket itself:
    ```
@@ -66,6 +66,20 @@ For each ticket to ready up:
    - Who investigated and what they concluded
    - Any proposed solution or follow-up actions already noted
 
+**For a brand-new ticket** (no Jira key yet, set `ticket.new_ticket: true`): there is no ticket or incident to fetch. Gather whatever source material the user already gave you (a meeting summary, a chat thread, a prior finding) and go straight to Step 2a — the interview pass is what supplies everything a fetch would otherwise have provided.
+
+### Step 2a — Interview for CoS/AC gaps
+
+Run one pass per section below, **after** gathering context and **before** populating the YAML. A pass only asks the user a question when the gathered source material does not already answer it — never invent an answer, never write a placeholder, and never silently pick one option among several open ones. Ask one section's questions at a time rather than front-loading everything at once.
+
+1. **Context / Problem.** If the source material states that something happened but not why it matters or what specifically breaks: ask what the triggering event was (incident, request, backlog carry-over, meeting decision), and what an engineer or user cannot currently do because of the gap. If the work touches a regulated system (personal data, payments, safety), ask whether a data-handling constraint needs stating in `context.background`.
+
+2. **Conditions of Satisfaction, per MoSCoW tier.** For each candidate MUST, ask what breaks if it ships without it — if nothing breaks, it likely belongs in SHOULD, not MUST. For each candidate SHOULD, ask whether it is expected in this delivery or genuinely deferrable (then it belongs in COULD). An empty COULD tier is not a gap; only ask about it if the user wants nice-to-haves captured. If two MUST/SHOULD items look like they require different, incompatible choices, ask the user to resolve it — do not silently pick one (see "Gap-Detection Heuristics" below).
+
+3. **Acceptance Criteria.** For each candidate AC, ask how someone who has not read the ticket would confirm it is met — what they would run, click, or observe. If the answer cannot be phrased as an observable check, the AC is not ready. If a MUST item has no AC that would fail were the MUST not met, ask what observable outcome proves it.
+
+4. **Supporting Information.** If a CoS/AC/Background item references something (a repo, file, incident, decision) without a link, ask for it. Never invent a plausible-looking URL — ask, or leave it as an explicit open item if the user doesn't have it to hand.
+
 ### Step 3 — Populate the YAML data file
 
 Create a data file at the output path using the template. The output path convention is:
@@ -74,22 +88,32 @@ Create a data file at the output path using the template. The output path conven
 <journal-dir>/YYYY/MM/YYYY-MM-DD-PROJ-NNN-ready-for-refinement.yaml
 ```
 
-Use your judgment to synthesise context from all available sources — the ticket description, linked incident comments, and any other information gathered in Step 2. The goal is a coherent narrative that lets a developer pick up the ticket cold and understand what needs to be done and why.
+For a brand-new ticket, use a placeholder slug instead of `PROJ-NNN` in the filename (e.g. the first few words of the summary) since no key exists yet.
+
+Use your judgment to synthesise context from all available sources — the ticket description, linked incident comments, and anything surfaced by the Step 2a interview. The goal is a coherent narrative that lets a developer pick up the ticket cold and understand what needs to be done and why.
 
 Key constraints:
 - Never leave a required field empty or as the placeholder `""`
 - `conditions_of_satisfaction.must` must have at least one item
 - `acceptance_criteria` must have at least two specific, testable items
 - If no incident is linked, derive all context from the ticket description alone
+- For a brand-new ticket, set `ticket.new_ticket: true` and omit `ticket.key` entirely (the schema rejects the combination of `new_ticket: true` with a `key` present)
 
-### Step 4 — Validate the YAML
+### Step 4 — Review for gaps beyond presence/count, then validate
+
+Before running the validator, read all MUST/SHOULD items together and check for two things a schema cannot catch (see "Gap-Detection Heuristics" below for the full set):
+
+- **Conflict:** do any two MUST/SHOULD items require different, incompatible choices? If so, this should already have been resolved in Step 2a — if it wasn't, resolve it now rather than letting both stand.
+- **Self-containment:** does any item depend on a fact not stated elsewhere in the ticket (e.g. "the way we discussed" with no record of what was discussed)? A reader with only this ticket must be able to act on every item.
+
+Then run the validator, which also checks three more gap-detection heuristics mechanically (testability, vagueness, MUST-to-AC coverage) and prints them as advisory warnings:
 
 ```bash
 bun run skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/scripts/validate-ticket.ts \
   <path-to-ticket-data.yaml>
 ```
 
-Fix any reported errors before proceeding to markdown generation.
+Fix every schema/field error before proceeding to markdown generation. Gap-detection warnings are advisory and can false-positive — review each one, but they do not block by default. Pass `--strict-gaps` to fail the run on any gap-detection warning (useful in CI or when you want a hard gate).
 
 **Prerequisite:** `bun` must be available (`which bun`).
 
@@ -99,6 +123,8 @@ Create the markdown file at:
 ```
 <journal-dir>/YYYY/MM/YYYY-MM-DD-PROJ-NNN-ready-for-refinement.md
 ```
+
+For a brand-new ticket, use the same placeholder slug from Step 3 in place of `PROJ-NNN`.
 
 Use this structure exactly:
 
@@ -138,6 +164,8 @@ Use this structure exactly:
 - [<INC-NNN>](<url>) — <incident summary>
 ```
 
+For a brand-new ticket (`ticket.new_ticket: true`), replace the `<Ticket Key>` in the H1 and drop the em dash if there is none yet, and add one line directly under the H1 stating this is a draft with no ticket created yet: `*Draft — no ticket key yet; creating the ticket and assigning a key is a separate, human-confirmed step, not performed by this skill.*`
+
 ### Step 6 — Validate the markdown
 
 ```bash
@@ -165,6 +193,20 @@ Store outputs in the journal directory:
 ```
 
 Use today's date for YYYY-MM-DD. The `journal-dir` is the current project root.
+
+## Gap-Detection Heuristics
+
+Beyond the schema's presence/count checks (>=1 MUST, >=2 AC, minimum lengths), five heuristics catch gaps a count cannot:
+
+| # | Heuristic | Where it runs |
+|---|---|---|
+| 1 | **Testability** — an acceptance criterion has no verb describing a checkable action/state (return, produce, emit, contain, respond, ...) and no measurable token (a number, quoted value, HTTP/error code) | `validate-ticket.ts`, advisory warning |
+| 2 | **Aspiration/vagueness** — a CoS or AC item is only a comparative/quality adjective with no concrete threshold ("more robust", "better logging", "improve reliability", "properly handle") | `validate-ticket.ts`, advisory warning |
+| 3 | **MUST/SHOULD conflict** — two items require different, incompatible choices | Manual review, Step 2a and Step 4 (needs semantic judgment, not scriptable) |
+| 4 | **Self-containment** — an item depends on a fact not stated elsewhere in the ticket | Manual review, Step 4 (needs semantic judgment, not scriptable) |
+| 5 | **MUST-to-AC coverage** — a MUST item has no acceptance criterion that would fail if the MUST were not met (checked via keyword overlap, not exact — a heuristic, not proof) | `validate-ticket.ts`, advisory warning |
+
+Heuristics 1, 2, and 5 print as advisory warnings by default (they can false-positive — read each one) and only fail the run when `--strict-gaps` is passed. Heuristics 3 and 4 cannot be scripted reliably because they require understanding what an item means, not just its text, so they are explicit review steps for the agent (Step 2a asks the interview questions that head off most conflicts before they're written down; Step 4 is the last check before validation).
 
 ## Template Schema Reference
 
@@ -200,11 +242,22 @@ WHY: "Improve reliability" is untestable. Refinement sessions get blocked when t
 ❌ BAD: MUST make the service more robust.
 ✅ GOOD: MUST return HTTP 400 with error code `INVALID_POSTAL_CODE` when input fails the expected validation pattern.
 
+### NEVER guess or leave a placeholder when source material doesn't answer a required question
+WHY: A guessed background, MUST, or acceptance criterion looks complete and passes the schema, but it's fiction — the ticket reader has no way to tell it apart from something actually confirmed. The whole point of Step 2a is that the agent stops and asks instead of filling the gap itself.
+❌ BAD: The meeting notes don't say what happens if the change ships without it, so writing "MUST ensure this is handled" anyway to keep the ticket moving.
+✅ GOOD: Ask the user what breaks if it ships without it (Step 2a, pass 2); use their answer, or leave it as an explicit open item if they don't know yet.
+
+### NEVER treat a clean validator run as proof the ticket is testable
+WHY: `validate-ticket.ts`'s schema check only confirms fields are present and meet a length minimum — it says nothing about whether an item is actually verifiable, non-contradictory, or self-contained. The gap-detection heuristics exist because presence and testability are different properties.
+❌ BAD: Schema validation passed, so the ticket is ready — skip Step 4's manual conflict/self-containment review.
+✅ GOOD: Always do the Step 4 manual review (conflict, self-containment) even when the automated gap-detection warnings are empty; the two scripted heuristics do not cover everything.
+
 ## References
 
 | Topic | Reference | When to Use |
 |---|---|---|
 | YAML field guide | `references/yaml-field-guide.md` | When unsure what a template field expects |
 | YAML template | `assets/templates/ready-for-refinement.yaml` | Step 1 of every workflow run |
-| JSON schema | `assets/schemas/ready-for-refinement.schema.json` | Understand validation rules |
-| Validation script | `scripts/validate-ticket.ts` | Steps 4 and 6 of the workflow |
+| JSON schema | `assets/schemas/ready-for-refinement.schema.json` | Understand validation rules, including the `new_ticket`/`key` cross-field rule |
+| Validation script | `scripts/validate-ticket.ts` | Steps 4 and 6 of the workflow; pass `--strict-gaps` to hard-fail on gap-detection warnings |
+| Gap-Detection Heuristics (this file) | `## Gap-Detection Heuristics` above | Understand which checks are scripted vs. manual review |

--- a/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/assets/schemas/ready-for-refinement.schema.json
+++ b/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/assets/schemas/ready-for-refinement.schema.json
@@ -13,13 +13,18 @@
   "properties": {
     "ticket": {
       "type": "object",
-      "required": ["key", "summary", "type"],
+      "required": ["summary", "type"],
       "additionalProperties": false,
       "properties": {
         "key": {
           "type": "string",
           "pattern": "^[A-Z][A-Z0-9]+-[0-9]+$",
-          "description": "Jira issue key, e.g. PROJ-NNN"
+          "description": "Jira issue key, e.g. PROJ-NNN. Must be absent when new_ticket is true (no key exists yet)."
+        },
+        "new_ticket": {
+          "type": "boolean",
+          "description": "True when this is a brand-new backlog item with no Jira key yet — creating the ticket and assigning a key is a separate, human-confirmed step outside this skill. When true, ticket.key must be absent.",
+          "default": false
         },
         "summary": {
           "type": "string",
@@ -36,7 +41,17 @@
           "pattern": "^[A-Z][A-Z0-9]+-[0-9]+$",
           "description": "Linked incident key, e.g. INC-NNN"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "new_ticket": { "const": true } },
+            "required": ["new_ticket"]
+          },
+          "then": { "not": { "required": ["key"] } },
+          "else": { "required": ["key"] }
+        }
+      ]
     },
     "context": {
       "type": "object",

--- a/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/assets/templates/ready-for-refinement.yaml
+++ b/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/assets/templates/ready-for-refinement.yaml
@@ -3,7 +3,8 @@
 # Validate with: scripts/validate-ticket.sh <your-ticket.yaml>
 
 ticket:
-  key: ""               # e.g. PROJ-NNN
+  key: ""               # e.g. PROJ-NNN. Omit this whole line for a brand-new, not-yet-keyed ticket — set new_ticket: true instead
+  new_ticket: false      # Set to true only for a brand-new backlog item with no Jira key yet; then omit the key line above entirely
   summary: ""           # The ticket title/summary
   type: ""              # Bug | Feature | Maintenance | Investigation
   linked_incident: ""   # e.g. INC-NNN (omit if none)

--- a/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/references/yaml-field-guide.md
+++ b/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/references/yaml-field-guide.md
@@ -10,7 +10,8 @@ Top-level metadata identifying the Jira ticket being readied up.
 
 | Field | Purpose | Example value |
 |---|---|---|
-| `ticket.key` | Jira issue key | `PROJ-NNN` |
+| `ticket.key` | Jira issue key. Required unless `ticket.new_ticket` is `true`, in which case it must be absent (schema-enforced) | `PROJ-NNN` |
+| `ticket.new_ticket` | Set to `true` for a brand-new backlog item with no Jira key yet — creating the ticket and assigning a key is a separate, human-confirmed step outside this skill. Defaults to `false` | `true` |
 | `ticket.summary` | Ticket title as it appears in Jira | `Handle invalid input in the address-lookup service` |
 | `ticket.type` | Issue type — controls markdown heading and linked-incident line | `Bug` / `Feature` / `Maintenance` / `Investigation` |
 | `ticket.linked_incident` | Key of the incident that triggered this ticket; omit or leave blank if none | `INC-NNN` |

--- a/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/scripts/validate-ticket.ts
+++ b/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/scripts/validate-ticket.ts
@@ -3,9 +3,14 @@
  * Validates a ready-for-refinement YAML data file against the JSON schema,
  * then optionally checks that the markdown output has the required sections.
  *
+ * Also runs advisory gap-detection heuristics beyond presence/count (AC
+ * testability, CoS/AC aspiration-and-vagueness, MUST-to-AC coverage) and
+ * prints them as warnings. Pass --strict-gaps to fail the run on any warning.
+ *
  * Usage:
  *   bun run scripts/validate-ticket.ts <ticket-data.yaml>
  *   bun run scripts/validate-ticket.ts <ticket-data.yaml> --markdown <ticket-output.md>
+ *   bun run scripts/validate-ticket.ts <ticket-data.yaml> --strict-gaps
  */
 
 import { readFileSync } from "node:fs";
@@ -18,10 +23,13 @@ import { load } from "js-yaml";
 const args = process.argv.slice(2);
 let yamlFile = "";
 let mdFile = "";
+let strictGaps = false;
 
 for (let i = 0; i < args.length; i++) {
   if ((args[i] === "--markdown" || args[i] === "-m") && args[i + 1]) {
     mdFile = args[++i];
+  } else if (args[i] === "--strict-gaps") {
+    strictGaps = true;
   } else if (!args[i].startsWith("-")) {
     yamlFile = args[i];
   } else {
@@ -87,10 +95,14 @@ const data = rawData as Record<string, unknown>;
 const ticket = (data.ticket ?? {}) as Record<string, unknown>;
 const context = (data.context ?? {}) as Record<string, unknown>;
 const cos = (data.conditions_of_satisfaction ?? {}) as Record<string, unknown>;
-const ac = data.acceptance_criteria as unknown[];
+const ac = (data.acceptance_criteria ?? []) as string[];
+const isNewTicket = ticket.new_ticket === true;
 
 const fieldErrors: string[] = [];
-if (!String(ticket.key ?? "").trim()) fieldErrors.push("ticket.key is empty");
+if (!isNewTicket && !String(ticket.key ?? "").trim())
+  fieldErrors.push(
+    "ticket.key is empty (set ticket.new_ticket: true for a brand-new, not-yet-keyed ticket)",
+  );
 if (!String(ticket.summary ?? "").trim())
   fieldErrors.push("ticket.summary is empty");
 if (!String(context.background ?? "").trim())
@@ -106,6 +118,141 @@ if (fieldErrors.length > 0) {
 }
 
 console.log("  OK: All required fields are populated.");
+
+// ── 2b. Gap-detection heuristics (advisory, beyond presence/count) ───────────
+//
+// These catch what presence/count checks above cannot: an item that exists,
+// meets the length minimum, and still is not testable, is vague, or has no
+// acceptance criterion verifying it. See docs/knowledge-base/jira/
+// cos-ac-interview-and-gap-detection-process.md in the journal repo for the
+// design this implements (heuristics 1, 2, and 5 of 5 — the other two, MUST/
+// SHOULD conflict and self-containment, need semantic judgment and are run
+// as an explicit review prompt in SKILL.md instead of code).
+
+console.log("Running gap-detection heuristics (advisory)...");
+
+const VAGUE_PATTERNS = [
+  /\bmore robust\b/i,
+  /\bmore reliable\b/i,
+  /\bimprove(?:d|s)? reliability\b/i,
+  /\bbetter (?:logging|error handling|performance|reliability)\b/i,
+  /\bproperly handle[sd]?\b/i,
+  /\bhandle[sd]? (?:it |this )?properly\b/i,
+  /\bas needed\b/i,
+  /\bas appropriate\b/i,
+  /\bwhere appropriate\b/i,
+  /\bmore efficient\b/i,
+  /\bmore performant\b/i,
+  /\bmore maintainable\b/i,
+  /\bcleaner code\b/i,
+  /\benhance(?:s|d)? (?:the )?(?:service|system|performance|reliability)\b/i,
+  /\bimprove(?:s|d)? (?:the )?(?:service|system|performance|reliability)\b/i,
+];
+
+const OBSERVABLE_VERB =
+  /\b(returns?|responds?|produces?|emits?|contains?|displays?|logs?|logged|rejects?|accepts?|matches?|equals?|shows?|lists?|counts?|triggers?|raises?|includes?|excludes?|redirects?|throws?|fails?|passes?|persists?|writes?|reads?|calls?|invokes?|renders?|sends?|receives?|blocks?|allows?|denies?|process(?:es|ed)?|forward(?:s|ed)?|continue[ds]?)\b/i;
+const HAS_MEASURABLE_TOKEN =
+  /\d|https?:\/\/|`[^`]+`|"[^"]+"|'[^']+'|\b(HTTP|error code|status code)\b/i;
+
+const gapWarnings: string[] = [];
+
+function checkVagueness(label: string, items: string[]): void {
+  for (const item of items) {
+    if (VAGUE_PATTERNS.some((re) => re.test(item))) {
+      gapWarnings.push(
+        `${label} reads as an aspiration, not a testable requirement: "${item}"`,
+      );
+    }
+  }
+}
+
+function checkTestability(items: string[]): void {
+  for (const item of items) {
+    if (!OBSERVABLE_VERB.test(item) && !HAS_MEASURABLE_TOKEN.test(item)) {
+      gapWarnings.push(
+        `Acceptance criterion has no observable outcome (no checkable verb or measurable token): "${item}"`,
+      );
+    }
+  }
+}
+
+function significantWords(text: string): Set<string> {
+  const stopwords = new Set([
+    "must",
+    "should",
+    "could",
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "of",
+    "to",
+    "for",
+    "with",
+    "when",
+    "that",
+    "this",
+    "is",
+    "are",
+    "be",
+    "it",
+    "on",
+    "in",
+    "at",
+    "no",
+    "not",
+  ]);
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((w) => w.length >= 4 && !stopwords.has(w)),
+  );
+}
+
+function checkMustToAcCoverage(musts: string[], criteria: string[]): void {
+  const acWordSets = criteria.map(significantWords);
+  for (const must of musts) {
+    const mustWords = significantWords(must);
+    const covered = acWordSets.some((acWords) => {
+      let overlap = 0;
+      for (const w of mustWords) if (acWords.has(w)) overlap++;
+      return overlap >= 2;
+    });
+    if (!covered) {
+      gapWarnings.push(
+        `MUST item has no acceptance criterion that appears to verify it (heuristic keyword-overlap check — verify manually): "${must}"`,
+      );
+    }
+  }
+}
+
+const musts = Array.isArray(cos.must) ? (cos.must as string[]) : [];
+const shoulds = Array.isArray(cos.should) ? (cos.should as string[]) : [];
+
+checkVagueness("CoS MUST item", musts);
+checkVagueness("CoS SHOULD item", shoulds);
+checkVagueness("Acceptance criterion", ac);
+checkTestability(ac);
+checkMustToAcCoverage(musts, ac);
+
+if (gapWarnings.length > 0) {
+  console.warn(`  ${gapWarnings.length} gap-detection warning(s) (advisory):`);
+  for (const w of gapWarnings) console.warn(`  WARN: ${w}`);
+  console.warn(
+    "  These are heuristic and can false-positive — review each one; they do not block unless --strict-gaps is set.",
+  );
+  if (strictGaps) {
+    console.error(
+      `\n--strict-gaps set: failing on ${gapWarnings.length} gap-detection warning(s).`,
+    );
+    process.exit(1);
+  }
+} else {
+  console.log("  OK: No gap-detection warnings.");
+}
 
 // ── 3. Markdown structure validation (optional) ───────────────────────────────
 


### PR DESCRIPTION
## What

`jira-ticket-readyup` now asks the user targeted questions when it can't
already answer them from the ticket or linked incident, instead of leaving
required fields thin or accepting vague ones. It also stops excluding
brand-new backlog items that don't have a Jira key yet, and adds checks that
catch untestable or aspirational wording ("make it more robust") beyond the
existing presence/count checks.

## Why

Refinement sessions were getting blocked on Conditions of Satisfaction and
Acceptance Criteria that technically filled every field but weren't
actually usable — vague, untestable, or missing a link to the incident that
justified them. There was also no way to use this skill for a ticket that
hasn't been created yet, which is exactly the case a recent LCT team
meeting produced.

## Notes

Verified against a clean ticket fixture (zero warnings) and a deliberately
vague one (all scripted gap-detection heuristics fire, non-blocking by
default, hard-fails under `--strict-gaps`); confirmed the schema rejects a
brand-new ticket that still has a key, and a normal ticket missing one.
Local skill-audit grade: B (non-blocking).

Deliberately left out: a new eval scenario covering the multi-turn
interview flow — the existing eval harness is single-shot with full
context already supplied, and it's unclear whether it supports multi-turn
Q&A. Tracked as a follow-up rather than guessed at blind.