### PR TITLE
fix: unblock the v0.2.0 tool releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pantheon-adr"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "common",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "pantheon-journal"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "clap",
  "common",

--- a/crates/adr/Cargo.toml
+++ b/crates/adr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantheon-adr"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantheon-journal"
-version = "0.2.0"
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -55,6 +55,6 @@ x86_64-apple-darwin = "macos-latest"
 # still bump it. Refresh these when bumping cargo-dist (new default tags) or when
 # Dependabot proposes a newer action release. See issue #227.
 [dist.github-action-commits]
-"actions/checkout" = "d23441a48e516b6c34aea4fa41551a30e30af803"       # v6
+"actions/checkout" = "3d3c42e5aac5ba805825da76410c181273ba90b1"       # v7
 "actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
 "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8


### PR DESCRIPTION
### **User description**
Follow-up to #288. The three v0.2.0 tags were pushed and all three release runs failed, so no installers exist yet. Two separate causes.

## Why the releases failed

**Stale action pin.** Dependabot bumped `actions/checkout` 6.1.0 to 7.0.1 in #268, editing the generated `tool-release.yml` but not the `dist-workspace.toml` that generates it. `dist` compares the two on every release and aborts when they disagree:

| | |
| --- | --- |
| `tool-release.yml` | `actions/checkout@3d3c42e5` (v7.0.1) |
| `dist-workspace.toml` | `actions/checkout@d23441a4` (v6.1.0) |

Repointed the config at the SHA already in the workflow. `dist generate` leaves `tool-release.yml` byte-identical afterwards, confirming this was the only drift.

**Releases were not scoped to one tool.** cargo-dist picks what a tag releases by matching the *version*, not the package name, so every dist-able package sharing a version gets announced together. With all three tools at 0.2.0, each tag would have produced a release carrying all three. This did not happen at v0.1.0 under cargo-dist 0.28; the workspace is now on 0.32.

Spread the versions so each tag resolves to one package:

```
pantheon-skill-auditor  0.2.0
pantheon-adr            0.2.1
pantheon-journal        0.2.2
skill-validator-rs      0.1.0  (unchanged)
```

Verified with `dist plan` against all three tags; each announces exactly its own package. The trade-off is that the three version numbers no longer line up.

## Notes

The docs Tools page reads versions from the crate manifests (added in #288), so its install URLs followed with no edit. The README's pinned auditor URL is unaffected since the auditor stays at 0.2.0.

The three existing `*-v0.2.0` tags need deleting and re-cutting after this merges; two of those versions no longer exist.

Nothing enforces the dist-config/workflow pin agreement, so the next Dependabot action bump breaks releases the same way. `dist-workspace.toml` already warns about this in a comment (see #227).

Verified: `cargo test --workspace` 0 failed. Docs build exits 0.


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Repins `actions/checkout` to `v7.0.1` in `dist-workspace.toml` to match the workflow.

- Assigns distinct versions to tool crates to prevent bundled releases.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  dist_config["dist-workspace.toml"] -- "Aligns checkout pin" --> workflow["tool-release.yml"]
  adr_cargo["crates/adr/Cargo.toml"] -- "Bumps to 0.2.1" --> dist_plan["cargo-dist release plan"]
  journal_cargo["crates/journal/Cargo.toml"] -- "Bumps to 0.2.2" --> dist_plan
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump pantheon-adr version to 0.2.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/adr/Cargo.toml

<ul><li>Bumps the package version of <code>pantheon-adr</code> from <code>0.2.0</code> to <code>0.2.1</code> to <br>ensure distinct releases under cargo-dist.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/289/files#diff-60947b145cf3ef7f8e5e20462515f13c0f4ed770bca0ab7a7250f50667ef3228">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump pantheon-journal version to 0.2.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/journal/Cargo.toml

<ul><li>Bumps the package version of <code>pantheon-journal</code> from <code>0.2.0</code> to <code>0.2.2</code> to <br>ensure distinct releases under cargo-dist.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/289/files#diff-ec3460dacb1c812bf2dd9622173a630d6aaa3952544ab1f1dde8aeccf7e11e33">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dist-workspace.toml</strong><dd><code>Update actions/checkout SHA pin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dist-workspace.toml

<ul><li>Updates the pinned commit SHA for <code>actions/checkout</code> to <br><code>3d3c42e5aac5ba805825da76410c181273ba90b1</code> (v7) to align with the <br>generated workflow and prevent release plan failures.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/289/files#diff-6199be2c7f198c8de61ee0af2ac953036007e5abb9047b66cc2156788650fdcb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

