### PR TITLE
feat(context-index): add check-wave-evidence.sh sibling to check-plan-staleness.sh

### DIFF
--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -120,7 +120,7 @@ Comprehensive toolkit for validating, linting, testing, and automating Terraform
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [terraform-validator](/tekhne/skills/infrastructure/terraform/validator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-07-24 | 8 |
+| [terraform-validator](/tekhne/skills/infrastructure/terraform/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
 
 ### terraform-generator
 

--- a/skills/project-mgmt/context-index/scripts/check-wave-evidence.sh
+++ b/skills/project-mgmt/context-index/scripts/check-wave-evidence.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# shell: bash
+# check-wave-evidence.sh - advisory-only nudge: flag a wave/task proof-of-work
+# line that claims a test-count or score metric but carries no quoted command
+# output backing it up. Mirrors check-plan-staleness.sh in spirit and shape:
+# a mechanical backstop for AGENTS.md's Wave-Based Implementation Rules ("Update
+# the plan on completion, with evidence, not just a checkmark"), not a
+# substitute for actually reading the line.
+#
+# A completed line is one containing the ✅ marker. It is flagged only when it
+# also claims a numeric test/score metric (e.g. "20 tests pass", "score 97")
+# without a quoted substring anywhere on the line - a bare commit SHA with no
+# metric claim is not flagged, since the rule is about unbacked *numbers*, not
+# about every checkmark needing a quote.
+#
+# Always exits 0. A flagged line may still be genuinely evidenced by a nearby
+# line, a linked commit, or a claim that just doesn't need a quote (e.g. an
+# ABANDONED line) - this is a prompt to check, not proof of a violation.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+PLANS_DIR="$ROOT/.context/plans"
+
+if [ ! -d "$PLANS_DIR" ]; then
+  exit 0
+fi
+
+python3 - "$PLANS_DIR" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+plans_dir = Path(sys.argv[1])
+
+MARKER = "✅"
+CLAIM_PATTERNS = [
+    re.compile(r"\b\d+\s*(tests?|pass(?:ed)?|fail(?:ed)?|skip(?:ped)?)\b", re.IGNORECASE),
+    re.compile(r"\bscore[:\s]*\d+\b", re.IGNORECASE),
+]
+
+flagged = []
+for path in sorted(plans_dir.rglob("*.md")):
+    rel = path.relative_to(plans_dir.parent.parent)
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        continue
+    for lineno, line in enumerate(lines, start=1):
+        if MARKER not in line:
+            continue
+        if '"' in line:
+            continue
+        if not any(p.search(line) for p in CLAIM_PATTERNS):
+            continue
+        flagged.append((str(rel), lineno, line.strip()))
+
+if flagged:
+    print(f"NOTICE: {len(flagged)} proof-of-work line(s) claim a metric with no quoted evidence (advisory, non-blocking):")
+    for rel, lineno, line in flagged:
+        print(f"  {rel}:{lineno}")
+        print(f"    {line}")
+    print()
+    print("A ✅ line stating a test count or score should carry a quoted excerpt of the")
+    print('command output backing it (e.g. (bun test: "20 pass, 0 fail")), not just the')
+    print("number restated from memory. Check whether this one actually has evidence")
+    print("nearby before treating it as unmet.")
+
+sys.exit(0)
+PYEOF

--- a/skills/project-mgmt/context-index/scripts/check-wave-evidence.sh
+++ b/skills/project-mgmt/context-index/scripts/check-wave-evidence.sh
@@ -42,7 +42,7 @@ flagged = []
 for path in sorted(plans_dir.rglob("*.md")):
     rel = path.relative_to(plans_dir.parent.parent)
     try:
-        lines = path.read_text().splitlines()
+        lines = path.read_text(encoding="utf-8").splitlines()
     except OSError:
         continue
     for lineno, line in enumerate(lines, start=1):


### PR DESCRIPTION
### **User description**
## What

A companion plan/wave-file check: it flags a plan or wave document line
marked complete that states a test count or score but doesn't show any
actual command output backing that number up.

## Why

The journal repo's AGENTS.md already requires evidence, not just a
checkmark, for a completed wave or task. Up to now that was enforced only
by an agent reading the instructions - nothing caught it mechanically if a
line just restated a number from memory. This adds that mechanical
backstop, the same way an existing check already nudges about stale plans.

## Notes

Advisory only, never fails a build - it prints a notice and exits 0.
Verified against real plan documents in the journal repo (correctly flags
three lines that predate this convention, correctly leaves alone lines
that just cite a commit with no number claim) and a synthetic
fully-evidenced fixture. shellcheck clean.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Add `check-wave-evidence.sh` to validate plan evidence.

- Scan markdown plans for ✅ lines claiming metrics without quotes.

- Update `terraform-validator` rating and audit date in documentation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  script["check-wave-evidence.sh"] -- "Scans markdown files in" --> plans[".context/plans/"]
  plans -- "Flags unevidenced ✅ lines" --> notice["Print advisory notice"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check-wave-evidence.sh</strong><dd><code>Add advisory script to check wave evidence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/project-mgmt/context-index/scripts/check-wave-evidence.sh

<ul><li>Adds a bash script that embeds a Python script to scan markdown plans.<br> <li> Identifies completed tasks (marked with ✅) claiming test counts or <br>scores without quoted evidence.<br> <li> Prints an advisory notice listing flagged lines and exits with code 0.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/286/files#diff-8c24d85f8f1a61fcfd1fd1799215596a42ec0cb7bab8fc88f0eeeaf635d92738">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tiles.md</strong><dd><code>Update terraform-validator rating and audit date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/content/docs/tiles.md

<ul><li>Updates the rating of <code>terraform-validator</code> from <code>B+</code> to <code>C+</code>.<br> <li> Updates the audit date of <code>terraform-validator</code> to <code>2026-03-02</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/286/files#diff-17244a108ff207a43d7a6c4959acfcdbfc1e25cf88a6e444d5eccc5a04a13b42">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

