### PR TITLE
fix: redeploy docs when a tool crate version changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - "docs/**"
       - "skills/**"
+      # The Tools page reads each tool's version from its crate manifest,
+      # so a version bump changes the rendered install URLs without
+      # touching docs/. Without this the site keeps publishing the URL of
+      # a superseded tag.
+      - "crates/*/Cargo.toml"
   workflow_dispatch:
 
 # Allow only one concurrent deployment; cancel in-progress runs.


### PR DESCRIPTION
### **User description**
## What

`deploy-docs.yml` now also watches `crates/*/Cargo.toml`.

## Why

The Tools page reads each tool's version from its crate manifest, so a version bump changes the rendered install URLs without touching `docs/`. The workflow only watched `docs/**` and `skills/**`, so #289's version change never redeployed the site.

The live site kept advertising `pantheon-adr-v0.2.0` and `pantheon-journal-v0.2.0` after those tags were deleted and re-cut as v0.2.1 and v0.2.2. Two published 404s, on the page whose whole purpose is telling people how to install.

Deriving the version from the manifest is still the right call, it just created a dependency the path filter did not cover. The pattern is narrow enough that ordinary source edits under `crates/` do not trigger a site rebuild.

I have already dispatched a manual deploy, so the live site is correct now; this stops it recurring.

## Notes

This is the second path-filter gap found this week. `rust-ci.yml` has the mirror-image problem: the golden corpus scores files under `skills/**`, but the workflow only watches `crates/**`, so the corpus drifted silently through a release. That one is still open and worth its own fix.


___

### **PR Type**
Bug fix, Other


___

### **Description**
- Trigger docs deployment on crate manifest changes.

- Prevent broken install URLs on the site.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cargo_toml["crates/*/Cargo.toml"] -- "Triggers" --> deploy_docs["deploy-docs.yml workflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-docs.yml</strong><dd><code>Trigger docs deployment on Cargo.toml changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-docs.yml

<ul><li>Adds <code>crates/*/Cargo.toml</code> to the workflow's path filters to trigger <br>deployments on version bumps.<br> <li> Includes explanatory comments regarding the dependency of the Tools <br>page on crate manifests.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/291/files#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

