### PR TITLE
fix: binaries report their real version

### DIFF
--- a/crates/adr/src/main.rs
+++ b/crates/adr/src/main.rs
@@ -14,7 +14,8 @@ use skill_install::agents::all as all_agents;
 use skill_install::env::Environment;
 use skill_install::install::InstallMode;
 
-const VERSION: &str = "0.1.0";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const NAME: &str = env!("CARGO_PKG_NAME");
 
 #[derive(Parser)]
 #[command(
@@ -138,7 +139,7 @@ fn main() {
     let cli = Cli::parse();
     let result = match cli.command {
         Command::Version => {
-            println!("adr v{VERSION}");
+            println!("{NAME} v{VERSION}");
             Ok(())
         }
         Command::New { title, dir } => run_new(&title, dir.as_deref()),

--- a/crates/journal/src/main.rs
+++ b/crates/journal/src/main.rs
@@ -21,7 +21,7 @@ use skill_install::agents::all as all_agents;
 use skill_install::env::Environment;
 use skill_install::install::InstallMode;
 
-const VERSION: &str = "0.1.0";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Parser)]
 #[command(

--- a/crates/skill-auditor/src/main.rs
+++ b/crates/skill-auditor/src/main.rs
@@ -22,7 +22,8 @@ use std::process;
 
 mod reports;
 
-const VERSION: &str = "0.1.0";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const NAME: &str = env!("CARGO_PKG_NAME");
 
 #[derive(Parser)]
 #[command(
@@ -244,7 +245,7 @@ fn main() {
     let cli = Cli::parse();
     let result = match cli.command {
         Command::Version => {
-            println!("skill-auditor v{VERSION}");
+            println!("{NAME} v{VERSION}");
             Ok(())
         }
         Command::Evaluate {


### PR DESCRIPTION
### **User description**
Found by installing the just-published v0.2.0 artefact into a clean HOME and running it.

## What

All three binaries carried `const VERSION: &str = "0.1.0"`, a hand-maintained copy of the crate version that nothing kept in sync. The releases cut today ship binaries that misreport themselves:

```
$ pantheon-skill-auditor --version
pantheon-skill-auditor 0.1.0     # actually 0.2.0
```

They now read `CARGO_PKG_VERSION`. The `version` subcommand also printed the pre-rename name (`skill-auditor v...`) and now uses `CARGO_PKG_NAME`.

## Why it matters

This is the same class of bug as the docs page hardcoding its version, and it lands in the worst possible spot. Two differently named binaries both claiming `0.1.0` is precisely the confusion the rename created, and `--version` is the obvious way someone would try to tell them apart.

## Notes

The published v0.2.0 / v0.2.1 / v0.2.2 artefacts install and run correctly; only the reported version string is wrong. Re-cutting is a judgement call, not a necessity.

Verified: clean-room install of the published installer into an isolated HOME and CARGO_HOME reproduced the wrong version; `cargo run` after this change reports 0.2.0, 0.2.1 and 0.2.2 respectively. `cargo test --workspace` 25 suites, 0 failed. Clippy clean.


___

### **PR Type**
Bug fix


___

### **Description**
- Use `CARGO_PKG_VERSION` instead of hardcoded "0.1.0" in binaries.

- Use `CARGO_PKG_NAME` for dynamic binary name reporting.

- Fixes version subcommand output for `adr` and `skill-auditor`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph CargoEnv ["Cargo Environment Variables"]
    V["CARGO_PKG_VERSION"]
    N["CARGO_PKG_NAME"]
  end
  subgraph Binaries ["Binaries Updated"]
    adr["crates/adr"]
    journal["crates/journal"]
    auditor["crates/skill-auditor"]
  end
  V --> adr
  V --> journal
  V --> auditor
  N --> adr
  N --> auditor
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Dynamically resolve version and name in adr binary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/adr/src/main.rs

<ul><li>Replaced the hardcoded <code>VERSION</code> constant with <br><code>env!("CARGO_PKG_VERSION")</code>.<br> <li> Added a <code>NAME</code> constant using <code>env!("CARGO_PKG_NAME")</code>.<br> <li> Updated the version command output to dynamically print the package <br>name and version.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/290/files#diff-07db815258db291ad34d7541c8c20e47b1f2186d96e5e3d88ca75f1a3df4af6a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Dynamically resolve version in journal binary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/journal/src/main.rs

<ul><li>Replaced the hardcoded <code>VERSION</code> constant with <br><code>env!("CARGO_PKG_VERSION")</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/290/files#diff-a65255ca4f4b16fd5f54f054a26bd6f037f065dd6e6dc91b166a91c3cfc1f2c5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Dynamically resolve version and name in skill-auditor binary</code></dd></summary>
<hr>

crates/skill-auditor/src/main.rs

<ul><li>Replaced the hardcoded <code>VERSION</code> constant with <br><code>env!("CARGO_PKG_VERSION")</code>.<br> <li> Added a <code>NAME</code> constant using <code>env!("CARGO_PKG_NAME")</code>.<br> <li> Updated the version command output to dynamically print the package <br>name and version.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/290/files#diff-0d4b7163e4c9e51150df1754c406f6127209644cfde6c7ca4bdb802f79a4f242">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

