### PR TITLE
fix: make the published install paths work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pantheon-adr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "common",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "pantheon-journal"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "common",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "pantheon-skill-auditor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "common",

--- a/README.md
+++ b/README.md
@@ -18,18 +18,25 @@ Skills are plain Markdown, so any ecosystem installer can add the whole
 collection to an agent configuration:
 
 ```bash
+git clone https://github.com/pantheon-org/tekhne.git
+cd tekhne
+
 # Install all skills into your project
 npx skills add ./skills --all
 ```
 
-Each bundled Rust tool can also install (or remove) its own companion skill in
-detected agents:
+Three of the skills also ship as standalone Rust binaries for macOS and Linux,
+each of which installs its own companion skill. These need no clone:
 
 ```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/pantheon-org/tekhne/releases/download/tool/pantheon-skill-auditor-v0.2.0/pantheon-skill-auditor-installer.sh | sh
+
 pantheon-skill-auditor skill install     # or: skill uninstall
-pantheon-adr skill install
-pantheon-journal skill install
 ```
+
+See the [Tools page](https://pantheon-org.github.io/tekhne/tools/) for `pantheon-adr`
+and `pantheon-journal`, and for what each command does.
 
 ## Maintaining the catalog
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ domain knowledge, workflows, and best practices that can be loaded on-demand.
 ## Skill Catalog
 
 <!-- skill-catalog-stats -->
-Browse all **0 skills across 0 tiles** in the [Skill Catalog](https://pantheon-org.github.io/tekhne/tiles/).
+Browse all **117 skills across 71 tiles** in the [Skill Catalog](https://pantheon-org.github.io/tekhne/tiles/).
 
 ## Installing skills
 

--- a/crates/adr/Cargo.toml
+++ b/crates/adr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantheon-adr"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantheon-journal"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/skill-auditor/Cargo.toml
+++ b/crates/skill-auditor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantheon-skill-auditor"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/skill-validator-rs/tests/golden-corpus/goldens.json
+++ b/crates/skill-validator-rs/tests/golden-corpus/goldens.json
@@ -1711,7 +1711,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 230
+          "Tokens": 461
         }
       ],
       "other_token_counts": [
@@ -1937,6 +1937,10 @@
           "Tokens": 1614
         },
         {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
+        },
+        {
           "File": "reference.md",
           "Tokens": 1077
         }
@@ -2048,6 +2052,10 @@
         {
           "File": "SKILL.md body",
           "Tokens": 1382
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         },
         {
           "File": "reference.md",
@@ -2232,7 +2240,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 272
+          "Tokens": 402
         }
       ],
       "other_token_counts": [
@@ -2405,7 +2413,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 138
+          "Tokens": 268
         }
       ],
       "other_token_counts": [
@@ -2552,7 +2560,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 221
+          "Tokens": 440
         }
       ],
       "other_token_counts": [
@@ -2683,7 +2691,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 438
+          "Tokens": 657
         }
       ],
       "other_token_counts": [
@@ -2823,7 +2831,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 272
+          "Tokens": 402
         }
       ],
       "other_token_counts": [
@@ -2918,6 +2926,10 @@
         {
           "File": "references/reference.md",
           "Tokens": 1616
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         }
       ],
       "other_token_counts": [
@@ -3022,6 +3034,10 @@
         {
           "File": "SKILL.md body",
           "Tokens": 2261
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         }
       ],
       "other_token_counts": [
@@ -3266,6 +3282,10 @@
         {
           "File": "SKILL.md body",
           "Tokens": 1514
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         },
         {
           "File": "reference.md",
@@ -3782,7 +3802,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 213
+          "Tokens": 422
         }
       ],
       "other_token_counts": [
@@ -3904,7 +3924,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 394
+          "Tokens": 530
         }
       ],
       "other_token_counts": [
@@ -6829,7 +6849,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -6996,7 +7016,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -7176,7 +7196,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -7434,7 +7454,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -7598,7 +7618,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -8209,7 +8229,7 @@
         {
           "Level": 3,
           "Category": "Tokens",
-          "Message": "total reference files: 63014 tokens — this will consume 25-40% of a typical context window; reduce content or split into a skill with fewer references",
+          "Message": "total reference files: 63150 tokens — this will consume 25-40% of a typical context window; reduce content or split into a skill with fewer references",
           "File": "",
           "Line": 0
         },
@@ -8424,7 +8444,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -9399,7 +9419,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 684
+          "Tokens": 900
         }
       ],
       "other_token_counts": [
@@ -10429,7 +10449,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 229
+          "Tokens": 454
         }
       ],
       "other_token_counts": [
@@ -13142,7 +13162,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         },
         {
           "File": "skill.json",
@@ -13440,7 +13460,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 370
         }
       ],
       "other_token_counts": [
@@ -13542,6 +13562,10 @@
         {
           "File": "references/markdown-report-example.md",
           "Tokens": 2133
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 148
         }
       ],
       "other_token_counts": [
@@ -15188,7 +15212,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -15698,7 +15722,7 @@
         {
           "Level": 2,
           "Category": "Tokens",
-          "Message": "total reference files: 27921 tokens — agents may load multiple references in one session, consider whether all this content is essential",
+          "Message": "total reference files: 28057 tokens — agents may load multiple references in one session, consider whether all this content is essential",
           "File": "",
           "Line": 0
         },
@@ -15785,7 +15809,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -15937,7 +15961,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 264
+          "Tokens": 788
         }
       ],
       "other_token_counts": [
@@ -17282,7 +17306,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -17426,7 +17450,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -17849,7 +17873,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -17988,7 +18012,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [
@@ -18092,6 +18116,10 @@
         {
           "File": "SKILL.md body",
           "Tokens": 3140
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 215
         }
       ],
       "other_token_counts": [
@@ -18236,6 +18264,10 @@
         {
           "File": "references/reference.md",
           "Tokens": 1355
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         }
       ],
       "other_token_counts": [
@@ -19884,6 +19916,10 @@
         {
           "File": "references/frame-problem-to-troubleshoot-llm.md",
           "Tokens": 514
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         }
       ],
       "other_token_counts": [
@@ -20027,6 +20063,10 @@
         {
           "File": "references/reference.md",
           "Tokens": 1137
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         }
       ],
       "other_token_counts": [
@@ -20659,6 +20699,10 @@
         {
           "File": "references/troubleshoot-to-frame-problem-llm.md",
           "Tokens": 492
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         }
       ],
       "other_token_counts": [
@@ -21172,7 +21216,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 212
+          "Tokens": 428
         }
       ],
       "other_token_counts": [
@@ -21273,7 +21317,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 264
+          "Tokens": 400
         }
       ],
       "other_token_counts": [
@@ -21369,7 +21413,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 524
+          "Tokens": 660
         }
       ],
       "other_token_counts": [
@@ -21483,6 +21527,10 @@
         {
           "File": "references/reference.md",
           "Tokens": 975
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         },
         {
           "File": "reference.md",
@@ -21600,6 +21648,10 @@
         {
           "File": "references/reference.md",
           "Tokens": 482
+        },
+        {
+          "File": "CHANGELOG.md",
+          "Tokens": 127
         },
         {
           "File": "reference.md",
@@ -22064,7 +22116,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 264
+          "Tokens": 400
         }
       ],
       "other_token_counts": [
@@ -22229,7 +22281,7 @@
         },
         {
           "File": "CHANGELOG.md",
-          "Tokens": 134
+          "Tokens": 270
         }
       ],
       "other_token_counts": [

--- a/docs/scripts/prelink.mjs
+++ b/docs/scripts/prelink.mjs
@@ -70,7 +70,18 @@ const rewriteReferenceLinks = (content) =>
   );
 
 /**
- * Walk up the directory tree from skillSrcDir to find the nearest tile.json.
+ * A plugin.json carries no publishedUrl; a public one is addressable on the
+ * tessl registry by its name. Private tiles have no public page.
+ * @param {{ name?: string, private?: boolean }} data
+ */
+const registryUrl = (data) =>
+  data.private === false && data.name
+    ? `https://tessl.io/registry/skills/${data.name}`
+    : null;
+
+/**
+ * Walk up the directory tree from skillSrcDir to find the nearest tile
+ * manifest (.tessl-plugin/plugin.json, or a legacy tile.json).
  * Returns { publishedUrl, version } or null if not found.
  * @param {string} skillSrcDir
  */
@@ -78,12 +89,15 @@ const loadTileMetadata = (skillSrcDir) => {
   let dir = skillSrcDir;
   const root = skillsRoot;
   while (dir.startsWith(root)) {
-    const tilePath = join(dir, "tile.json");
-    if (existsSync(tilePath)) {
+    const manifestPath = [
+      join(dir, ".tessl-plugin", "plugin.json"),
+      join(dir, "tile.json"),
+    ].find((candidate) => existsSync(candidate));
+    if (manifestPath) {
       try {
-        const data = JSON.parse(readFileSync(tilePath, "utf-8"));
+        const data = JSON.parse(readFileSync(manifestPath, "utf-8"));
         return {
-          publishedUrl: data.publishedUrl ?? null,
+          publishedUrl: data.publishedUrl ?? registryUrl(data),
           version: data.version ?? null,
         };
       } catch {

--- a/docs/src/content/docs/tiles.md
+++ b/docs/src/content/docs/tiles.md
@@ -8,327 +8,279 @@ tableOfContents:
 
 Detailed information for all tiles and skills organized by domain.
 
-## CI/CD (12 skills)
+## CI/CD (6 tiles)
 
 CI/CD pipelines & deployment automation
 
-### azure-pipelines-validator
+### azure-pipelines-toolkit
 
-Validates, lints, and security-scans Azure DevOps Pipeline configurations (azure...
+Complete azure-pipelines toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [azure-pipelines-validator](/tekhne/skills/ci-cd/azure-pipelines/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
-
-### azure-pipelines-generator
-
-Generates production-ready Azure DevOps Pipelines (azure-pipelines.yml) followin...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/azure-pipelines-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [azure-pipelines-generator](/tekhne/skills/ci-cd/azure-pipelines/generator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 5 |
+| [generator](/tekhne/skills/ci-cd/azure-pipelines/generator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 5 |
+| [validator](/tekhne/skills/ci-cd/azure-pipelines/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
 
-### gitlab-ci-validator
+### gitlab-ci-toolkit
 
-Validates .gitlab-ci.yml syntax, detects security misconfigurations in job defin...
+Complete GitLab CI/CD toolkit with generation and validation capabilities for pipelines and configurations
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [gitlab-ci-validator](/tekhne/skills/ci-cd/gitlab-ci/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
-
-### gitlab-ci-generator
-
-Creates .gitlab-ci.yml files, configures pipeline stages, defines CI jobs and ru...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/gitlab-ci-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [gitlab-ci-generator](/tekhne/skills/ci-cd/gitlab-ci/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [generator](/tekhne/skills/ci-cd/gitlab-ci/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [validator](/tekhne/skills/ci-cd/gitlab-ci/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
 
-### fluentbit-validator
+### fluentbit-toolkit
 
-Validates syntax, checks pipeline tag connections, detects security misconfigura...
+Complete fluentbit toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [fluentbit-validator](/tekhne/skills/ci-cd/fluentbit/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 6 |
-
-### fluentbit-generator
-
-Generates, validates, and optimizes Fluent Bit configurations for production use...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/fluentbit-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [fluentbit-generator](/tekhne/skills/ci-cd/fluentbit/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [generator](/tekhne/skills/ci-cd/fluentbit/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [validator](/tekhne/skills/ci-cd/fluentbit/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 6 |
 
-### jenkinsfile-validator
+### jenkinsfile-toolkit
 
-Comprehensive toolkit for validating, linting, testing, and automating Jenkinsfi...
+Complete jenkinsfile toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [jenkinsfile-validator](/tekhne/skills/ci-cd/jenkinsfile/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
-
-### jenkinsfile-generator
-
-Generates Jenkinsfiles with stages, agents, parallel builds, post-build actions,...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/jenkinsfile-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [jenkinsfile-generator](/tekhne/skills/ci-cd/jenkinsfile/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [generator](/tekhne/skills/ci-cd/jenkinsfile/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [validator](/tekhne/skills/ci-cd/jenkinsfile/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
 
-### helm-validator
+### helm-toolkit
 
-Comprehensive toolkit for validating, linting, testing, and analyzing Helm chart...
+Complete helm toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [helm-validator](/tekhne/skills/ci-cd/helm/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
-
-### helm-generator
-
-Comprehensive toolkit for generating best practice Helm charts and resources fol...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/helm-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [helm-generator](/tekhne/skills/ci-cd/helm/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
+| [generator](/tekhne/skills/ci-cd/helm/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
+| [validator](/tekhne/skills/ci-cd/helm/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
 
-### github-actions-validator
+### github-actions-toolkit
 
-Comprehensive toolkit for validating, linting, and testing GitHub Actions workfl...
+Complete GitHub Actions toolkit with generation and validation capabilities for workflows, custom actions, and CI/CD configurations
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [github-actions-validator](/tekhne/skills/ci-cd/github-actions/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
-
-### github-actions-generator
-
-Generates production-ready GitHub Actions workflows, custom actions, and CI/CD c...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/github-actions-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [github-actions-generator](/tekhne/skills/ci-cd/github-actions/generator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 5 |
+| [generator](/tekhne/skills/ci-cd/github-actions/generator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 5 |
+| [validator](/tekhne/skills/ci-cd/github-actions/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
 
 ---
 
-## Infrastructure (16 skills)
+## Infrastructure (10 tiles)
 
 Infrastructure as Code
 
-### terraform-validator
+### terraform-toolkit
 
-Comprehensive toolkit for validating, linting, testing, and automating Terraform...
+Complete terraform toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [terraform-validator](/tekhne/skills/infrastructure/terraform/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
-
-### terraform-generator
-
-Generate Terraform modules, configure providers, define variables and outputs, s...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/terraform-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [terraform-generator](/tekhne/skills/infrastructure/terraform/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [generator](/tekhne/skills/infrastructure/terraform/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [validator](/tekhne/skills/infrastructure/terraform/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
 
-### dockerfile-validator
+### dockerfile-toolkit
 
-Validates, lints, and secures Dockerfiles by running syntax checking, detecting ...
+Complete dockerfile toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [dockerfile-validator](/tekhne/skills/infrastructure/dockerfile/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
-
-### dockerfile-generator
-
-Generates production-ready Dockerfiles with multi-stage builds, layer caching, s...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/dockerfile-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [dockerfile-generator](/tekhne/skills/infrastructure/dockerfile/generator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 8 |
+| [generator](/tekhne/skills/infrastructure/dockerfile/generator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 8 |
+| [validator](/tekhne/skills/infrastructure/dockerfile/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
 
-### terragrunt-validator
+### terragrunt-toolkit
 
-Comprehensive toolkit for validating, linting, testing, and automating Terragrun...
+Complete terragrunt toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [terragrunt-validator](/tekhne/skills/infrastructure/terragrunt/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
-
-### terragrunt-generator
-
-Comprehensive toolkit for generating best-practice Terragrunt configurations (HC...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/terragrunt-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [terragrunt-generator](/tekhne/skills/infrastructure/terragrunt/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 7 |
+| [generator](/tekhne/skills/infrastructure/terragrunt/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 7 |
+| [validator](/tekhne/skills/infrastructure/terragrunt/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
 
-### k8s-yaml-validator
+### k8s-toolkit
 
-Comprehensive toolkit for validating, linting, and testing Kubernetes YAML resou...
+Comprehensive Kubernetes toolkit for YAML generation, validation, and cluster debugging
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [k8s-yaml-validator](/tekhne/skills/infrastructure/k8s/yaml-validator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-06 | 5 |
-
-### k8s-yaml-generator
-
-Comprehensive toolkit for generating, validating, and managing Kubernetes YAML r...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/k8s-toolkit) | **Version:** 0.5.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [k8s-yaml-generator](/tekhne/skills/infrastructure/k8s/yaml-generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-06 | 5 |
+| [yaml-generator](/tekhne/skills/infrastructure/k8s/yaml-generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-06 | 5 |
+| [yaml-validator](/tekhne/skills/infrastructure/k8s/yaml-validator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-06 | 5 |
+| [debug](/tekhne/skills/infrastructure/k8s/debug/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-06 | 5 |
 
-### k8s-debug
+### cfn-toolkit
 
-Inspect pod logs, analyze resource quotas, trace network policies, check deploym...
+Complete CloudFormation toolkit with generation and validation capabilities
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/cfn-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [k8s-debug](/tekhne/skills/infrastructure/k8s/debug/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-06 | 5 |
+| [behavior-validator](/tekhne/skills/infrastructure/cfn/behavior-validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
+| [template-compare](/tekhne/skills/infrastructure/cfn/template-compare/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-03 | 5 |
 
 ### cfn-behavior-validator
 
-Creates test stacks, analyzes CloudFormation events, and compares actual vs docu...
+Creates test stacks, analyzes CloudFormation events, and compares actual vs documented update behavior to validate whether resource property changes trigger replacement or in-place updates. Use when: a user wants to test if a CFN property change causes resource replacement; when investigating stack update behavior or "Update requires" documentation accuracy; when validating whether a workaround (e.g. hash-based logical IDs) is actually necessary; when questioning UpdateRequiresReplacement behavior for immutable properties; when empirical evidence is needed before an architectural decision involving CDK or CloudFormation stack updates.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/cfn-behavior-validator) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [cfn-behavior-validator](/tekhne/skills/infrastructure/cfn/behavior-validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
+| [behavior-validator](/tekhne/skills/infrastructure/cfn/behavior-validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
 
 ### cfn-template-compare
 
-Compares deployed CloudFormation templates with locally synthesized CDK template...
+Compares deployed CloudFormation templates with locally synthesized CDK templates to detect drift, validate changes, and ensure consistency before deployment. Use when the user wants to compare CDK output with a deployed stack, check for infrastructure drift, run a pre-deployment validation, audit IAM or security changes, investigate a failing deployment, or perform a 'cdk diff'-style review. Triggered by phrases like 'compare templates', 'check for drift', 'cfn drift', 'stack comparison', 'infrastructure drift detection', 'safe to deploy', or 'what changed in my CDK stack'.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/cfn-template-compare) | **Version:** 0.2.2
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [cfn-template-compare](/tekhne/skills/infrastructure/cfn/template-compare/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-03 | 5 |
+| [template-compare](/tekhne/skills/infrastructure/cfn/template-compare/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-03 | 5 |
 
-### ansible-validator
+### ansible-toolkit
 
-Comprehensive toolkit for validating, linting, testing, and automating Ansible p...
+Complete ansible toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [ansible-validator](/tekhne/skills/infrastructure/ansible/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
-
-### ansible-generator
-
-Generates, validates, and refactors production-ready Ansible playbooks, roles, t...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/ansible-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [ansible-generator](/tekhne/skills/infrastructure/ansible/generator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
+| [generator](/tekhne/skills/infrastructure/ansible/generator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
+| [validator](/tekhne/skills/infrastructure/ansible/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
 
-### aws-investigation-toolkit-skills-aws-cloudwatch-url-builder
+### aws-investigation-toolkit
 
-Construct deep-link URLs for the AWS CloudWatch console — Logs Insights queries,...
+Toolkit for AWS incident investigation and console navigation — construct CloudWatch deep-link URLs (Logs Insights, Alarms, Metrics) and navigate the AWS Console via SSO or Playwright for screenshot capture.
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [aws-investigation-toolkit-skills-aws-cloudwatch-url-builder](/tekhne/skills/infrastructure/aws/investigation-toolkit/skills/aws-cloudwatch-url-builder/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 3 |
-
-### aws-investigation-toolkit-skills-aws-console-navigator
-
-Navigate the AWS Console via browser or Playwright MCP — SSO authentication, acc...
+**Published:** - | **Version:** 0.2.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [aws-investigation-toolkit-skills-aws-console-navigator](/tekhne/skills/infrastructure/aws/investigation-toolkit/skills/aws-console-navigator/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 3 |
+| [aws-cloudwatch-url-builder](/tekhne/skills/infrastructure/aws/investigation-toolkit/skills/aws-cloudwatch-url-builder/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 3 |
+| [aws-console-navigator](/tekhne/skills/infrastructure/aws/investigation-toolkit/skills/aws-console-navigator/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 3 |
 
-### aws-cdk-cdk-nag
+### cdk-nag
 
-Enforce AWS CDK security and compliance controls with cdk-nag. Use when adding r...
+Enforce AWS CDK security and compliance controls with cdk-nag. Use when adding rule packs, triaging findings, writing justified suppressions, integrating checks in CI/CD, or preventing insecure infrastructure patterns in CDK stacks.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/cdk-nag) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [aws-cdk-cdk-nag](/tekhne/skills/infrastructure/aws-cdk/cdk-nag/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 5 |
+| [cdk-nag](/tekhne/skills/infrastructure/aws-cdk/cdk-nag/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 5 |
 
 ---
 
-## Repository Management (5 skills)
+## Repository Management (5 tiles)
 
 Repository & workspace management
 
 ### nx-biome-integration
 
-Integrate Biome into Nx monorepos with deterministic setup, caching, migration f...
+Integrate Biome into Nx monorepos with deterministic setup, caching, migration from ESLint and Prettier, and plugin-based inferred tasks; use when adding Biome, replacing ESLint/Prettier, tuning cache inputs, or scaling lint and format workflows across projects.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/nx-biome-integration) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [nx-biome-integration](/tekhne/skills/repository-mgmt/nx/biome-integration/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 4 |
+| [biome-integration](/tekhne/skills/repository-mgmt/nx/biome-integration/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 4 |
 
 ### nx-bun-integration
 
-Integrate Bun runtime into Nx monorepos with deterministic plugin setup, executo...
+Integrate Bun runtime into Nx monorepos with deterministic plugin setup, executor configuration, migration from Node.js toolchains, and cache-aware build/test workflows; use when adding the nx-bun plugin, converting projects, or standardizing Bun targets across Nx workspaces.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/nx-bun-integration) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [nx-bun-integration](/tekhne/skills/repository-mgmt/nx/bun-integration/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 4 |
+| [bun-integration](/tekhne/skills/repository-mgmt/nx/bun-integration/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 4 |
 
 ### nx-workspace-patterns
 
-Configure and optimize Nx monorepo workspaces with deterministic project-graph s...
+Configure and optimize Nx monorepo workspaces with deterministic project-graph structure, boundary enforcement, cache-aware pipelines, and affected-command CI workflows; use when designing workspace architecture, tightening dependency rules, or reducing CI cost through Nx task orchestration.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/nx-workspace-patterns) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [nx-workspace-patterns](/tekhne/skills/repository-mgmt/nx/workspace-patterns/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 4 |
+| [workspace-patterns](/tekhne/skills/repository-mgmt/nx/workspace-patterns/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 4 |
+
+### nx-plugin-toolkit
+
+Complete Nx plugin development toolkit: create custom generators, executors, and extend Nx workspaces with reusable automation
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/nx-plugin-toolkit) | **Version:** 5.0.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [nx-plugin-authoring](/tekhne/skills/repository-mgmt/nx/nx-plugin-authoring/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-06 | 5 |
 
 ### nx-vite-integration
 
-Configure and integrate Vite in Nx monorepos for applications and libraries. Cov...
+Configure and integrate Vite in Nx monorepos for applications and libraries. Covers vite.config.ts setup, framework plugins, TypeScript path resolution, asset copying, library mode builds, and Vitest integration.  Use when: adding Vite to an Nx project, migrating from Webpack, configuring Vitest, fixing tsconfig path resolution, or setting up library mode.  Triggers: "add vite", "nx vite", "vite setup", "vite.config.ts", "vitest config", "library mode", "nxViteTsPaths", "copy assets", "vite path aliases", "migrate webpack to vite"  Examples: - user: "Add Vite to this Nx app" -> install plugin and configure vite.config.ts - user: "Vitest is failing in Nx" -> fix test config and cache/coverage paths - user: "Path aliases break in Vite" -> add nxViteTsPaths plugin - user: "Set up Vite for my Nx library" -> configure lib mode + dts + externals
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/nx-vite-integration) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [nx-vite-integration](/tekhne/skills/repository-mgmt/nx/vite-integration/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 4 |
-
-### nx-nx-plugin-authoring
-
-Create Nx plugins with custom generators and executors for TypeScript monorepos....
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [nx-nx-plugin-authoring](/tekhne/skills/repository-mgmt/nx/nx-plugin-authoring/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-06 | 5 |
+| [vite-integration](/tekhne/skills/repository-mgmt/nx/vite-integration/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 4 |
 
 ---
 
-## Development (10 skills)
+## Development (8 tiles)
 
 Development tooling
 
-### scripting-makefile-validator
+### makefile-toolkit
 
-Comprehensive toolkit for validating, linting, and optimizing Makefiles. Use whe...
+Complete makefile toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [scripting-makefile-validator](/tekhne/skills/development/scripting/makefile/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 5 |
-
-### scripting-makefile-generator
-
-Generate GNU Make build systems that define build targets, configure dependencie...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/makefile-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [scripting-makefile-generator](/tekhne/skills/development/scripting/makefile/generator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 5 |
+| [generator](/tekhne/skills/development/scripting/makefile/generator/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 5 |
+| [validator](/tekhne/skills/development/scripting/makefile/validator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 5 |
 
-### scripting-bash-script-validator
+### bash-script-toolkit
 
-Comprehensive toolkit for validating, linting, and optimizing bash and shell scr...
+Complete bash-script toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [scripting-bash-script-validator](/tekhne/skills/development/scripting/bash-script/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
-
-### scripting-bash-script-generator
-
-Creates bash scripts with argument parsing, error handling, logging, and input v...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/bash-script-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [scripting-bash-script-generator](/tekhne/skills/development/scripting/bash-script/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
+| [generator](/tekhne/skills/development/scripting/bash-script/generator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
+| [validator](/tekhne/skills/development/scripting/bash-script/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
 
 ### commanderjs
 
-Complete Commander.js CLI framework guidance covering command structure, options...
+Complete Commander.js CLI framework guidance covering command structure, options, arguments, subcommands, action handlers, version management, and TypeScript integration. Use when: building CLI tools, parsing command-line arguments, implementing subcommands, handling options/flags, creating interactive CLIs, or migrating from other CLI frameworks.  Keywords: Commander.js, CLI, command-line, arguments, options, flags, subcommands, action handlers, version, help text, TypeScript, yargs, meow, program, parseAsync, opts, args, variadic, required options, default values, custom help, error handling
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/commanderjs) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -336,7 +288,9 @@ Complete Commander.js CLI framework guidance covering command structure, options
 
 ### bun-development
 
-Complete Bun.js ecosystem guidance for runtime APIs, file I/O, package managemen...
+Complete Bun.js ecosystem guidance for runtime APIs, file I/O, package management, testing, SQLite, and security; use proactively when setting up Bun projects, replacing Node.js APIs with Bun-native APIs, writing bun test suites, implementing Bun.serve services, using bun:sqlite with prepared statements, configuring workspaces and lockfiles, hardening shell and SQL boundaries, or optimizing Bun performance and migration workflows.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/bun-development) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -344,7 +298,9 @@ Complete Bun.js ecosystem guidance for runtime APIs, file I/O, package managemen
 
 ### biome-complete
 
-Complete Biome toolchain guidance for real repository workflows. Use when users ...
+Complete Biome toolchain guidance for real repository workflows. Use when users ask to configure biome.json, run lint or format commands, migrate from ESLint or Prettier, tune rule severity, fix formatter drift, or replace mixed ESLint+Prettier pipelines with Biome-only workflows.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/biome-complete) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -352,77 +308,59 @@ Complete Biome toolchain guidance for real repository workflows. Use when users 
 
 ### typescript-advanced
 
-Comprehensive TypeScript guidance covering compiler configuration, advanced type...
+Comprehensive TypeScript guidance covering compiler configuration, advanced types, utility types, type guards, strict mode workflows, and documentation patterns; use when configuring tsconfig, designing complex generics, making illegal states unrepresentable, fixing type errors, or writing testable and maintainable type-safe APIs.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/typescript-advanced) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [typescript-advanced](/tekhne/skills/development/typescript-advanced/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 5 |
 
-### front-end-website-theme-porter
+### website-theme-porter
 
-Ports the visual identity of any live website into a React plus Tailwind CSS pro...
+Port the visual theme and styling from a live website to a React/Tailwind CSS project. Extracts colours, typography, spacing, and component styles — via agent-browser automation, manual inspection, curl/wget, or direct source reading — writes structured documentation and all artifacts under .context/artifacts/{website}/ with timestamps, applies findings as Tailwind v4 CSS tokens, then verifies by visually diffing the original site against the local or deployed version. Use when cloning a brand, replicating a design system, matching a reference site, migrating visual identity, copying a style guide, or porting a theme from any live URL into a React codebase.
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [front-end-website-theme-porter](/tekhne/skills/development/front-end/website-theme-porter/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 5 |
-
-### front-end-web-reference-sheet-generator
-
-Generate a project-specific web design reference sheet (docs/design/design-refer...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/website-theme-porter) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [front-end-web-reference-sheet-generator](/tekhne/skills/development/front-end/web-reference-sheet-generator/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
+| [website-theme-porter](/tekhne/skills/development/front-end/website-theme-porter/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 5 |
+
+### web-reference-sheet-generator
+
+Generate a comprehensive web design reference sheet (docs/design/design-reference.md) and its companion enforcement skill (.agents/skills/{project-slug}/SKILL.md) for any website project. Extracts tokens from CSS files, validates completeness against a JSON schema scratchpad, inspects existing components, and produces a 12-section living document covering colours, typography, spacing, layout, borders, shadows, motion, component patterns, accessibility, dark mode, and Figma sync notes. Use when starting a new project, onboarding a design system, creating a Figma reference sheet, porting design tokens, or auditing existing styles. Triggers on: "create a design reference", "generate a style guide", "document the design tokens", "make a brand reference sheet", "create design docs", "port design tokens", "audit existing styles".
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/web-reference-sheet-generator) | **Version:** 0.3.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [web-reference-sheet-generator](/tekhne/skills/development/front-end/web-reference-sheet-generator/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
 
 ---
 
-## Agentic Harness (23 skills)
+## Agentic Harness (10 tiles, 9 skills)
 
 Agent framework configurations
 
-### opencode-toolkit-design-agents
+### opencode-toolkit
 
-Create and refine OpenCode agents via guided Q&A. Use when creating an agent fil...
+Complete toolkit for configuring and extending OpenCode: agent creation, custom slash commands, configuration management, plugin development, and SDK usage.
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [opencode-toolkit-design-agents](/tekhne/skills/agentic-harness/opencode-toolkit/design-agents/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
-
-### opencode-toolkit-build-plugins
-
-Create OpenCode plugins using the opencode-ai/plugin SDK. Use when user wants to...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/opencode-toolkit) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [opencode-toolkit-build-plugins](/tekhne/skills/agentic-harness/opencode-toolkit/build-plugins/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
-
-### opencode-toolkit-configure
-
-Configure OpenCode via opencode.json and AGENTS.md with deterministic provider s...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [opencode-toolkit-configure](/tekhne/skills/agentic-harness/opencode-toolkit/configure/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
-
-### opencode-toolkit-build-tool
-
-Build custom tools and plugins using the OpenCode SDK packages. Use when creatin...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [opencode-toolkit-build-tool](/tekhne/skills/agentic-harness/opencode-toolkit/build-tool/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
-
-### opencode-toolkit-design-commands
-
-Create custom /slash commands for repetitive tasks in OpenCode. Use when user wa...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [opencode-toolkit-design-commands](/tekhne/skills/agentic-harness/opencode-toolkit/design-commands/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
+| [design-agents](/tekhne/skills/agentic-harness/opencode-toolkit/design-agents/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
+| [design-commands](/tekhne/skills/agentic-harness/opencode-toolkit/design-commands/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
+| [configure](/tekhne/skills/agentic-harness/opencode-toolkit/configure/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
+| [build-plugins](/tekhne/skills/agentic-harness/opencode-toolkit/build-plugins/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
+| [build-tool](/tekhne/skills/agentic-harness/opencode-toolkit/build-tool/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
 
 ### socratic-method
 
-Refine vague, complex, or high-stakes prompts through Socratic dialogue — surfac...
+Refine vague or high-stakes prompts through Socratic questioning — surfaces hidden assumptions, probes reasoning, and iterates toward clarity before committing to a response
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/socratic-method) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -430,11 +368,83 @@ Refine vague, complex, or high-stakes prompts through Socratic dialogue — surf
 
 ### pin
 
-Pin session decisions, questions, objections, scope constraints, and corrections...
+Pin session decisions, questions, constraints, and corrections to a persistent board that survives context compaction.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/pin) | **Version:** 0.2.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [pin](/tekhne/skills/agentic-harness/pin/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-11 | 5 |
+
+### skill-quality-auditor
+
+Audit and improve skill collections with a 9-dimension scoring framework (Knowledge Delta, Mindset, Anti-Patterns, Specification Compliance, Progressive Disclosure, Freedom Calibration, Pattern Recognition, Practical Usability, Eval Validation), duplication detection, remediation planning, baseline comparison, and CI quality gates; use when evaluating skill quality, generating remediation plans, detecting duplicates, validating artifact conventions, or enforcing publication thresholds.
+
+**Published:** - | **Version:** 0.2.1
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [skill-quality-auditor](/tekhne/skills/agentic-harness/skill-quality-auditor/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-04-27 | 5 |
+
+### create-context
+
+Bootstrap project context from .context/session/in/ with manifest-driven organisation and token-aware file sizing.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/create-context) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [create-context](/tekhne/skills/agentic-harness/create-context/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
+
+### load-context
+
+Resume a previous session from .context/session/CONTEXT-llm.md with optional full resource expansion.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/load-context) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [load-context](/tekhne/skills/agentic-harness/load-context/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
+
+### agents-md
+
+Create and maintain AGENTS.md documentation for simple projects and complex monorepos with deterministic discovery, scoped instruction files, and low-token navigation patterns; use when generating AGENTS.md, updating agent docs, or standardizing AI-facing project guidance.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/agents-md) | **Version:** 0.3.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [agents-md](/tekhne/skills/agentic-harness/agents-md/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-27 | 5 |
+
+### save-context
+
+Checkpoint the current session to .context/session/CONTEXT-llm.md with a structured LLM-optimised summary.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/save-context) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [save-context](/tekhne/skills/agentic-harness/save-context/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
+
+### tessl-publish-public
+
+Ensure Tessl plugins meet all requirements for public registry publishing with comprehensive validation, quality gates, and evaluation scenarios. Use when preparing skills for public Tessl release, validating plugin.json manifest, creating evaluation scenarios, enforcing quality thresholds, or checking agent-agnostic compliance. Keywords: tessl, plugin, publishing, public-registry, validation, quality-gates, plugin.json, eval-scenarios, skill-publishing
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/tessl-publish-public) | **Version:** 1.4.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [publish-public](/tekhne/skills/agentic-harness/tessl/publish-public/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 9 |
+
+### pick-model
+
+Recommend the optimal Claude model (Haiku/Sonnet/Opus) for a task using a decision matrix with complexity escalators.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/pick-model) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [pick-model](/tekhne/skills/agentic-harness/pick-model/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
 
 ### professional-honesty
 
@@ -460,22 +470,6 @@ Propose or apply consolidation of episodic memories into semantic ones, combinin
 | --- | --- | --- | --- |
 | [vault-consolidate](/tekhne/skills/agentic-harness/vault-consolidate/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 5 |
 
-### skill-quality-auditor
-
-Evaluate, score, and remediate agent skill collections using a 9-dimension quali...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [skill-quality-auditor](/tekhne/skills/agentic-harness/skill-quality-auditor/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-04-27 | 5 |
-
-### create-context
-
-Create baseline context from .context/session/in/ folder with manifest-driven or...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [create-context](/tekhne/skills/agentic-harness/create-context/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
-
 ### cache-audit
 
 Audit your Claude Code setup against prompt caching best practices. Checks order...
@@ -492,14 +486,6 @@ Conduct a structured, one-question-at-a-time interview to explore a specific top
 | --- | --- | --- | --- |
 | [guided-interview](/tekhne/skills/agentic-harness/guided-interview/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
 
-### load-context
-
-Resume session from CONTEXT-llm.md. Use when resuming work, loading saved contex...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [load-context](/tekhne/skills/agentic-harness/load-context/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
-
 ### session-reflection
 
 Conduct a two-question session-end reflection to catch blind spots and under-inv...
@@ -507,14 +493,6 @@ Conduct a two-question session-end reflection to catch blind spots and under-inv
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [session-reflection](/tekhne/skills/agentic-harness/session-reflection/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
-
-### agents-md
-
-Create and maintain AGENTS.md documentation for simple projects, complex monorep...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [agents-md](/tekhne/skills/agentic-harness/agents-md/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-27 | 5 |
 
 ### vault-fetch
 
@@ -532,30 +510,6 @@ Captures an important insight, decision, constraint, pattern, or discovery to pe
 | --- | --- | --- | --- |
 | [vault-capture](/tekhne/skills/agentic-harness/vault-capture/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 5 |
 
-### save-context
-
-Save session to CONTEXT-llm.md with conversation summary. Use when saving work, ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [save-context](/tekhne/skills/agentic-harness/save-context/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
-
-### tessl-publish-public
-
-Ensure Tessl plugins meet all requirements for public registry publication with ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [tessl-publish-public](/tekhne/skills/agentic-harness/tessl/publish-public/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 9 |
-
-### pick-model
-
-Recommend optimal Claude model (haiku/sonnet/opus) for a task. Use when user ask...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [pick-model](/tekhne/skills/agentic-harness/pick-model/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
-
 ### rules-management
 
 Manage project-level agent behavioural rules recorded in a single rules file. Us...
@@ -566,13 +520,15 @@ Manage project-level agent behavioural rules recorded in a single rules file. Us
 
 ---
 
-## Testing (3 skills)
+## Testing (3 tiles)
 
 Testing methodologies & quality
 
 ### test-driven-development
 
-Guides TDD (test-driven development) with red-green-refactor workflows, test-fir...
+Master Test-Driven Development with deterministic red-green-refactor workflows, test-first feature delivery, bug reproduction through failing tests, behavior-focused assertions, and refactoring safety; use when implementing new functions, changing APIs, fixing regressions, or restructuring code under test.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/test-driven-development) | **Version:** 0.5.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -580,7 +536,9 @@ Guides TDD (test-driven development) with red-green-refactor workflows, test-fir
 
 ### bdd-testing
 
-Write and maintain Behavior-Driven Development tests with Gherkin and Cucumber. ...
+Write and maintain Behavior-Driven Development tests with Gherkin and Cucumber. Use when defining acceptance scenarios, writing feature files, implementing step definitions, running Three Amigos sessions, or diagnosing BDD test quality issues. Keywords: bdd, gherkin, cucumber, given when then, feature files, step definitions, acceptance criteria, three amigos, example mapping.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/bdd-testing) | **Version:** 0.2.1
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -588,7 +546,9 @@ Write and maintain Behavior-Driven Development tests with Gherkin and Cucumber. 
 
 ### ui-debug-workflow
 
-Debug UI changes with a repeatable evidence-first workflow. Use when validating ...
+Debug UI changes with a repeatable evidence-first workflow. Use when validating visual regressions, reproducing frontend bugs, comparing baseline vs changed behavior, collecting screenshots/DOM/logs, or producing stakeholder-ready UI debug reports. Keywords: ui bug, visual regression, browser devtools, playwright, screenshot evidence, dom snapshot, frontend debugging.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/ui-debug-workflow) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -596,41 +556,72 @@ Debug UI changes with a repeatable evidence-first workflow. Use when validating 
 
 ---
 
-## Software Engineering (20 skills)
+## Software Engineering (6 tiles, 11 skills)
 
 Software engineering principles
 
-### design-principles-testable-design
+### design-principles
 
-Design code for testability using boundary isolation, dependency injection, and ...
+Strategic architecture, tactical design, and testable code principles (SOLID, Clean Architecture, Design Patterns, Testable Design)
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [design-principles-testable-design](/tekhne/skills/software-engineering/design-principles/testable-design/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-04 | 5 |
-
-### design-principles-solid-principles
-
-Apply SOLID principles (SRP, OCP, LSP, ISP, DIP) for tactical class design, meth...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/design-principles) | **Version:** 1.4.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [design-principles-solid-principles](/tekhne/skills/software-engineering/design-principles/solid-principles/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-04 | 5 |
+| [solid-principles](/tekhne/skills/software-engineering/design-principles/solid-principles/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-04 | 5 |
+| [clean-architecture](/tekhne/skills/software-engineering/design-principles/clean-architecture/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-04 | 5 |
+| [design-patterns](/tekhne/skills/software-engineering/design-principles/design-patterns/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-04 | 5 |
+| [testable-design](/tekhne/skills/software-engineering/design-principles/testable-design/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-04 | 5 |
 
-### design-principles-design-patterns
+### troubleshoot
 
-Select and apply structural design patterns (Strategy, Factory, Adapter, Observe...
+Search-first troubleshooting with a diagnostic phase — use when an error, bug, or unexpected behaviour is reported.
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [design-principles-design-patterns](/tekhne/skills/software-engineering/design-principles/design-patterns/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-04 | 5 |
-
-### design-principles-clean-architecture
-
-Apply Clean Architecture principles to define layer boundaries, identify depende...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/troubleshoot) | **Version:** 0.2.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [design-principles-clean-architecture](/tekhne/skills/software-engineering/design-principles/clean-architecture/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-03-04 | 5 |
+| [troubleshoot](/tekhne/skills/software-engineering/troubleshoot/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
+
+### frame-problem
+
+Classify a problem using Cynefin triangulation before acting — routes to the right skill chain (investigate, brainstorm, probe, troubleshoot).
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/frame-problem) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [frame-problem](/tekhne/skills/software-engineering/frame-problem/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
+
+### bridge
+
+Capture cross-project connections on the fly and persist them as structured YAML in a bridges directory.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/bridge) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [bridge](/tekhne/skills/software-engineering/bridge/skill/) | <span class="skill-badge skill-badge--f">F</span> | 2026-04-11 | 5 |
+
+### challenge
+
+Challenge AI output with structured devil's-advocate protocols: anchor, verify, framing, and deep sub-commands.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/challenge) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [challenge](/tekhne/skills/software-engineering/challenge/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-04-11 | 5 |
+
+### probe
+
+Run a safe-to-fail experiment for Complex domain problems where cause-and-effect is only visible in retrospect.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/probe) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [probe](/tekhne/skills/software-engineering/probe/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-11 | 5 |
 
 ### design-debate
 
@@ -656,22 +647,6 @@ Review a saved standards document via a one-standard-at-a-time interview. Prompt
 | --- | --- | --- | --- |
 | [why](/tekhne/skills/software-engineering/why/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-08-22 | 5 |
 
-### troubleshoot
-
-Use when user reports an error, bug, or something not working. Search-first trou...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [troubleshoot](/tekhne/skills/software-engineering/troubleshoot/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
-
-### frame-problem
-
-Sense-making before action. Classify problem using Cynefin triangulation (3 test...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [frame-problem](/tekhne/skills/software-engineering/frame-problem/skill/) | <span class="skill-badge skill-badge--d">D</span> | 2026-04-11 | 5 |
-
 ### how
 
 -
@@ -695,14 +670,6 @@ Use when designing solutions, adding features, or refactoring by applying KISS, 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [blast-radius](/tekhne/skills/software-engineering/blast-radius/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-08-22 | 5 |
-
-### bridge
-
-Capture cross-project connections on the fly. Use when you notice a shared patte...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [bridge](/tekhne/skills/software-engineering/bridge/skill/) | <span class="skill-badge skill-badge--f">F</span> | 2026-04-11 | 5 |
 
 ### fp-immutability
 
@@ -728,14 +695,6 @@ Write pure functions and avoid side effects for predictable, testable code
 | --- | --- | --- | --- |
 | [fp-pure-functions](/tekhne/skills/software-engineering/fp-pure-functions/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
-### challenge
-
-Challenge, push back, play devil's advocate on AI output. Use when: challenge th...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [challenge](/tekhne/skills/software-engineering/challenge/skill/) | <span class="skill-badge skill-badge--c">C</span> | 2026-04-11 | 5 |
-
 ### fp-higher-order-functions
 
 Master higher-order functions, map/filter/reduce patterns for expressive data tr...
@@ -743,14 +702,6 @@ Master higher-order functions, map/filter/reduce patterns for expressive data tr
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [fp-higher-order-functions](/tekhne/skills/software-engineering/fp-higher-order-functions/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
-
-### probe
-
-Safe-to-fail experiment for Complex domain problems where cause-effect is only v...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [probe](/tekhne/skills/software-engineering/probe/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-11 | 5 |
 
 ### standards-to-tooling
 
@@ -762,127 +713,152 @@ Translates project coding standards into concrete linting and formatting tool co
 
 ---
 
-## Observability (3 skills)
+## Observability (2 tiles)
 
 Monitoring, logging & debugging
 
 ### logql-generator
 
-Generate label matchers, line filters, log aggregations, and metric queries in L...
+Generate label matchers, line filters, log aggregations, and metric queries in LogQL (Loki Query Language) following current standards and conventions. Use this skill when creating new LogQL queries, implementing log analysis dashboards, alerting rules, or troubleshooting with Loki.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/logql-generator) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [logql-generator](/tekhne/skills/observability/logql-generator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 5 |
 
-### promql-validator
+### promql-toolkit
 
-Comprehensive toolkit for validating, optimizing, and understanding Prometheus Q...
+Complete PromQL toolkit with generation and validation capabilities
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [promql-validator](/tekhne/skills/observability/promql/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 7 |
-
-### promql-generator
-
-Generate PromQL queries for calculating error rates, aggregating metrics across ...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/promql-toolkit) | **Version:** 5.0.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [promql-generator](/tekhne/skills/observability/promql/generator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
+| [generator](/tekhne/skills/observability/promql/generator/skill/) | <span class="skill-badge skill-badge--c-plus">C+</span> | 2026-03-02 | 8 |
+| [validator](/tekhne/skills/observability/promql/validator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 7 |
 
 ---
 
-## Documentation (30 skills)
+## Documentation (10 tiles, 4 skills)
 
 Writing & communication
 
-### research-sci-hub-search
+### research
 
-Search and download academic papers through Sci-Hub by DOI, title, or keyword. S...
+Research toolkit for triaging academic papers and GitHub projects. Triage papers and tools, reproduce benchmark claims, search Google Scholar, Semantic Scholar, PubMed, or Sci-Hub, extract structured data from scientific PDFs, evaluate scholarly work, generate publication-quality scientific diagrams, and query Google NotebookLM notebooks for source-grounded answers.
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [research-sci-hub-search](/tekhne/skills/documentation/research/sci-hub-search/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
-
-### research-scientific-schematics
-
-Create publication-quality scientific diagrams using Claude AI with smart iterat...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/research) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [research-scientific-schematics](/tekhne/skills/documentation/research/scientific-schematics/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
+| [triage-paper](/tekhne/skills/documentation/research/triage-paper/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
+| [triage-tool](/tekhne/skills/documentation/research/triage-tool/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
+| [reproduce-benchmark](/tekhne/skills/documentation/research/reproduce-benchmark/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
+| [google-scholar-search](/tekhne/skills/documentation/research/google-scholar-search/skill/) | <span class="skill-badge skill-badge--a-plus">A+</span> | 2026-04-09 | 3 |
+| [semantic-scholar-search](/tekhne/skills/documentation/research/semantic-scholar-search/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
+| [pubmed-search](/tekhne/skills/documentation/research/pubmed-search/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
+| [sci-hub-search](/tekhne/skills/documentation/research/sci-hub-search/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
+| [sci-data-extractor](/tekhne/skills/documentation/research/sci-data-extractor/skill/) | <span class="skill-badge skill-badge--a-plus">A+</span> | 2026-04-10 | 3 |
+| [scholar-evaluation](/tekhne/skills/documentation/research/scholar-evaluation/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
+| [scientific-schematics](/tekhne/skills/documentation/research/scientific-schematics/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
+| [notebooklm](/tekhne/skills/documentation/research/notebooklm/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
 
-### research-triage-tool
+### markdown-authoring
 
-Triage a tool or library into a structured reference summary for the research re...
+Author high-quality Markdown documentation with deterministic structure, lint compliance, and CI integration. Use when writing README files, creating docs pages, fixing markdownlint failures, defining style rules, or wiring markdown checks into pre-commit and pipelines. Keywords: markdown, markdownlint, readme, docs, headings, lists, code fences, links, images, lint config, ci, documentation style.
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [research-triage-tool](/tekhne/skills/documentation/research/triage-tool/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
-
-### research-pubmed-search
-
-Search and analyze biomedical literature from PubMed using the free E-utilities ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [research-pubmed-search](/tekhne/skills/documentation/research/pubmed-search/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
-
-### research-google-scholar-search
-
-Search Google Scholar for academic papers and author profiles. Use when discover...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/markdown-authoring) | **Version:** 0.5.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [research-google-scholar-search](/tekhne/skills/documentation/research/google-scholar-search/skill/) | <span class="skill-badge skill-badge--a-plus">A+</span> | 2026-04-09 | 3 |
+| [markdown-authoring](/tekhne/skills/documentation/markdown-authoring/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-07-01 | 7 |
 
-### research-sci-data-extractor
+### plain-english
 
-Extract structured data from scientific literature PDFs using AI-powered OCR and...
+Write technical content in plain English for non-technical stakeholders by translating jargon into business language, surfacing decisions and impact early, and producing actionable recommendations with clear ownership and timeline.
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [research-sci-data-extractor](/tekhne/skills/documentation/research/sci-data-extractor/skill/) | <span class="skill-badge skill-badge--a-plus">A+</span> | 2026-04-10 | 3 |
-
-### research-notebooklm
-
-Query Google NotebookLM notebooks directly for source-grounded, citation-backed ...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/plain-english) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [research-notebooklm](/tekhne/skills/documentation/research/notebooklm/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
+| [plain-english](/tekhne/skills/documentation/plain-english/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-11 | 8 |
 
-### research-triage-paper
+### proof-of-work
 
-Triage an academic paper into a structured reference summary for the research re...
+Instructs agents to document findings as proof-of-work artifacts: screenshots via agent-browser or playwright-mcp, captured logs, and script output
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [research-triage-paper](/tekhne/skills/documentation/research/triage-paper/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 3 |
-
-### research-reproduce-benchmark
-
-Reproduce and verify the benchmark claims of a tool or paper already triaged in ...
+**Published:** - | **Version:** 0.2.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [research-reproduce-benchmark](/tekhne/skills/documentation/research/reproduce-benchmark/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
+| [proof-of-work](/tekhne/skills/documentation/proof-of-work/skills/proof-of-work/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 5 |
 
-### research-scholar-evaluation
+### adr-creator
 
-Systematically evaluate scholarly and research work using the ScholarEval framew...
+Creates, lists, and supersedes Architecture Decision Records with the adr CLI, following the house ADR template; use when recording an architectural decision, writing an ADR, documenting a technical choice, superseding a prior decision, numbering a new record, or bootstrapping an ADR log under docs/adr.
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [research-scholar-evaluation](/tekhne/skills/documentation/research/scholar-evaluation/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
-
-### research-semantic-scholar-search
-
-Search Semantic Scholar for academic papers, fetch paper details by ID or DOI, r...
+**Published:** - | **Version:** 0.1.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [research-semantic-scholar-search](/tekhne/skills/documentation/research/semantic-scholar-search/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-10 | 3 |
+| [adr-creator](/tekhne/skills/documentation/adr-creator/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
+
+### astro-starlight
+
+Skills for setting up and customizing Astro Starlight documentation sites, covering project setup, custom theming, and component overrides.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/astro-starlight) | **Version:** 0.3.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [starlight-base](/tekhne/skills/documentation/astro-starlight/skills/starlight-base/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-17 | 6 |
+| [starlight-theme](/tekhne/skills/documentation/astro-starlight/skills/starlight-theme/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-17 | 6 |
+| [starlight-custom-component](/tekhne/skills/documentation/astro-starlight/skills/starlight-custom-component/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-17 | 7 |
+
+### journal-entry-creator
+
+Create structured journal entries with YAML frontmatter, template-based sections, and compliance validation. Use when user asks to 'create journal entry', 'new journal', 'document [topic]', 'journal about [topic]', or needs to create timestamped .md files in YYYY/MM/ directories. Supports six entry types: general journal entries, troubleshooting sessions, learning notes, article summaries, ticket-refinement sessions, and ticket-kickoff sessions. Keywords: journal, documentation, troubleshooting, learning, article-summary, ticket-refinement, ticket-kickoff, YAML frontmatter, template schemas, validation.
+
+**Published:** - | **Version:** 0.5.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [journal-entry-creator](/tekhne/skills/documentation/journal-entry-creator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-03 | 5 |
+
+### journal-entry-import
+
+Reconstructs journal entries from external systems: bulk-imports a historical work log from a legacy source system, enriches ticket references with self-contained detail entries reconstructed from an issue tracker, and annotates links to systems that have since moved. Use when asked to import an old journal, migrate a log into the journal format, turn ticket mentions into entries, or point old links at a new host. Produces entries compatible with journal-entry-creator's frontmatter and tag taxonomy.
+
+**Published:** - | **Version:** 0.1.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [journal-entry-import](/tekhne/skills/documentation/journal-entry-import/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 5 |
+
+### conventional-commits
+
+Skill for creating structured, semantic commit messages following the Conventional Commits specification
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/conventional-commits) | **Version:** 0.3.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [conventional-commits](/tekhne/skills/documentation/conventional-commits/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 5 |
+
+### obsidian-toolkit
+
+Skills for working with Obsidian vaults and related formats: Obsidian Flavored Markdown, JSON Canvas files, the Obsidian CLI, and Defuddle for clean web content extraction.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/obsidian-toolkit) | **Version:** 0.3.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [obsidian-markdown](/tekhne/skills/documentation/obsidian/obsidian-markdown/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 4 |
+| [obsidian-cli](/tekhne/skills/documentation/obsidian/obsidian-cli/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 4 |
+| [json-canvas](/tekhne/skills/documentation/obsidian/json-canvas/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 4 |
+| [defuddle](/tekhne/skills/documentation/obsidian/defuddle/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 4 |
+| [obsidian-bases](/tekhne/skills/documentation/obsidian/obsidian-bases/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 5 |
 
 ### professional-communication
 
@@ -900,14 +876,6 @@ Comprehensive guide for creating software diagrams using Mermaid syntax. Use whe
 | --- | --- | --- | --- |
 | [mermaid-diagrams](/tekhne/skills/documentation/mermaid-diagrams/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
-### markdown-authoring
-
-Author high-quality Markdown documentation with deterministic structure, lint co...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [markdown-authoring](/tekhne/skills/documentation/markdown-authoring/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-07-01 | 7 |
-
 ### sop-structure
 
 Use when structuring Standard Operating Procedures with proper sections, organiz...
@@ -915,118 +883,6 @@ Use when structuring Standard Operating Procedures with proper sections, organiz
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [sop-structure](/tekhne/skills/documentation/sop-structure/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
-
-### plain-english
-
-Translates technical content into plain English for non-technical stakeholders b...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [plain-english](/tekhne/skills/documentation/plain-english/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-11 | 8 |
-
-### proof-of-work-skills-proof-of-work
-
-Captures and documents agent findings as verifiable artifacts — screenshots via ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [proof-of-work-skills-proof-of-work](/tekhne/skills/documentation/proof-of-work/skills/proof-of-work/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 5 |
-
-### adr-creator
-
-Creates, lists, and supersedes Architecture Decision Records with the adr CLI, f...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [adr-creator](/tekhne/skills/documentation/adr-creator/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
-
-### astro-starlight-skills-starlight-theme
-
-Create and apply custom themes to an Astro Starlight documentation site. Use whe...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [astro-starlight-skills-starlight-theme](/tekhne/skills/documentation/astro-starlight/skills/starlight-theme/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-17 | 6 |
-
-### astro-starlight-skills-starlight-custom-component
-
-Create and override Astro Starlight UI components. Use when replacing or extendi...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [astro-starlight-skills-starlight-custom-component](/tekhne/skills/documentation/astro-starlight/skills/starlight-custom-component/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-17 | 7 |
-
-### astro-starlight-skills-starlight-base
-
-Set up a new Astro Starlight documentation site from scratch. Use when creating ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [astro-starlight-skills-starlight-base](/tekhne/skills/documentation/astro-starlight/skills/starlight-base/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-03-17 | 6 |
-
-### journal-entry-creator
-
--
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [journal-entry-creator](/tekhne/skills/documentation/journal-entry-creator/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-03 | 5 |
-
-### journal-entry-import
-
--
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [journal-entry-import](/tekhne/skills/documentation/journal-entry-import/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 5 |
-
-### conventional-commits
-
-Generates and formats git commit messages following the Conventional Commits spe...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [conventional-commits](/tekhne/skills/documentation/conventional-commits/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-08 | 5 |
-
-### obsidian-defuddle
-
-Extract clean markdown content from web pages using Defuddle CLI, removing clutt...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [obsidian-defuddle](/tekhne/skills/documentation/obsidian/defuddle/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 4 |
-
-### obsidian-obsidian-markdown
-
-Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, pro...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [obsidian-obsidian-markdown](/tekhne/skills/documentation/obsidian/obsidian-markdown/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 4 |
-
-### obsidian-obsidian-bases
-
-Create and edit Obsidian Bases (.base files) with views, filters, formulas, and ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [obsidian-obsidian-bases](/tekhne/skills/documentation/obsidian/obsidian-bases/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 5 |
-
-### obsidian-obsidian-cli
-
-Interact with Obsidian vaults using the Obsidian CLI to read, create, search, an...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [obsidian-obsidian-cli](/tekhne/skills/documentation/obsidian/obsidian-cli/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 4 |
-
-### obsidian-json-canvas
-
-Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and conne...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [obsidian-json-canvas](/tekhne/skills/documentation/obsidian/json-canvas/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-16 | 4 |
 
 ### humanizer
 
@@ -1038,13 +894,15 @@ Remove signs of AI-generated writing from text. Use when editing or reviewing te
 
 ---
 
-## Package Management (1 skill)
+## Package Management (1 tile)
 
 Package & version management
 
 ### mise-complete
 
-Configure and operate Mise for deterministic developer environments. Use when in...
+Configure and operate Mise for deterministic developer environments. Use when installing runtime/tool versions, defining reusable tasks, managing layered environment variables, migrating from asdf/nvm/pyenv, or debugging mise.toml behavior in CI and local shells. Keywords: mise, mise.toml, tool versions, tasks, env, asdf migration, setup automation, dev environment.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/mise-complete) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -1052,9 +910,54 @@ Configure and operate Mise for deterministic developer environments. Use when in
 
 ---
 
-## Project Management (17 skills)
+## Project Management (4 tiles, 8 skills)
 
 Planning & organization
+
+### planning-toolkit
+
+End-to-end project planning toolkit: converts requirements into structured phased implementation plans, groups phases into dependency-ordered waves for parallel subagent execution, executes wave plans by spawning parallel agents with correct model tiers, and decomposes large branches into focused pull requests.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/planning-toolkit) | **Version:** 1.1.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [implementation-planner](/tekhne/skills/project-mgmt/planning-toolkit/implementation-planner/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-06 | 5 |
+| [wave-execution-planner](/tekhne/skills/project-mgmt/planning-toolkit/wave-execution-planner/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 7 |
+| [wave-executor](/tekhne/skills/project-mgmt/planning-toolkit/wave-executor/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
+| [pr-stacker](/tekhne/skills/project-mgmt/planning-toolkit/pr-stacker/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 5 |
+
+### context-index
+
+Regenerates .context/index.yaml from the YAML frontmatter across every .context/**/*.md file, grouped by typology (findings, plans, guides, follow-ups, merge-requests, tickets, decisions, notes, research), and validates that each file carries the required frontmatter fields; use when the index is stale, context files were added or removed, or a pre-commit gate blocks on missing frontmatter.
+
+**Published:** - | **Version:** 0.1.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [context-index](/tekhne/skills/project-mgmt/context-index/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
+
+### create-context-file
+
+Create context files under .context/<typology>/ (findings, plans, guides, follow-ups, merge-requests, tickets, ...) with date-prefixed YYYY-MM-DD-slug.md filenames and YAML frontmatter
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/create-context-file) | **Version:** 1.0.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [create-context-file](/tekhne/skills/project-mgmt/create-context-file/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-03 | 5 |
+
+### issue-tracker-toolkit
+
+Toolkit for writing, refining, and prioritizing tickets on issue-tracking systems (Jira and equivalents). Covers three concerns: writing clear acceptance criteria for user stories; applying MoSCoW prioritization to requirements and backlogs; and readying sparse backlog tickets for refinement by gathering incident context, applying a YAML template, and generating a validated structured document.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/issue-tracker-toolkit) | **Version:** 0.2.0
+
+| Skill | Rating | Audit | Evals |
+| --- | --- | --- | --- |
+| [acceptance-criteria](/tekhne/skills/project-mgmt/issue-tracker-toolkit/acceptance-criteria/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 8 |
+| [moscow-prioritization](/tekhne/skills/project-mgmt/issue-tracker-toolkit/moscow-prioritization/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
+| [jira-ticket-readyup](/tekhne/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
 
 ### risk-register
 
@@ -1080,46 +983,6 @@ Maintain docs/TECH_DEBT.md, the living list of code-level cleanup that isn't a r
 | --- | --- | --- | --- |
 | [tech-debt](/tekhne/skills/project-mgmt/tech-debt/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
 
-### planning-toolkit-wave-executor
-
-Execute a wave-based plan by spawning parallel agents per wave, enforcing merge ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [planning-toolkit-wave-executor](/tekhne/skills/project-mgmt/planning-toolkit/wave-executor/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
-
-### planning-toolkit-implementation-planner
-
-Converts a PRD or requirements document into a structured, phased implementation...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [planning-toolkit-implementation-planner](/tekhne/skills/project-mgmt/planning-toolkit/implementation-planner/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-04-06 | 5 |
-
-### planning-toolkit-wave-execution-planner
-
-Groups plan phases and tasks into dependency-ordered waves for parallel subagent...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [planning-toolkit-wave-execution-planner](/tekhne/skills/project-mgmt/planning-toolkit/wave-execution-planner/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 7 |
-
-### planning-toolkit-pr-stacker
-
-Splits a large feature branch into smaller, focused pull requests using stacked ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [planning-toolkit-pr-stacker](/tekhne/skills/project-mgmt/planning-toolkit/pr-stacker/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-06 | 5 |
-
-### context-index
-
-Regenerates the project's context index (index.yaml) from the YAML frontmatter a...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [context-index](/tekhne/skills/project-mgmt/context-index/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
-
 ### tech-evaluation
 
 Investigate a candidate library, dependency, or file format against a fixed ques...
@@ -1135,38 +998,6 @@ Create `.context/plans/*.md` files with standard YAML frontmatter, phases/tasks/
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [plan-create](/tekhne/skills/project-mgmt/plan-create/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 4 |
-
-### create-context-file
-
-Creates a structured, date-stamped context file filed by typology (findings, pla...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [create-context-file](/tekhne/skills/project-mgmt/create-context-file/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-03 | 5 |
-
-### issue-tracker-toolkit-jira-ticket-readyup
-
-Ready up Jira tickets for refinement, including brand-new not-yet-keyed backlog ...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [issue-tracker-toolkit-jira-ticket-readyup](/tekhne/skills/project-mgmt/issue-tracker-toolkit/jira-ticket-readyup/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
-
-### issue-tracker-toolkit-acceptance-criteria
-
-Write clear, testable acceptance criteria for user stories and feature delivery;...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [issue-tracker-toolkit-acceptance-criteria](/tekhne/skills/project-mgmt/issue-tracker-toolkit/acceptance-criteria/skill/) | <span class="skill-badge skill-badge--b-plus">B+</span> | 2026-03-02 | 8 |
-
-### issue-tracker-toolkit-moscow-prioritization
-
-MoSCoW prioritization: categorize requirements into Must Should Could Won't tier...
-
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [issue-tracker-toolkit-moscow-prioritization](/tekhne/skills/project-mgmt/issue-tracker-toolkit/moscow-prioritization/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 8 |
 
 ### nasa-pm-lessons
 
@@ -1194,13 +1025,15 @@ Read-only status check across the follow-up backlog: lists every ACTIVE follow-u
 
 ---
 
-## Specialized (7 skills)
+## Specialized (6 tiles)
 
 Domain-specific tools
 
 ### github-copilot-models
 
-Query and display available GitHub Copilot AI models with their capabilities, co...
+Query and display available GitHub Copilot AI models with their capabilities, context limits, and features. Use when: "what models are available", "show copilot models", "list github models", "check model capabilities", "switch models".  Examples: - user: "What models can I use with GitHub Copilot?" → fetch and display available models - user: "Show me models with vision support" → filter models by capability - user: "Which model has the largest context window?" → compare model specifications - user: "List all GPT-5 models" → filter by model family
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/github-copilot-models) | **Version:** 0.5.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -1208,7 +1041,9 @@ Query and display available GitHub Copilot AI models with their capabilities, co
 
 ### gitlab-api
 
-Fetches and analyzes GitLab merge request (MR) comments, metadata, and review fe...
+Retrieve and analyze GitLab merge request comments and metadata using authenticated API calls
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/gitlab-api) | **Version:** 1.8.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -1216,7 +1051,9 @@ Fetches and analyzes GitLab merge request (MR) comments, metadata, and review fe
 
 ### retrospect-domain
 
-Analyze domain insights (WHAT/WHY learned) from captured sessions. Use when revi...
+Extract domain insights, patterns, and learnings from captured sessions for long-term knowledge retention.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/retrospect-domain) | **Version:** 0.2.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
@@ -1224,31 +1061,30 @@ Analyze domain insights (WHAT/WHY learned) from captured sessions. Use when revi
 
 ### colyseus-multiplayer
 
-Build authoritative real-time multiplayer servers with Colyseus 0.17+. Use when ...
+Build authoritative real-time multiplayer servers with Colyseus 0.17+. Use when implementing rooms, schema state sync, client message validation, matchmaking, authentication, reconnection handling, or server-side anti-cheat constraints. Keywords: colyseus, room lifecycle, schema, multiplayer, websocket, matchmaking, onJoin, onLeave, onDrop, allowReconnection.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/colyseus-multiplayer) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
 | [colyseus-multiplayer](/tekhne/skills/specialized/colyseus-multiplayer/skill/) | <span class="skill-badge skill-badge--b">B</span> | 2026-03-02 | 5 |
 
-### chezmoi-managing-chezmoi-packages
+### chezmoi
 
-Use this skill when managing packages, external dependencies, binaries, or CLI t...
+Expert assistant for chezmoi dotfiles management. Use when: "add this file to chezmoi", "make this a template", "encrypt this secret", "apply on a new machine", "run script only once", "manage dotfiles across machines".  Examples: - user: "Track my .zshrc with chezmoi" → chezmoi add ~/.zshrc - user: "Make my .gitconfig machine-specific" → convert to .tmpl, use {{ .chezmoi.hostname }} - user: "Run a script only on first apply" → once_ prefix - user: "Sync to a new laptop" → chezmoi init --apply $GITHUB_USERNAME - user: "Why isn't my file being applied?" → diagnose source attribute, diff, doctor
 
-| Skill | Rating | Audit | Evals |
-| --- | --- | --- | --- |
-| [chezmoi-managing-chezmoi-packages](/tekhne/skills/specialized/chezmoi/managing-chezmoi-packages/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-24 | 5 |
-
-### chezmoi-chezmoi-assistant
-
-Expert assistant for chezmoi dotfiles management. Use when the user is managing ...
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/chezmoi) | **Version:** 0.3.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |
-| [chezmoi-chezmoi-assistant](/tekhne/skills/specialized/chezmoi/chezmoi-assistant/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
+| [chezmoi-assistant](/tekhne/skills/specialized/chezmoi/chezmoi-assistant/skill/) | <span class="skill-badge skill-badge--unknown">?</span> | - | 3 |
+| [managing-chezmoi-packages](/tekhne/skills/specialized/chezmoi/managing-chezmoi-packages/skill/) | <span class="skill-badge skill-badge--a">A</span> | 2026-04-24 | 5 |
 
 ### retrospect-collab
 
-Analyze collaboration patterns (HOW) and compute metrics from captured sessions....
+Analyse human-AI collaboration patterns and compute quality metrics from captured session data.
+
+**Published:** [Public](https://tessl.io/registry/skills/pantheon-ai/retrospect-collab) | **Version:** 0.2.0
 
 | Skill | Rating | Audit | Evals |
 | --- | --- | --- | --- |

--- a/docs/src/lib/crate-versions.ts
+++ b/docs/src/lib/crate-versions.ts
@@ -1,0 +1,54 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const CRATES_ROOT = resolve(process.cwd(), "../crates");
+
+/**
+ * Read `name` and `version` out of a Cargo manifest's [package] section,
+ * stopping at the next section header so a later [package.metadata.*] table
+ * cannot contribute keys.
+ */
+export const readPackageSection = (
+  toml: string,
+): { name?: string; version?: string } => {
+  const result: { name?: string; version?: string } = {};
+  let inPackage = false;
+
+  for (const line of toml.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[")) {
+      if (inPackage) break;
+      inPackage = trimmed === "[package]";
+      continue;
+    }
+    if (!inPackage) continue;
+    result.name ??= trimmed.match(/^name = "(.+)"$/)?.[1];
+    result.version ??= trimmed.match(/^version = "(.+)"$/)?.[1];
+  }
+
+  return result;
+};
+
+/**
+ * Cargo package version keyed by package name, read from the workspace crates.
+ *
+ * The tool install URLs are built from these versions, and a release tag is
+ * `tool/<package>-v<version>`. A hand-maintained copy here silently 404s the
+ * moment a crate is renamed or released, which is exactly what happened when
+ * the binaries were namespaced to `pantheon-*`.
+ */
+export const crateVersions = (): Map<string, string> => {
+  const versions = new Map<string, string>();
+  if (!existsSync(CRATES_ROOT)) return versions;
+
+  for (const dir of readdirSync(CRATES_ROOT)) {
+    const manifest = join(CRATES_ROOT, dir, "Cargo.toml");
+    if (!existsSync(manifest)) continue;
+    const { name, version } = readPackageSection(
+      readFileSync(manifest, "utf-8"),
+    );
+    if (name && version) versions.set(name, version);
+  }
+
+  return versions;
+};

--- a/docs/src/lib/tiles.ts
+++ b/docs/src/lib/tiles.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 
 const SKILLS_ROOT = resolve(process.cwd(), "../skills");
 
@@ -19,7 +19,7 @@ export interface TileData {
   tilePath: string;
 }
 
-const MANIFEST_SUFFIXES = ["/.tessl-plugin/plugin.json", "/tile.json"];
+const PLUGIN_DIR = ".tessl-plugin";
 
 const findTileManifests = (dir: string, results: string[] = []): string[] => {
   for (const entry of readdirSync(dir)) {
@@ -28,7 +28,7 @@ const findTileManifests = (dir: string, results: string[] = []): string[] => {
       findTileManifests(full, results);
     } else if (
       entry === "tile.json" ||
-      (entry === "plugin.json" && dir.endsWith("/.tessl-plugin"))
+      (entry === "plugin.json" && basename(dir) === PLUGIN_DIR)
     ) {
       results.push(full);
     }
@@ -36,12 +36,16 @@ const findTileManifests = (dir: string, results: string[] = []): string[] => {
   return results;
 };
 
+/**
+ * The tile directory holding a manifest, relative to SKILLS_ROOT and always
+ * "/"-separated. Compared and sliced with path calls rather than string
+ * suffixes, because join()/relative() emit "\" on Windows and a hardcoded "/"
+ * would match nothing there.
+ */
 const manifestToTilePath = (file: string): string => {
-  const rel = relative(SKILLS_ROOT, file);
-  for (const suffix of MANIFEST_SUFFIXES) {
-    if (rel.endsWith(suffix)) return rel.slice(0, -suffix.length);
-  }
-  return rel;
+  const dir = dirname(file);
+  const tileDir = basename(dir) === PLUGIN_DIR ? dirname(dir) : dir;
+  return relative(SKILLS_ROOT, tileDir).split(sep).join("/");
 };
 
 /**

--- a/docs/src/lib/tiles.ts
+++ b/docs/src/lib/tiles.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
 const SKILLS_ROOT = resolve(process.cwd(), "../skills");
@@ -19,16 +19,90 @@ export interface TileData {
   tilePath: string;
 }
 
-const findTileJsonFiles = (dir: string, results: string[] = []): string[] => {
+const MANIFEST_SUFFIXES = ["/.tessl-plugin/plugin.json", "/tile.json"];
+
+const findTileManifests = (dir: string, results: string[] = []): string[] => {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) {
-      findTileJsonFiles(full, results);
-    } else if (entry === "tile.json") {
+      findTileManifests(full, results);
+    } else if (
+      entry === "tile.json" ||
+      (entry === "plugin.json" && dir.endsWith("/.tessl-plugin"))
+    ) {
       results.push(full);
     }
   }
   return results;
+};
+
+const manifestToTilePath = (file: string): string => {
+  const rel = relative(SKILLS_ROOT, file);
+  for (const suffix of MANIFEST_SUFFIXES) {
+    if (rel.endsWith(suffix)) return rel.slice(0, -suffix.length);
+  }
+  return rel;
+};
+
+/**
+ * A skill's key is its `name` frontmatter, which for a nested skill is a
+ * consolidated name ("github-actions-generator") rather than its directory
+ * name ("generator"). The docs pages are keyed the same way, so read it from
+ * source and fall back to the directory name only when it cannot be found.
+ */
+const skillKeyAt = (skillPath: string): string | null => {
+  const file = join(SKILLS_ROOT, skillPath, "SKILL.md");
+  if (!existsSync(file)) return null;
+  const frontmatter = readFileSync(file, "utf-8").match(
+    /^---\n([\s\S]*?)\n---/,
+  );
+  return frontmatter?.[1].match(/^name:\s*(.+)$/m)?.[1].trim() || null;
+};
+
+/**
+ * `skills` is a record of {path, summary} in a legacy tile.json, and an array
+ * of paths relative to the tile in a .tessl-plugin/plugin.json. A relative
+ * path may be a subdirectory ("generator"), or a bare "SKILL.md" meaning the
+ * tile directory is itself the skill.
+ */
+const entryPath = (entry: unknown): string =>
+  typeof entry === "string"
+    ? entry
+    : ((entry as { path?: string })?.path ?? "");
+
+const skillsFromArray = (
+  raw: unknown[],
+  tilePath: string,
+): Record<string, TileSkillEntry> => {
+  const skills: Record<string, TileSkillEntry> = {};
+  for (const entry of raw) {
+    const rawPath = entryPath(entry);
+    if (!rawPath) continue;
+    const relDir = rawPath.replace(/(^|\/)SKILL\.md$/, "");
+    const skillPath = relDir ? `${tilePath}/${relDir}` : tilePath;
+    const key = skillKeyAt(skillPath) ?? skillPath.split("/").pop();
+    if (key) skills[key] = { key, path: skillPath };
+  }
+  return skills;
+};
+
+const skillsFromRecord = (raw: object): Record<string, TileSkillEntry> => {
+  const skills: Record<string, TileSkillEntry> = {};
+  for (const [key, val] of Object.entries(
+    raw as Record<string, { path: string; summary?: string }>,
+  )) {
+    skills[key] = { key, path: val.path, summary: val.summary };
+  }
+  return skills;
+};
+
+const normaliseSkills = (
+  raw: unknown,
+  tilePath: string,
+): Record<string, TileSkillEntry> => {
+  if (Array.isArray(raw)) return skillsFromArray(raw, tilePath);
+  if (raw && typeof raw === "object") return skillsFromRecord(raw);
+  return {};
 };
 
 const tileNameToSlug = (name: string): string => name.replace(/^[^/]+\//, "");
@@ -38,7 +112,7 @@ let _tiles: TileData[] | null = null;
 export const loadTiles = (): TileData[] => {
   if (_tiles) return _tiles;
 
-  const files = findTileJsonFiles(SKILLS_ROOT);
+  const files = findTileManifests(SKILLS_ROOT);
   const all: TileData[] = [];
 
   for (const file of files) {
@@ -47,20 +121,19 @@ export const loadTiles = (): TileData[] => {
         name?: string;
         version?: string;
         summary?: string;
+        description?: string;
         private?: boolean;
-        skills?: Record<string, { path: string; summary?: string }>;
+        skills?: unknown;
       };
       if (!raw.name || !raw.skills) continue;
-      const tilePath = relative(SKILLS_ROOT, file).replace(/\/tile\.json$/, "");
-      const skills: Record<string, TileSkillEntry> = {};
-      for (const [key, val] of Object.entries(raw.skills)) {
-        skills[key] = { key, path: val.path, summary: val.summary };
-      }
+      const tilePath = manifestToTilePath(file);
+      const skills = normaliseSkills(raw.skills, tilePath);
+      if (Object.keys(skills).length === 0) continue;
       all.push({
         name: raw.name,
         slug: tileNameToSlug(raw.name),
         version: raw.version ?? "0.0.0",
-        summary: raw.summary ?? "",
+        summary: raw.summary ?? raw.description ?? "",
         private: raw.private ?? false,
         skills,
         tilePath,

--- a/docs/src/pages/tools.astro
+++ b/docs/src/pages/tools.astro
@@ -1,5 +1,6 @@
 ---
 import DocsLayout from "../layouts/DocsLayout.astro";
+import { crateVersions } from "../lib/crate-versions";
 
 const base = import.meta.env.BASE_URL;
 const repo = "pantheon-org/tekhne";
@@ -11,7 +12,6 @@ interface ToolCommand {
 
 interface Tool {
   name: string;
-  version: string;
   icon: string;
   tagline: string;
   description: string;
@@ -25,7 +25,6 @@ interface Tool {
 const tools: Tool[] = [
   {
     name: "pantheon-skill-auditor",
-    version: "0.1.0",
     icon: "🔍",
     tagline: "Audit skill quality using the 9-dimension framework.",
     description:
@@ -48,7 +47,6 @@ const tools: Tool[] = [
   },
   {
     name: "pantheon-adr",
-    version: "0.1.0",
     icon: "🧭",
     tagline: "Create and manage Architecture Decision Records.",
     description:
@@ -64,7 +62,6 @@ const tools: Tool[] = [
   },
   {
     name: "pantheon-journal",
-    version: "0.1.0",
     icon: "📓",
     tagline: "Create and validate structured journal entries.",
     description:
@@ -82,8 +79,11 @@ const tools: Tool[] = [
   },
 ];
 
+const versions = crateVersions();
+const versionOf = (tool: Tool) => versions.get(tool.name) ?? "0.0.0";
+
 const installerUrl = (tool: Tool) =>
-  `https://github.com/${repo}/releases/download/tool/${tool.name}-v${tool.version}/${tool.name}-installer.sh`;
+  `https://github.com/${repo}/releases/download/tool/${tool.name}-v${versionOf(tool)}/${tool.name}-installer.sh`;
 ---
 
 <DocsLayout title="Tools" description="The shipped Tekhne tool CLIs: skill-auditor, adr, and journal. Standalone Rust binaries you install with a single curl command, each bundling a companion skill." sidebar={false}>
@@ -103,7 +103,7 @@ const installerUrl = (tool: Tool) =>
         Installers follow the cargo-dist shell installer shape and are published under the
         <code>tool/</code> tag namespace, so every release tag looks like
         <code>tool/&lt;package&gt;-v&lt;semver&gt;</code> (for example
-        <code>tool/skill-auditor-v0.1.0</code>). Binaries land in <code>CARGO_HOME</code>.
+        <code>tool/pantheon-skill-auditor-v0.2.0</code>). Binaries land in <code>CARGO_HOME</code>.
         Looking for the validators or the other skills? They ship as plain Markdown skills in the
         <a href={`${base}/tiles/`}>Skills catalog</a>.
       </p>
@@ -117,7 +117,7 @@ const installerUrl = (tool: Tool) =>
         <div class="tool-titles">
           <h2 class="tool-name">
             {tool.name}
-            <span class="tool-version">v{tool.version}</span>
+            <span class="tool-version">v{versionOf(tool)}</span>
           </h2>
           <p class="tool-tagline">{tool.tagline}</p>
         </div>

--- a/scripts/catalog/discovery/find-all-tiles.ts
+++ b/scripts/catalog/discovery/find-all-tiles.ts
@@ -1,23 +1,23 @@
-import { dirname } from "node:path";
 import { $ } from "bun";
 import { parseShortName } from "../parsing";
 import type { TileEntry } from "../types";
 import { buildTileSkills } from "./build-tile-skills";
 import { isChildTile } from "./is-child-tile";
 import { parsePublishedStatus } from "./parse-published-status";
+import { tileRoot } from "./tile-root";
 
 export const findAllTiles = async (): Promise<TileEntry[]> => {
   const output =
     await $`find skills -name "plugin.json" -path "*/.tessl-plugin/*" -o -name "tile.json" -type f`.text();
   const files = output.trim().split("\n").filter(Boolean);
 
-  const tileDirs = new Set(files.map((f) => dirname(f)));
+  const tileDirs = new Set(files.map(tileRoot));
   const tiles: TileEntry[] = [];
 
   for (const file of files) {
     try {
       const rawData = (await Bun.file(file).json()) as Record<string, unknown>;
-      const tileDir = dirname(file);
+      const tileDir = tileRoot(file);
 
       if (isChildTile(tileDir, tileDirs, rawData.private === true)) continue;
 

--- a/scripts/catalog/discovery/index.ts
+++ b/scripts/catalog/discovery/index.ts
@@ -11,3 +11,4 @@ export * from "./parse-published-status";
 export * from "./parse-skill-description";
 export * from "./resolve-skill-dir";
 export * from "./tessl-status";
+export * from "./tile-root";

--- a/scripts/catalog/discovery/read-package-section.test.ts
+++ b/scripts/catalog/discovery/read-package-section.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { readPackageSection } from "../../../docs/src/lib/crate-versions";
+
+describe("readPackageSection", () => {
+  test("reads name and version from the [package] section", () => {
+    const toml = [
+      "[package]",
+      'name = "pantheon-skill-auditor"',
+      'version = "0.2.0"',
+      "edition.workspace = true",
+      "",
+      "[package.metadata.dist]",
+      "dist = true",
+    ].join("\n");
+
+    expect(readPackageSection(toml)).toEqual({
+      name: "pantheon-skill-auditor",
+      version: "0.2.0",
+    });
+  });
+
+  test("ignores a version declared in a later section", () => {
+    const toml = [
+      "[package]",
+      'name = "pantheon-adr"',
+      'version = "0.2.0"',
+      "",
+      "[dependencies]",
+      'version = "9.9.9"',
+    ].join("\n");
+
+    expect(readPackageSection(toml).version).toBe("0.2.0");
+  });
+
+  test("returns nothing when there is no [package] section", () => {
+    expect(readPackageSection('[workspace]\nmembers = ["a"]')).toEqual({});
+  });
+});

--- a/scripts/catalog/discovery/tile-root.test.ts
+++ b/scripts/catalog/discovery/tile-root.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { tileRoot } from "./tile-root";
+
+describe("tileRoot", () => {
+  test("unwraps the .tessl-plugin directory", () => {
+    expect(
+      tileRoot("skills/repository-mgmt/nx/.tessl-plugin/plugin.json"),
+    ).toBe("skills/repository-mgmt/nx");
+  });
+
+  test("unwraps a nested child tile manifest", () => {
+    expect(
+      tileRoot("skills/infrastructure/terraform/.tessl-plugin/plugin.json"),
+    ).toBe("skills/infrastructure/terraform");
+  });
+
+  test("returns the containing directory for a legacy tile.json", () => {
+    expect(tileRoot("skills/ci-cd/github-actions/tile.json")).toBe(
+      "skills/ci-cd/github-actions",
+    );
+  });
+
+  test("does not unwrap a directory merely containing the marker name", () => {
+    expect(tileRoot("skills/foo/.tessl-plugin-backup/plugin.json")).toBe(
+      "skills/foo/.tessl-plugin-backup",
+    );
+  });
+});

--- a/scripts/catalog/discovery/tile-root.ts
+++ b/scripts/catalog/discovery/tile-root.ts
@@ -1,0 +1,6 @@
+import { basename, dirname } from "node:path";
+
+export const tileRoot = (manifestPath: string): string => {
+  const dir = dirname(manifestPath);
+  return basename(dir) === ".tessl-plugin" ? dirname(dir) : dir;
+};


### PR DESCRIPTION
### **User description**
## What

- The skill catalog reported "0 skills across 0 tiles" in the README and on the published tiles page. It now reports the real numbers: 117 skills across 71 tiles, and 64 of 64 public tiles render on the site.
- The three tool binaries move to v0.2.0 so a release can be cut under the names the documentation already uses.
- The README gains the clone step it was missing, and a working install command for the binaries.

## Why

Nobody outside the repo could install the tools. The binaries were renamed to `pantheon-*` the day after the only release was cut, the docs followed the rename, and no release ever did. Every published install command pointed at a tag that does not exist:

| Documented | Result |
| --- | --- |
| `tool/pantheon-skill-auditor-v0.1.0` | 404 |
| `tool/pantheon-adr-v0.1.0` | 404 |
| `tool/pantheon-journal-v0.1.0` | 404 |

The only working artefacts are the pre-rename tags, which install a differently named binary than the docs describe. Both meanings claimed version 0.1.0.

Separately, the skills catalog counted zero because the tile manifest moved from `tile.json` to `.tessl-plugin/plugin.json`. Three consumers still derived the tile root with `dirname()` or looked for `tile.json` outright, so every skill path resolved somewhere that does not exist and all 76 tiles were dropped. The first thing a visitor read was that the repository contains no skills.

The README also told readers to run `npx skills add ./skills --all` without ever telling them to clone, so that path failed too.

## Notes

The docs Tools page now reads each version from its crate manifest instead of repeating it by hand. That hand-maintained copy is what silently desynced, so removing it removes the recurrence.

Two things surfaced that are not mine and are flagged rather than folded in:

- `cargo test --workspace` has been failing on `main` since `45daddc0`. That release commit rewrote 70 skill CHANGELOGs, which the golden corpus scores, but `rust-ci.yml` filters on `crates/**` and never ran. Regenerated via the documented `BLESS_GOLDENS=1` flow in its own commit; the path-filter gap that hid it still needs fixing.
- `findAllTiles` trips the cognitive-complexity rule at 35 (max 15). Pre-existing at the identical value; untouched.

Verified: `cargo test --workspace` 25 suites, 0 failed. `bun test scripts/` 108 pass. Clippy clean. Docs build exits 0.

Refs #245


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Fixes tile discovery by supporting `.tessl-plugin/plugin.json` manifests alongside legacy `tile.json`.

- Dynamically resolves crate versions from Cargo manifests for documentation and installer links.

- Bumps tool crate versions (`pantheon-skill-auditor`, `pantheon-adr`, `pantheon-journal`) to `0.2.0`.

- Updates README instructions, regenerates the skill catalog, and refreshes the test golden corpus.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  manifests["Tile Manifests (.tessl-plugin/plugin.json)"] -- "Discovered by" --> discovery["scripts/catalog (tileRoot)"]
  discovery -- "Regenerates" --> catalog["README & Docs Catalog (117 skills / 71 tiles)"]
  crates["crates/*/Cargo.toml"] -- "Parsed by" --> crate_versions["crate-versions.ts"]
  crate_versions -- "Populates" --> tools_page["tools.astro (Dynamic Versions)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>tiles.ts</strong><dd><code>Support both <code>.tessl-plugin/plugin.json</code> and legacy <code>tile.json</code> manifests</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-ae812a2fb554ae2412cf79ec5979f4f17b7969cbd90ff37e7f073299742f4c74">+85/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>crate-versions.ts</strong><dd><code>Read package names and versions dynamically from workspace Cargo </code><br><code>manifests</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-6fec34fd57908bd56f7f4d3ca537ed8f61a49e662b52d65a7ad5514b0babaf1a">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tile-root.ts</strong><dd><code>Helper to resolve the root directory of a tile from its manifest path</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-f09c18410c38466f409809849fc75a7d33e03343aca6d8d89eecbe038e410c5d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tools.astro</strong><dd><code>Dynamically resolve tool versions and update installer links</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-ad915b696237feb208a8fa985e6ce5de24e48b0af46e7ce9bd1770cb1d6eb4b8">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prelink.mjs</strong><dd><code>Support <code>.tessl-plugin/plugin.json</code> and generate fallback registry URLs</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-8699fbfcc80762cf618d6a100fcbfbcc4d79f3dff7d90a6df1f500cba4ad7c56">+19/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>read-package-section.test.ts</strong><dd><code>Unit tests for parsing Cargo package sections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-03197b707706ad0b36e2884b3347801a6933cae6dd1326a718c2a6c032e6f959">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tile-root.test.ts</strong><dd><code>Unit tests for the `tileRoot` helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-afdbb3e4f94217b3fd396a399e65df022a6e65cfae8ab7205b41ab9b98e0bb88">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>goldens.json</strong><dd><code>Update golden corpus test data with refreshed token counts</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-d44f58d0e2f60a15bf762d12c46e76eee7a422c725527a2d6b4189d61594a2b5">+84/-32</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>find-all-tiles.ts</strong><dd><code>Use `tileRoot` helper to correctly resolve tile directories</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-02ab47d23ca02f3828ce2268653f072ebeb5a9369314fd8d40558820587e87ad">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Export the new `tileRoot` helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-5cc6c1a01f1e08b1e195391e880f45edd40a095ef606cb37dd60849d7b2c106f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update catalog stats, installation instructions, and binary installer </code><br><code>commands</code></dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+12/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump version to `0.2.0`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-9159a4ff627ab39d744f5ffbda7b10194fc70b7a395db0f9c47aa6d5adbd99f2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump version to `0.2.0`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-60947b145cf3ef7f8e5e20462515f13c0f4ed770bca0ab7a7250f50667ef3228">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump version to `0.2.0`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-ec3460dacb1c812bf2dd9622173a630d6aaa3952544ab1f1dde8aeccf7e11e33">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tiles.md</strong></td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/288/files#diff-17244a108ff207a43d7a6c4959acfcdbfc1e25cf88a6e444d5eccc5a04a13b42">+389/-553</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

