### PR TITLE
fix: re-cut tool releases with the correct version string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pantheon-adr"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "clap",
  "common",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "pantheon-journal"
-version = "0.2.2"
+version = "0.2.5"
 dependencies = [
  "clap",
  "common",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "pantheon-skill-auditor"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "clap",
  "common",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ each of which installs its own companion skill. These need no clone:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/pantheon-org/tekhne/releases/download/tool/pantheon-skill-auditor-v0.2.0/pantheon-skill-auditor-installer.sh | sh
+  https://github.com/pantheon-org/tekhne/releases/download/tool/pantheon-skill-auditor-v0.2.3/pantheon-skill-auditor-installer.sh | sh
 
 pantheon-skill-auditor skill install     # or: skill uninstall
 ```

--- a/crates/adr/Cargo.toml
+++ b/crates/adr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantheon-adr"
-version = "0.2.1"
+version = "0.2.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/journal/Cargo.toml
+++ b/crates/journal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantheon-journal"
-version = "0.2.2"
+version = "0.2.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/skill-auditor/Cargo.toml
+++ b/crates/skill-auditor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pantheon-skill-auditor"
-version = "0.2.0"
+version = "0.2.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### **User description**
Follow-up to #290, which fixed the hardcoded version too late for today's releases.

## What

Patch bumps so a corrected build ships:

```
pantheon-skill-auditor  0.2.0 -> 0.2.3
pantheon-adr            0.2.1 -> 0.2.4
pantheon-journal        0.2.2 -> 0.2.5
```

## Why

The published artefacts were built before #290 and report `0.1.0`:

```
$ pantheon-skill-auditor --version
pantheon-skill-auditor 0.1.0     # tag says 0.2.0
```

New versions rather than re-pointing the existing tags. Mutating a published release so one version means two different binaries is exactly the problem this sequence has been untangling, and the numbers were already non-aligned so spending three costs nothing semantically.

## Notes

Verified `dist plan` still resolves each tag to exactly one package, and `cargo run --version` now reports 0.2.3, 0.2.4 and 0.2.5.

The docs Tools page install URLs follow from the manifests automatically, and #291 means the site now redeploys on a crate version change.

The README still pins its install URL by hand. Corrected here, but it is the last instance of the drift that caused all of this: automating it needs the catalog generator to rewrite a fenced code block rather than a single line, so it is left as a follow-up rather than bolted onto an urgent fix.

Verified: `cargo test --workspace` 0 failed. Docs build exits 0.


___

### **PR Type**
Bug fix, Other


___

### **Description**
- Bump crate versions to re-cut tool releases.

- Update `pantheon-skill-auditor` to version `0.2.3`.

- Update `pantheon-adr` to version `0.2.4`.

- Update `pantheon-journal` to version `0.2.5`.

- Update the installer URL in `README.md`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Crates ["Crate Version Bumps"]
    adr["crates/adr (0.2.1 -> 0.2.4)"]
    journal["crates/journal (0.2.2 -> 0.2.5)"]
    auditor["crates/skill-auditor (0.2.0 -> 0.2.3)"]
  end
  subgraph Docs ["Documentation Updates"]
    readme["README.md"]
  end
  auditor -- "Updates installer URL" --> readme
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update installer URL in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated the <code>pantheon-skill-auditor</code> installer script URL to reference <br>version <code>0.2.3</code> instead of <code>0.2.0</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/292/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump pantheon-adr version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/adr/Cargo.toml

- Bumped the package version from `0.2.1` to `0.2.4`.


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/292/files#diff-60947b145cf3ef7f8e5e20462515f13c0f4ed770bca0ab7a7250f50667ef3228">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump pantheon-journal version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/journal/Cargo.toml

- Bumped the package version from `0.2.2` to `0.2.5`.


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/292/files#diff-ec3460dacb1c812bf2dd9622173a630d6aaa3952544ab1f1dde8aeccf7e11e33">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump pantheon-skill-auditor version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/skill-auditor/Cargo.toml

- Bumped the package version from `0.2.0` to `0.2.3`.


</details>


  </td>
  <td><a href="https://github.com/pantheon-org/tekhne/pull/292/files#diff-9159a4ff627ab39d744f5ffbda7b10194fc70b7a395db0f9c47aa6d5adbd99f2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

